### PR TITLE
Remove reward token sanitization from BoringChef decoder

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol
@@ -5,29 +5,18 @@ import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndS
 import {IBoringChef} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";
 
 abstract contract BoringChefDecoderAndSanitizer is BaseDecoderAndSanitizer {
-    //============================== IMMUTABLES ===============================
-    IBoringChef internal immutable boringChef;
+    //============================== BoringChef ===============================
 
-    constructor(address _boringChef) {
-        boringChef = IBoringChef(_boringChef);
+    function claimRewards(uint256[] calldata /*rewardIds*/) external view virtual returns (bytes memory addressesFound) {
+        return addressesFound;
     }
 
-    // BoringVault that inherits from BoringChef
-    function claimRewards(uint256[] calldata rewardIds) external view virtual returns (bytes memory addressesFound) {
-        for (uint256 i = 0; i < rewardIds.length; i++) {
-            addressesFound = abi.encodePacked(addressesFound, boringChef.rewards(rewardIds[i]).token);
-        }
-    }
-
-    function claimRewardsOnBehalfOfUser(uint256[] calldata rewardIds, address user)
+    function claimRewardsOnBehalfOfUser(uint256[] calldata /*rewardIds*/, address user)
         external
         view
         virtual
         returns (bytes memory addressesFound)
     {
-        for (uint256 i = 0; i < rewardIds.length; i++) {
-            addressesFound = abi.encodePacked(addressesFound, boringChef.rewards(rewardIds[i]).token);
-        }
-        addressesFound = abi.encodePacked(addressesFound, user);
+        addressesFound = abi.encodePacked(user);
     }
 }

--- a/test/integrations/BoringChefIntegration.t.sol
+++ b/test/integrations/BoringChefIntegration.t.sol
@@ -52,7 +52,7 @@ contract BoringChefIntegrationTest is Test, MerkleTreeHelper {
 
         // TODO: DELETE MOCK, replace with real BoringVault using BoringChef
         mockBoringChef = address(new MockBoringChef());
-        rawDataDecoderAndSanitizer = address(new FullBoringChefDecoderAndSanitizer(mockBoringChef));
+        rawDataDecoderAndSanitizer = address(new FullBoringChefDecoderAndSanitizer());
 
         setAddress(false, sourceChain, "boringVault", address(boringVault));
         setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
@@ -123,12 +123,12 @@ contract BoringChefIntegrationTest is Test, MerkleTreeHelper {
 
         ManageLeaf[] memory leafs = new ManageLeaf[](2);
 
-        address[] memory rewardTokens = new address[](2);
-        rewardTokens[0] = getAddress(sourceChain, "BEETS");
-        rewardTokens[1] = getAddress(sourceChain, "wS");
+        // address[] memory rewardTokens = new address[](2);
+        // rewardTokens[0] = getAddress(sourceChain, "BEETS");
+        // rewardTokens[1] = getAddress(sourceChain, "wS");
 
-        _addBoringChefClaimLeaf(leafs, mockBoringChef, rewardTokens);
-        _addBoringChefClaimOnBehalfOfLeaf(leafs, mockBoringChef, rewardTokens, address(this));
+        _addBoringChefClaimLeaf(leafs, mockBoringChef);
+        _addBoringChefClaimOnBehalfOfLeaf(leafs, mockBoringChef, address(this));
 
 
         //string memory filePath = "./TestTEST.json";
@@ -178,7 +178,6 @@ contract BoringChefIntegrationTest is Test, MerkleTreeHelper {
 }
 
 contract FullBoringChefDecoderAndSanitizer is BoringChefDecoderAndSanitizer {
-    constructor(address _boringChef) BoringChefDecoderAndSanitizer(_boringChef) {}
 }
 
 // Temporary Mock Contract for test until real BoringChef is deployed

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -11171,7 +11171,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         );
     }
 
-    function _addBoringChefClaimLeaf(ManageLeaf[] memory leafs, address boringChef, address[] memory rewardTokens) internal {
+    function _addBoringChefClaimLeaf(ManageLeaf[] memory leafs, address boringChef) internal {
         unchecked {
             leafIndex++;
         }
@@ -11179,16 +11179,13 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
             boringChef,
             false,
             "claimRewards(uint256[])",
-            new address[](rewardTokens.length),
+            new address[](0),
             string.concat("Claim rewards from BoringChef"),
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
-        for (uint256 i = 0; i < rewardTokens.length; i++) {
-            leafs[leafIndex].argumentAddresses[i] = rewardTokens[i];
-        }
     }
 
-    function _addBoringChefClaimOnBehalfOfLeaf(ManageLeaf[] memory leafs, address boringChef, address[] memory rewardTokens, address user) internal {
+    function _addBoringChefClaimOnBehalfOfLeaf(ManageLeaf[] memory leafs, address boringChef, address user) internal {
         unchecked {
             leafIndex++;
         }
@@ -11196,14 +11193,11 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
             boringChef,
             false,
             "claimRewardsOnBehalfOfUser(uint256[],address)",
-            new address[](rewardTokens.length + 1),
+            new address[](1),
             string.concat("Claim rewards from BoringChef on behalf of user"),
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
-        for (uint256 i = 0; i < rewardTokens.length; i++) {
-            leafs[leafIndex].argumentAddresses[i] = rewardTokens[i];
-        }
-        leafs[leafIndex].argumentAddresses[rewardTokens.length] = user;
+        leafs[leafIndex].argumentAddresses[0] = user;
     }
 
     // ========================================= JSON FUNCTIONS =========================================


### PR DESCRIPTION
this has the benefit of removing the requirement of the boringChef immutable variable in order to access the rewards mapping, which means we only need 1 decoder for all chefs instead of 1 per chef