### PR TITLE
Add BoringChef Decoder

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {IBoringChef} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";
+
+abstract contract BoringChefDecoderAndSanitizer is BaseDecoderAndSanitizer {
+    //============================== IMMUTABLES ===============================
+    IBoringChef internal immutable boringChef;
+
+    constructor(address _boringChef) {
+        boringChef = IBoringChef(_boringChef);
+    }
+
+    // BoringVault that inherits from BoringChef
+    function claimRewards(uint256[] calldata rewardIds) external view virtual returns (bytes memory addressesFound) {
+        for (uint256 i = 0; i < rewardIds.length; i++) {
+            addressesFound = abi.encodePacked(addressesFound, boringChef.rewards(rewardIds[i]).token);
+        }
+    }
+
+    function claimRewardsOnBehalfOfUser(uint256[] calldata rewardIds, address user)
+        external
+        view
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        for (uint256 i = 0; i < rewardIds.length; i++) {
+            addressesFound = abi.encodePacked(addressesFound, boringChef.rewards(rewardIds[i]).token);
+        }
+        addressesFound = abi.encodePacked(addressesFound, user);
+    }
+}

--- a/src/interfaces/DecoderCustomTypes.sol
+++ b/src/interfaces/DecoderCustomTypes.sol
@@ -562,6 +562,14 @@ contract DecoderCustomTypes {
         address[] incentivesRequested;
         uint256[] incentivesRatesRequested;
     }
