### PR TITLE
Feat/add lz full address

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@
 # This overrides the `auto_detect_solc` value
 solc_version = '0.8.21'
 auto_detect_solc = false 
-evm_version = 'london'
+evm_version = 'shanghai'
 optimizer = true
 optimizer_runs = 200
 fs_permissions = [{ access = "read-write", path = "./" }]

--- a/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
@@ -23,6 +23,6 @@ abstract contract OFTDecoderAndSanitizer is BaseDecoderAndSanitizer {
         }
 
         sensitiveArguments =
-            abi.encodePacked(address(uint160(_sendParam.dstEid)), address(bytes20(_sendParam.to << 96)), _refundAddress);
+            abi.encodePacked(address(uint160(_sendParam.dstEid)), address(bytes20(bytes16(_sendParam.to))), address(bytes20(bytes16(_sendParam.to << 128))), _refundAddress);
     }
 }

--- a/test/integrations/OFTBridgeIntegration.t.sol
+++ b/test/integrations/OFTBridgeIntegration.t.sol
@@ -254,7 +254,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
 
         ManageLeaf[] memory leafs = new ManageLeaf[](2);
         _addLayerZeroLeafs(
-            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroMovementEndpointId, moveAddress
+            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "weETHOFTAdapterMovement"), layerZeroMovementEndpointId, moveAddress
         );
 
         bytes32[][] memory manageTree = _generateMerkleTree(leafs);
@@ -269,11 +269,11 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
 
         address[] memory targets = new address[](2);
         targets[0] = getAddress(sourceChain, "WEETH");
-        targets[1] = getAddress(sourceChain, "EtherFiOFTAdapter");
+        targets[1] = getAddress(sourceChain, "weETHOFTAdapterMovement");
 
         bytes[] memory targetData = new bytes[](2);
         targetData[0] = abi.encodeWithSignature(
-            "approve(address,uint256)", getAddress(sourceChain, "EtherFiOFTAdapter"), type(uint256).max
+            "approve(address,uint256)", getAddress(sourceChain, "weETHOFTAdapterMovement"), type(uint256).max
         );
         DecoderCustomTypes.SendParam memory param;
         param.dstEid = layerZeroMovementEndpointId;

--- a/test/integrations/OFTBridgeIntegration.t.sol
+++ b/test/integrations/OFTBridgeIntegration.t.sol
@@ -40,7 +40,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
         setSourceChainName(mainnet);
         // Setup forked environment.
         string memory rpcKey = "MAINNET_RPC_URL";
-        uint256 blockNumber = 22046375;
+        uint256 blockNumber = 22238413;
 
         _startFork(rpcKey, blockNumber);
 
@@ -113,7 +113,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
 
         ManageLeaf[] memory leafs = new ManageLeaf[](2);
         _addLayerZeroLeafs(
-            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroBaseEndpointId
+            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroBaseEndpointId, bytes32(uint256(uint160(address(boringVault))))
         );
 
         bytes32[][] memory manageTree = _generateMerkleTree(leafs);
@@ -168,7 +168,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
 
         ManageLeaf[] memory leafs = new ManageLeaf[](2);
         _addLayerZeroLeafs(
-            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroBaseEndpointId
+            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroBaseEndpointId, bytes32(uint256(uint160(address(boringVault))))
         );
 
         bytes32[][] memory manageTree = _generateMerkleTree(leafs);
