### PR TITLE
fix _boringRedeemSolve for USDT

### DIFF
--- a/src/base/Roles/BoringQueue/BoringSolver.sol
+++ b/src/base/Roles/BoringQueue/BoringSolver.sol
@@ -193,7 +193,7 @@ contract BoringSolver is IBoringSolver, Auth, Multicall {
         } // else nothing to do, we have exact change.
 
         // Approve Boring Queue to spend the required assets.
-        asset.approve(address(queue), requiredAssets);
+        asset.safeApprove(address(queue), requiredAssets);
     }
 
     /**
@@ -269,6 +269,6 @@ contract BoringSolver is IBoringSolver, Auth, Multicall {
         }
 
         // Approve Boring Queue to spend the required assets.
-        ERC20(toBoringVault).approve(address(queue), requiredShares);
+        ERC20(toBoringVault).safeApprove(address(queue), requiredShares);
     }
 }


### PR DESCRIPTION
safeApprove asset in _boringRedeemSolve in order to account for standard ERC20s and nonstandard ERC20s that do not return a boolean on approval.

USDT also reverts on approvals when there is a preexisting approval from/to the same user, but this does not need to be accounted for because the Queue always spends all of the Solver;s approval in a successful transaction

Note: toBoringVault should correctly implement ERC20 standard, unlike asset which might not always, but safeApprove is added there for consistency