+
+    struct Reward {
+        uint48 startEpoch;
+        uint48 endEpoch;
+        address token;
+        uint256 rewardRate;
+    }
+
     // ========================================= Permit2 ==================================
     
     struct TokenSpenderPair {

--- a/src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol
+++ b/src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol
@@ -112,3 +112,7 @@ interface IUniswapV4PositionManager {
 interface IPoolRegistry {
     function poolInfo(uint256 _pid) external view returns (address, address, address, address, uint8); 
 }
+
+interface IBoringChef {
+    function rewards(uint256 rewardId) external view returns (DecoderCustomTypes.Reward memory);
+}

--- a/test/integrations/BoringChefIntegration.t.sol
+++ b/test/integrations/BoringChefIntegration.t.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ERC4626} from "@solmate/tokens/ERC4626.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {BoringChefDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol";
+import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+contract BoringChefIntegrationTest is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    ManagerWithMerkleVerification public manager;
+    BoringVault public boringVault;
+    address public rawDataDecoderAndSanitizer;
+    RolesAuthority public rolesAuthority;
+
+    // TODO: DELETE MOCK, replace with real BoringVault using BoringChef
+    address mockBoringChef = address(new MockBoringChef());
+
+    uint8 public constant MANAGER_ROLE = 1;
+    uint8 public constant STRATEGIST_ROLE = 2;
+    uint8 public constant MANGER_INTERNAL_ROLE = 3;
+    uint8 public constant ADMIN_ROLE = 4;
+    uint8 public constant BORING_VAULT_ROLE = 5;
+    uint8 public constant BALANCER_VAULT_ROLE = 6;
+
+    function setUp() external {
+        setSourceChainName("sonicMainnet");
+        // Setup forked environment.
+        string memory rpcKey = "SONIC_MAINNET_RPC_URL";
+        uint256 blockNumber = 4875362;
+
+        _startFork(rpcKey, blockNumber);
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 18);
+
+        manager =
+            new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
+
+
+        // TODO: DELETE MOCK, replace with real BoringVault using BoringChef
+        mockBoringChef = address(new MockBoringChef());
+        rawDataDecoderAndSanitizer = address(new FullBoringChefDecoderAndSanitizer(mockBoringChef));
+
+        setAddress(false, sourceChain, "boringVault", address(boringVault));
+        setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
+        setAddress(false, sourceChain, "manager", address(manager));
+        setAddress(false, sourceChain, "managerAddress", address(manager));
+        setAddress(false, sourceChain, "accountantAddress", address(1));
+
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+        boringVault.setAuthority(rolesAuthority);
+        manager.setAuthority(rolesAuthority);
+
+        // Setup roles authority.
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address,bytes,uint256)"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address[],bytes[],uint256[])"))),
+            true
+        );
+
+        rolesAuthority.setRoleCapability(
+            STRATEGIST_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANGER_INTERNAL_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(manager), ManagerWithMerkleVerification.setManageRoot.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BORING_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.flashLoan.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BALANCER_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.receiveFlashLoan.selector, true
+        );
+
+        // Grant roles
+        rolesAuthority.setUserRole(address(this), STRATEGIST_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANGER_INTERNAL_ROLE, true);
+        rolesAuthority.setUserRole(address(this), ADMIN_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANAGER_ROLE, true);
+        rolesAuthority.setUserRole(address(boringVault), BORING_VAULT_ROLE, true);
+        rolesAuthority.setUserRole(getAddress(sourceChain, "vault"), BALANCER_VAULT_ROLE, true);
+
+        // Allow the boring vault to receive ETH.
+        rolesAuthority.setPublicCapability(address(boringVault), bytes4(0), true);
+    }
+
+    function testBoringChefIntegration() external {
+        //deal(getAddress(sourceChain, "USDC"), address(boringVault), 100_000e6);
+
+        // Set up mock test scenario
+        // TODO: When a real vault with BoringChef is deployed, replace mocks with real data
+
+        deal(getAddress(sourceChain, "BEETS"), mockBoringChef, 1e8);
+        deal(getAddress(sourceChain, "wS"), mockBoringChef, 100_000e18);
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](2);
+
+        address[] memory rewardTokens = new address[](2);
+        rewardTokens[0] = getAddress(sourceChain, "BEETS");
+        rewardTokens[1] = getAddress(sourceChain, "wS");
+
+        _addBoringChefClaimLeaf(leafs, mockBoringChef, rewardTokens);
+        _addBoringChefClaimOnBehalfOfLeaf(leafs, mockBoringChef, rewardTokens, address(this));
+
+
+        //string memory filePath = "./TestTEST.json";
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        //_generateLeafs(filePath, leafs, manageTree[manageTree.length - 1][0], manageTree);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0]; //claimRewards
+        manageLeafs[1] = leafs[1]; //claimRewardsOnBehalfOfUser
+
+
+        (bytes32[][] memory manageProofs) = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](2);
+        targets[0] = mockBoringChef; //BoringVault inheriting from BoringChef
+        targets[1] = mockBoringChef; //BoringVault inheriting from BoringChef
+
+        uint256[] memory rewardIds = new uint256[](2);
+        rewardIds[0] = 0;
+        rewardIds[1] = 1;
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] =
+            abi.encodeWithSignature("claimRewards(uint256[])", rewardIds);
+        targetData[1] =
+            abi.encodeWithSignature("claimRewardsOnBehalfOfUser(uint256[],address)", rewardIds, address(this)); // TODO test with real user
+
+        uint256[] memory values = new uint256[](2);
+
+        address[] memory decodersAndSanitizers = new address[](2);
+        for (uint256 i = 0; i < decodersAndSanitizers.length; i++) {
+            decodersAndSanitizers[i] = rawDataDecoderAndSanitizer;
+        }
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    // ========================================= HELPER FUNCTIONS =========================================
+
+    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+        forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+        vm.selectFork(forkId);
+    }
+}
+
+contract FullBoringChefDecoderAndSanitizer is BoringChefDecoderAndSanitizer {
+    constructor(address _boringChef) BoringChefDecoderAndSanitizer(_boringChef) {}
+}
+
+// Temporary Mock Contract for test until real BoringChef is deployed
+contract MockBoringChef {
+    address beets = 0x2D0E0814E62D80056181F5cd932274405966e4f0;
+    address wS = 0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38;
+
+    mapping (uint256 => DecoderCustomTypes.Reward) public rewards;
+
+    constructor() {
+        rewards[0] = DecoderCustomTypes.Reward(1, 2, beets, 10);
+        rewards[1] = DecoderCustomTypes.Reward(1, 3, wS, 100);
+    }
+
+    function claimRewards(uint256[] calldata rewardIds) external {
+        ERC20(beets).transfer(msg.sender, 1e7);
+        ERC20(wS).transfer(msg.sender, 10_000e18);
+    }
+
+    function claimRewardsOnBehalfOfUser(uint256[] calldata rewardIds, address user) external {
+        ERC20(beets).transfer(user, 2e7);
+        ERC20(wS).transfer(user, 20_000e18);
+    }
+}

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -11169,7 +11169,42 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
             string.concat("Claim ELX Airdrop"),
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
-    } 
+    }
+
+    function _addBoringChefClaimLeaf(ManageLeaf[] memory leafs, address boringChef, address[] memory rewardTokens) internal {
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            boringChef,
+            false,
+            "claimRewards(uint256[])",
+            new address[](rewardTokens.length),
+            string.concat("Claim rewards from BoringChef"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        for (uint256 i = 0; i < rewardTokens.length; i++) {
+            leafs[leafIndex].argumentAddresses[i] = rewardTokens[i];
+        }
+    }
+
+    function _addBoringChefClaimOnBehalfOfLeaf(ManageLeaf[] memory leafs, address boringChef, address[] memory rewardTokens, address user) internal {
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            boringChef,
+            false,
+            "claimRewardsOnBehalfOfUser(uint256[],address)",
+            new address[](rewardTokens.length + 1),
+            string.concat("Claim rewards from BoringChef on behalf of user"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        for (uint256 i = 0; i < rewardTokens.length; i++) {
+            leafs[leafIndex].argumentAddresses[i] = rewardTokens[i];
+        }
+        leafs[leafIndex].argumentAddresses[rewardTokens.length] = user;
+    }
 
     // ========================================= JSON FUNCTIONS =========================================
     // TODO this should pass in a bool or something to generate leafs indicating that we want leaf indexes printed.


### PR DESCRIPTION
TODO: replace mocks in test with real Boring Vault that inherits from Boring Chef
Note: claimOnBehalfOf is unlikely to be used but was included just in case