@@ -241,6 +241,64 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
             fee,
             boringVault
         );
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    function testBridgingToMove() external {
+        deal(getAddress(sourceChain, "WEETH"), address(boringVault), 101e18);
+        deal(getAddress(sourceChain, "boringVault"), 101e18);
+
+        // This is a random placeholder address on movement, replace with real desired address
+        bytes32 moveAddress = 0x0e3ff4b536786141b08d0fbbc1ccfde4513931ee997711f3e00df822c2f017e5;
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](2);
+        _addLayerZeroLeafs(
+            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroMovementEndpointId, moveAddress
+        );
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0];
+        manageLeafs[1] = leafs[1];
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](2);
+        targets[0] = getAddress(sourceChain, "WEETH");
+        targets[1] = getAddress(sourceChain, "EtherFiOFTAdapter");
+
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "EtherFiOFTAdapter"), type(uint256).max
+        );
+        DecoderCustomTypes.SendParam memory param;
+        param.dstEid = layerZeroMovementEndpointId;
+        param.to = moveAddress; //placeholder movement address
+        param.amountLD = 100e18;
+        param.minAmountLD = 99e18;
+        param.extraOptions = hex"0003";
+        param.composeMsg = hex"";
+        param.oftCmd = hex"";
+
+        DecoderCustomTypes.MessagingFee memory fee;
+        fee.nativeFee = 0.0006e18;
+        fee.lzTokenFee = 0;
+
+        targetData[1] = abi.encodeWithSignature(
+            "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
+            param,
+            fee,
+            boringVault
+        );
+        uint256[] memory values = new uint256[](2);
+        values[1] = fee.nativeFee;
+        address[] memory decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
 
         manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
     }

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -49,6 +49,7 @@ contract ChainValues {
     uint32 public constant layerZeroSonicMainnetEndpointId = 30332;
     uint32 public constant layerZeroSepoliaEndpointId = 40161;
     uint32 public constant layerZeroSonicBlazeEndpointId = 40349;
+    uint32 public constant layerZeroMovementEndpointId = 30325;
     uint32 public constant hyperlaneMainnetEndpointId = 1;
     uint32 public constant hyperlaneEclipseEndpointId = 1408864445;
 

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -1110,6 +1110,7 @@ contract ChainValues {
         // Layer Zero.
         values[mainnet]["LayerZeroEndPoint"] = 0x1a44076050125825900e736c501f859c50fE728c.toBytes32();
         values[mainnet]["EtherFiOFTAdapter"] = 0xcd2eb13D6831d4602D80E5db9230A57596CDCA63.toBytes32();
+        values[mainnet]["weETHOFTAdapterMovement"] = 0x6FFcE32713417569237786cbeFBe355090642bF9.toBytes32();
         values[mainnet]["LBTCOFTAdapter"] = 0x6bc15D7930839Ec18A57F6f7dF72aE1B439D077f.toBytes32();
         values[mainnet]["WBTCOFTAdapter"] = 0x0555E30da8f98308EdB960aa94C0Db47230d2B9c.toBytes32();
         values[mainnet]["stargateUSDC"] = 0xc026395860Db2d07ee33e05fE50ed7bD583189C7.toBytes32();

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -7086,7 +7086,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
 
     // ========================================= LayerZero =========================================
 
-    function _addLayerZeroLeafs(ManageLeaf[] memory leafs, ERC20 asset, address oftAdapter, uint32 endpoint) internal {
+    function _addLayerZeroLeafsOldDecoder(ManageLeaf[] memory leafs, ERC20 asset, address oftAdapter, uint32 endpoint) internal {
         if (address(asset) != oftAdapter) {
             unchecked {
                 leafIndex++;
@@ -7115,6 +7115,38 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex].argumentAddresses[0] = address(uint160(endpoint));
         leafs[leafIndex].argumentAddresses[1] = getAddress(sourceChain, "boringVault");
         leafs[leafIndex].argumentAddresses[2] = getAddress(sourceChain, "boringVault");
+    }
+
+    function _addLayerZeroLeafs(ManageLeaf[] memory leafs, ERC20 asset, address oftAdapter, uint32 endpoint, bytes32 to) internal {
+        if (address(asset) != oftAdapter) {
+            unchecked {
+                leafIndex++;
+            }
+            leafs[leafIndex] = ManageLeaf(
+                address(asset),
+                false,
+                "approve(address,uint256)",
+                new address[](1),
+                string.concat("Approve LayerZero to spend ", asset.symbol()),
+                getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+            );
+            leafs[leafIndex].argumentAddresses[0] = oftAdapter;
+        }
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            oftAdapter,
+            true,
+            "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
+            new address[](4),
+            string.concat("Bridge ", asset.symbol(), " to LayerZero endpoint: ", vm.toString(endpoint)),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = address(uint160(endpoint));
+        leafs[leafIndex].argumentAddresses[1] = address(bytes20(bytes16(to)));
+        leafs[leafIndex].argumentAddresses[2] = address(bytes20(bytes16(to << 128)));
+        leafs[leafIndex].argumentAddresses[3] = getAddress(sourceChain, "boringVault");
     }
 
     // ========================================= Compound V3 =========================================


### PR DESCRIPTION
Decodes LayerZero OFT _sendParams.to into two bytes16s stored in two addresses, replacing the single cut off bytes20 stored in one address, tests weETH Move OFT Bridging