### PR TITLE
Update liquidBeraETH/BTC (prime and non) merkle roots

### DIFF
--- a/leafs/Berachain/LiquidBeraBtcStrategistLeafs.json
+++ b/leafs/Berachain/LiquidBeraBtcStrategistLeafs.json
@@ -10,14 +10,16 @@
             "Bytes4(TARGET_FUNCTION_SELECTOR)",
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
-        "LeafCount": 65,
-        "ManageRoot": "0x96e7be2de0cb613e7a1dfa54bbadc55074968fbbaceea518bdf9f9fbfc8c566a",
+        "LeafCount": 77,
+        "ManageRoot": "0x128e99663759753c8e27572d8220252a4db24c7da70befeca4e48b29af29f24c",
         "ManagerAddress": "0x603064caAf2e76C414C5f7b6667D118322d311E6",
         "TreeCapacity": 128
     },
     "leafs": [
         {
-            "AddressArguments": ["0xF44BD12956a0a87c2C20113DdFe1537A442526B5"],
+            "AddressArguments": [
+                "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Accountant to spend WBTC",
@@ -28,7 +30,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0xF44BD12956a0a87c2C20113DdFe1537A442526B5"],
+            "AddressArguments": [
+                "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Accountant to spend LBTC",
@@ -39,7 +43,9 @@
             "TargetAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
         },
         {
-            "AddressArguments": ["0xF44BD12956a0a87c2C20113DdFe1537A442526B5"],
+            "AddressArguments": [
+                "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Accountant to spend eBTC",
@@ -50,7 +56,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Claim fees in WBTC",
@@ -61,7 +69,9 @@
             "TargetAddress": "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Claim yield in WBTC",
@@ -72,7 +82,9 @@
             "TargetAddress": "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
         },
         {
-            "AddressArguments": ["0xecAc9C5F704e954931349Da37F60E39f515c11c1"],
+            "AddressArguments": [
+                "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Claim fees in LBTC",
@@ -83,7 +95,9 @@
             "TargetAddress": "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
         },
         {
-            "AddressArguments": ["0xecAc9C5F704e954931349Da37F60E39f515c11c1"],
+            "AddressArguments": [
+                "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Claim yield in LBTC",
@@ -94,7 +108,9 @@
             "TargetAddress": "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Claim fees in eBTC",
@@ -105,7 +121,9 @@
             "TargetAddress": "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Claim yield in eBTC",
@@ -116,7 +134,9 @@
             "TargetAddress": "0xF44BD12956a0a87c2C20113DdFe1537A442526B5"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Ooga Booga Router to spend WBTC",
@@ -131,15 +151,15 @@
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap WBTC for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xaf4fdc5117b3f2c6c820a2dda87726d418377cdfc3ad99926c7e7145d6c00d22",
-            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9cecac9c5f704e954931349da37f60e39f515c11c1c673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x48c51bcf58b0384041a27d154843a686485bdb2d2e66b3bf2fda6638e4535443",
+            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9cecac9c5f704e954931349da37f60e39f515c11c1c673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -147,15 +167,15 @@
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap LBTC for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xf954af2bdfa4d6b4d33e0802cc65a20b1cea94ef37214b2676433188947594b0",
-            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c10555e30da8f98308edb960aa94c0db47230d2b9cc673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x32fd0c13b846efae95775eb2c87fa578baf948cf10adbb560b2fb771c6266840",
+            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c10555e30da8f98308edb960aa94c0db47230d2b9cc673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -163,15 +183,15 @@
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap WBTC for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xc80f5d7b9c602cd873a3b3d697f9f74f63c0b3d0e443276a180a24b2747bdb40",
-            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9c657e8c867d8b37dcc18fa4caead9c45eb088c642c673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x1978aea2311ae6fcb470e0e47f92234e853a69f0576a426f871606cbd5ef003a",
+            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9c657e8c867d8b37dcc18fa4caead9c45eb088c642c673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -179,15 +199,15 @@
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap eBTC for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xe9aa2405f5e1c111ab182441d070f9ef29d700d37e1db3e250278021deadef83",
-            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c6420555e30da8f98308edb960aa94c0db47230d2b9cc673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x7ae08f3058ce83471f4008088bdc39b34ab9f1eb2af05f81fbbea27ec924f04b",
+            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c6420555e30da8f98308edb960aa94c0db47230d2b9cc673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -195,19 +215,21 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap iBGT for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xefde57259a3e932c7f015e310ed539ead6bc14408c43db7ebd98a1ad4dc0cbbb",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b0555e30da8f98308edb960aa94c0db47230d2b9cc673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x002013e8fa53daef05ddd73275a70bfa2c0c0f33ce80b2bca53fa111c8d725c3",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b0555e30da8f98308edb960aa94c0db47230d2b9cc673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Ooga Booga Router to spend LBTC",
@@ -222,15 +244,15 @@
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap LBTC for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x3c73d20afccc3fa03b3fb308039dc86aa6833498c1f4b43639c137eced022e63",
-            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c1657e8c867d8b37dcc18fa4caead9c45eb088c642c673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xd57a1b1a956152156991f6dc2c1990183321a5a6e9d3be95c6ec74013303e4c5",
+            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c1657e8c867d8b37dcc18fa4caead9c45eb088c642c673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -238,15 +260,15 @@
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap eBTC for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x9ae757f747950e562421d08e2133e4832ac22208cc640093b807143c3e7b4cc2",
-            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642ecac9c5f704e954931349da37f60e39f515c11c1c673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x166403ee9b03a047deea0742add460adac612425aeaf965b8c91beb2f7379c31",
+            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642ecac9c5f704e954931349da37f60e39f515c11c1c673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -254,19 +276,21 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap iBGT for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x7a8dc7e9bca5b65c360dc63c5c6074bc1a72961f9a049b658294c07696809cb2",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6becac9c5f704e954931349da37f60e39f515c11c1c673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x365c71417c57fec0eb8ec6418dbcb73a7d8b399e3322091013f894d806f7d376",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6becac9c5f704e954931349da37f60e39f515c11c1c673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Ooga Booga Router to spend eBTC",
@@ -281,19 +305,21 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Swap iBGT for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x2fce1586cc0373e3c94000ca7a4f12ed04215c06626ed7bb1621b2a4398ba280",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b657e8c867d8b37dcc18fa4caead9c45eb088c642c673ef7791724f0dcca38adb47fbb3aef3db6c802242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x332d520f9bb98335122eccedc5f4c3a1f8cfdb4339f2330823ebed0aaeb7e39f",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b657e8c867d8b37dcc18fa4caead9c45eb088c642c673ef7791724f0dcca38adb47fbb3aef3db6c800e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Ooga Booga Router to spend iBGT",
@@ -304,10 +330,12 @@
             "TargetAddress": "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b"
         },
         {
-            "AddressArguments": ["0x8704852E95AA04799db5A1B03C4205156A74af0F"],
+            "AddressArguments": [
+                "0x8704852E95AA04799db5A1B03C4205156A74af0F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
-            "Description": "Withdraw from Royco using merkle proofs",
+            "Description": "Withdraw Weiroll deposit from 0x8704852E95AA04799db5A1B03C4205156A74af0F",
             "FunctionSelector": "0xe927c240",
             "FunctionSignature": "withdrawMerkleDeposit(address,uint256,uint256,bytes32[])",
             "LeafDigest": "0x224f4dc5feb58e29053039de8acf82a449e2c3d22d0e828014bbd280fbb67642",
@@ -315,10 +343,12 @@
             "TargetAddress": "0xEC1F64Cd852c65A22bCaA778b2ed76Bc5502645C"
         },
         {
-            "AddressArguments": ["0x7f668bAee90cA161e6a7a9D3E0148a6738C78360"],
+            "AddressArguments": [
+                "0x7f668bAee90cA161e6a7a9D3E0148a6738C78360"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
-            "Description": "Withdraw from Royco using merkle proofs",
+            "Description": "Withdraw Weiroll deposit from 0x7f668bAee90cA161e6a7a9D3E0148a6738C78360",
             "FunctionSelector": "0xe927c240",
             "FunctionSignature": "withdrawMerkleDeposit(address,uint256,uint256,bytes32[])",
             "LeafDigest": "0x082d1ea322ba092f1214e5f40d0ac9b939a12f09bb18aa9528c32456530f0270",
@@ -326,7 +356,9 @@
             "TargetAddress": "0xEC1F64Cd852c65A22bCaA778b2ed76Bc5502645C"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Prime Ether.Fi Liquid Bera BTC, to spend WBTC",
@@ -365,7 +397,9 @@
             "TargetAddress": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit WBTC into Prime Ether.Fi Liquid Bera BTC",
@@ -376,7 +410,9 @@
             "TargetAddress": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Prime Ether.Fi Liquid Bera BTC, to spend LBTC",
@@ -415,7 +451,9 @@
             "TargetAddress": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7"
         },
         {
-            "AddressArguments": ["0xecAc9C5F704e954931349Da37F60E39f515c11c1"],
+            "AddressArguments": [
+                "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit LBTC into Prime Ether.Fi Liquid Bera BTC",
@@ -426,7 +464,9 @@
             "TargetAddress": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Prime Ether.Fi Liquid Bera BTC, to spend eBTC",
@@ -465,7 +505,9 @@
             "TargetAddress": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit eBTC into Prime Ether.Fi Liquid Bera BTC",
@@ -476,7 +518,9 @@
             "TargetAddress": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Prime Ether.Fi Liquid Bera BTC, to spend WBTC",
@@ -515,7 +559,9 @@
             "TargetAddress": "0xCD20c63dDAfAc686d311B40f24DcaD316dDE8D9c"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit WBTC into Prime Ether.Fi Liquid Bera BTC",
@@ -526,7 +572,9 @@
             "TargetAddress": "0xCD20c63dDAfAc686d311B40f24DcaD316dDE8D9c"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Prime Ether.Fi Liquid Bera BTC, to spend LBTC",
@@ -565,7 +613,9 @@
             "TargetAddress": "0xCD20c63dDAfAc686d311B40f24DcaD316dDE8D9c"
         },
         {
-            "AddressArguments": ["0xecAc9C5F704e954931349Da37F60E39f515c11c1"],
+            "AddressArguments": [
+                "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit LBTC into Prime Ether.Fi Liquid Bera BTC",
@@ -576,7 +626,9 @@
             "TargetAddress": "0xCD20c63dDAfAc686d311B40f24DcaD316dDE8D9c"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve Prime Ether.Fi Liquid Bera BTC, to spend eBTC",
@@ -615,7 +667,9 @@
             "TargetAddress": "0xCD20c63dDAfAc686d311B40f24DcaD316dDE8D9c"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit eBTC into Prime Ether.Fi Liquid Bera BTC",
@@ -626,7 +680,9 @@
             "TargetAddress": "0xCD20c63dDAfAc686d311B40f24DcaD316dDE8D9c"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve ether.fi BTC, to spend WBTC",
@@ -665,7 +721,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit WBTC into ether.fi BTC",
@@ -676,7 +734,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve ether.fi BTC, to spend LBTC",
@@ -715,7 +775,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0xecAc9C5F704e954931349Da37F60E39f515c11c1"],
+            "AddressArguments": [
+                "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Deposit LBTC into ether.fi BTC",
@@ -742,7 +804,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0x630e12D53D4E041b8C5451aD035Ea841E08391d7"],
+            "AddressArguments": [
+                "0x630e12D53D4E041b8C5451aD035Ea841E08391d7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve LayerZero to spend LBTC",
@@ -769,7 +833,9 @@
             "TargetAddress": "0x630e12D53D4E041b8C5451aD035Ea841E08391d7"
         },
         {
-            "AddressArguments": ["0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"],
+            "AddressArguments": [
+                "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve CrossChain Teller to spend eBTC",
@@ -780,7 +846,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve CrossChain Teller to spend LBTC",
@@ -791,7 +859,9 @@
             "TargetAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
             "Description": "Approve CrossChain Teller to spend WBTC",
@@ -849,136 +919,144 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": [],
+            "AddressArguments": [
+                "0x4bA0a69621eA72870F9fcf2D974D39B8609343cC"
+            ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Approve Infrared Vault to spend primeLiquidBeraBTC",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x5917462b0c8412b10f0164e7491fe32681ff0d5a98780200ac9fcd1d5c0415b7",
+            "PackedArgumentAddresses": "0x4ba0a69621ea72870f9fcf2d974d39b8609343cc",
+            "TargetAddress": "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Stake primeLiquidBeraBTC into Infrared Vault",
+            "FunctionSelector": "0xa694fc3a",
+            "FunctionSignature": "stake(uint256)",
+            "LeafDigest": "0xc52c2f096bb84ef90f811a2751251fc9e32a3c7dd4fd337147a195d53b04f17b",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x4bA0a69621eA72870F9fcf2D974D39B8609343cC"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Withdraw primeLiquidBeraBTC from Infrared Vault",
+            "FunctionSelector": "0x2e1a7d4d",
+            "FunctionSignature": "withdraw(uint256)",
+            "LeafDigest": "0x12e60346a04b82999d8680425a9a4cba96411993283a19744e4b22d5340103e3",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x4bA0a69621eA72870F9fcf2D974D39B8609343cC"
+        },
+        {
+            "AddressArguments": [
+                "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Get Reward for user from primeLiquidBeraBTC Infrared Vault",
+            "FunctionSelector": "0xef790a82",
+            "FunctionSignature": "getRewardForUser(address)",
+            "LeafDigest": "0x729b56751b114f850868ea193035975db87b594aa942ddfff7d5a2987e0f7c0f",
+            "PackedArgumentAddresses": "0xc673ef7791724f0dcca38adb47fbb3aef3db6c80",
+            "TargetAddress": "0x4bA0a69621eA72870F9fcf2D974D39B8609343cC"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Get Reward for primeLiquidBeraBTC Infrared Vault",
+            "FunctionSelector": "0x3d18b912",
+            "FunctionSignature": "getReward()",
+            "LeafDigest": "0x0fe1e39c6201068f15e5ea164190bac33e1a535f1e0815c9109fc7985af898d1",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x4bA0a69621eA72870F9fcf2D974D39B8609343cC"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Exit from primeLiquidBeraBTC Infrared Vault",
+            "FunctionSelector": "0xe9fad8ee",
+            "FunctionSignature": "exit()",
+            "LeafDigest": "0xe91902fded169a6a91c57eeaf670747e052d31bc2af5f3fb4d00bb5255fa7e9d",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x4bA0a69621eA72870F9fcf2D974D39B8609343cC"
+        },
+        {
+            "AddressArguments": [
+                "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Approve Infrared Vault to spend iBGT",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0xd85d431b2010c83875df5a776b4474741fa7865da80f9c694b2b7ef350b06c0a",
+            "PackedArgumentAddresses": "0x75f3be06b02e235f6d0e7ef2d462b29739168301",
+            "TargetAddress": "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Stake iBGT into Infrared Vault",
+            "FunctionSelector": "0xa694fc3a",
+            "FunctionSignature": "stake(uint256)",
+            "LeafDigest": "0x59679f84dfc3a93b4842b3ce8d394edafb2d33addfd096a3a7c60414f8a41746",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Withdraw iBGT from Infrared Vault",
+            "FunctionSelector": "0x2e1a7d4d",
+            "FunctionSignature": "withdraw(uint256)",
+            "LeafDigest": "0xe55d8c4234f6bebe03f2f3be88ab214a6e283804c51292fab7dd5280e7be72bf",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+        },
+        {
+            "AddressArguments": [
+                "0xC673ef7791724f0dcca38adB47Fbb3AEF3DB6C80"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Get Reward for user from iBGT Infrared Vault",
+            "FunctionSelector": "0xef790a82",
+            "FunctionSignature": "getRewardForUser(address)",
+            "LeafDigest": "0xcbe424bbf78a71f2ff8bc3c062cf9627f7a50c39dc0b85a7f293ec8d81c3fcb8",
+            "PackedArgumentAddresses": "0xc673ef7791724f0dcca38adb47fbb3aef3db6c80",
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Get Reward for iBGT Infrared Vault",
+            "FunctionSelector": "0x3d18b912",
+            "FunctionSignature": "getReward()",
+            "LeafDigest": "0xbf0c76c2e7040056cf40ff3e88b26518bd27efe094ba90142ef3506101bc5bbc",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x4aE6F23a15B7D1Ef3733Fa6694324f89f51EB491",
+            "Description": "Exit from iBGT Infrared Vault",
+            "FunctionSelector": "0xe9fad8ee",
+            "FunctionSignature": "exit()",
+            "LeafDigest": "0x4e8e569d749c03ae8e1b8b252f33d25732553b505e324eb3a61a7ccdbcaebc45",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
         },
         {
             "AddressArguments": [],
@@ -1544,39 +1622,39 @@
     ],
     "MerkleTree": {
         "0": [
-            "0x96e7be2de0cb613e7a1dfa54bbadc55074968fbbaceea518bdf9f9fbfc8c566a"
+            "0x128e99663759753c8e27572d8220252a4db24c7da70befeca4e48b29af29f24c"
         ],
         "1": [
-            "0xd7235c970cb71db65d6996aa5fb6a75060af25ce4e55d4ad7597c9bed54833b1",
-            "0xd8030c6e40c0f59f36b0467b71ba78c94b483bbaa18e8a76c77c04bd8d7f8de9"
+            "0xc68dd12d568f06a19020212cc19b299107e2ceb32a83281e38f5efd63e481301",
+            "0x3f89033a994e43982f5ac626d2515f172497c64c724a1e2e3a8456cb3a7add74"
         ],
         "2": [
-            "0x84d8dcf942a2ffd9aa31be410524a9b942c2536284ff203d427f44e6897f1ab0",
+            "0x3177b82291214a35f52723fa9bd146cd1ec09b8765650945aece53a6ae17f01d",
             "0x86ced9eb5b070c3365af85a3b171b2a0a8573cff6eb47542a0a293fb08450b37",
-            "0x5ab4196b060de8f64e8c2cd73ca361a54ac8471f284d4cc3b6bc8bde5bf1a786",
+            "0xd0139b567d3c52160766316e5c3bdaca4968cffcb2cd369fcbb80411b0306134",
             "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a"
         ],
         "3": [
-            "0xb8ab7bfb977ea14284165dce926395fa5611e8a5ef2434cdfbfb2a59d3a80891",
-            "0x9002111bb8378c8e89192688d0e5b627358ef8857eac280aecf45ee39a797caf",
+            "0x91e31b91c5ce0ba180e1df2fae301c47bbf0d01bd4e27d995e0be062f3a22e2b",
+            "0x4985d3efe5dae19ff156ef14073f6673eb572ea7daf30b854f24f7c47e7ed151",
             "0x8628078562941a4c7efcee6efc8174ace7f64754ce901c0698e48e6849ed9ae7",
             "0x24a932c6a9d19196b70f9251ddb993cf88da4ad73760e1ba33c9b12fa3d4cd4b",
-            "0x4d2ef97482106eece9697b82e8922606eba08c9b3fa9023469a40b34627c0cb0",
+            "0x1902ada039a1e9ad208529be3338e2430e3b521cc3038e2b4e1a7eb903cf1282",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
         "4": [
             "0x92396e8636b8e027bb85d50903a7f63ccc4d5655f6e689414e97ed60aa821e06",
-            "0x8e2ee73382225590737ad4aae97d35b998afd83f784bd3fea17654e4e243d41e",
-            "0xe309e9a1aa56781f7c553a9e34297e7c52f0b24ed078d8badf3b7b814685808e",
+            "0xe1b58ba6ecd10a1c7897de5a3db0f69c2bf100e705db07c3ab9659057212e237",
+            "0x142770828fd9ebc565a8786ca2569708bc43c6db87d6347dcf88cf5c97dc9212",
             "0xe8e882180572abef85840ed9230c07decb45867b4c6ad536c657f8d5f4c08c13",
             "0x463ae28bf979e0d4c1ebf02538eb67fe5c7700888ce6e037db48cb443981ab4b",
             "0xa36d3ccdd7766fef67fb9d2f7f25caa9d72967602487a2bf5c56280d37dabe6e",
             "0x63187ddfe02e34c9d3d0a61ba1a57d9699e505cbc713f778fba9b724eb120d40",
             "0xf18b0215eca0a7287deead0c0d7ff7d05fb387bb2453a1ae8b55f326ece58bd1",
-            "0xa03ecb3339fbf68934c046c0e0c11f560cc5e3cf62e4876a35db9df34fd4a139",
-            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
+            "0xf9cdfe84c529a5b48a7d426d0bd6d0120e1fe1aa863637ea08a61707ea962304",
+            "0x195c7ed36efd6a7009e7f9f7587bd8e6fadf1f95586fac8515720b0badc42113",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
@@ -1587,10 +1665,10 @@
         "5": [
             "0x41488f84ed6b482f53afa86322300e8f502e2f5e72e79820467ec12db6a266eb",
             "0xf3f119b3dcd03c219f91431936003999bf9e4aff538ea46a9e4f28955cc0b263",
-            "0x488c1e2356c4b3f6ca0c47754f8ccc322d65dfa7f8f6da9e0b389c343cd873b6",
-            "0xa72eb54c55c1592393f710aecc7398495bec6a2ea25de78d96948f0428d468a2",
-            "0x3f9db794dd6e38f1b089f4c9b9ec6872ff0caf514934d30a099194ac2ed747e4",
-            "0x0ebf98130c817804df9beb29deae17c126db2e48d3c6f3185d0755075946cc5e",
+            "0x200fc93bf60cd607ff187bc7bf7506e805340518a3704e12d74f60e3a8e25b03",
+            "0xfa56959506f79e4ebf1466f9f6562c731579ee28a889836fae597353668692fa",
+            "0xb08d02ef61f8b226742378258edc9eaf28bbe29c0a136a70edd7d10abe07aaf0",
+            "0xe8b7e2aa4a01b348bc406feb76596250fb484b893f142553481705c7bf68a2b1",
             "0xdd6c7768c2ced1d33d725b107dfa4934b6a1b4a12af86361ec71501915149bc6",
             "0x7733397db9c44e450ff53fa97622d764c36e7798bf0a8ab1fd4a743c78d001e4",
             "0xd1df8c3824401682f0efd780133277e3a60f1789e00a8a8c07cb00843503ebaf",
@@ -1601,10 +1679,10 @@
             "0x7ddced993ffe35efc6b63ff7d9ec685df95a1ad784fffbd7747d4b2be62787ae",
             "0x56d677b4f099dbe10019edd0b0a682ad0c93fe294a1d24038d28f6c511b204d1",
             "0x4bfeda544abc5a82bb2d5ce4a78d66d817bdef55c70801caf77f31662703d43c",
-            "0xe8cba739181428ef7fa6a3882b5b29bb9af4a8fb97c774d89411745b43ae9b34",
-            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x30eb7d8f7e6246121cf8a7225b00abc5be50fe55dfb855d2fa93a4fa44e51ae1",
+            "0xc730600e36ad33ad7f0458cf2d0ffeae908a87a78bfab8fbb8502994e79e912d",
+            "0x80f9c4127bdbc2e555bc6769cdeb7564bea016bd6c3d8b3b1be25fb8d05a6b7c",
+            "0x8d2967603d78ae09552377b2b00a257e65c506abfd5c68e56d82da430bbc9b5b",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -1624,12 +1702,12 @@
             "0x3a3a82b434b44b3bfb020677743acd1867a5c24b7ca6364b3343bb44f02c06ac",
             "0xe856fc36be0ee3b0d041e92e23892f19666c84da389634695168155cdd892c52",
             "0xfbdfbe7be361922248d33d04c56c32aa1805bcca81e17938bec73b2a669e967a",
-            "0x086e567be637c2fb051e7ffaa17523e7b3065d3edae20cf4ec62d254b00081cb",
-            "0x30022ba6f4dc0fc3e24410a6ca0a1830cd494812444d291ebe31764bf9dc451c",
-            "0x0dff48da1a4a86615a8a97075938212b63864f4723a0465cdb2e0c453db79d5d",
-            "0x7d9fdedd74c52c83e160495470221ec756d4741bb04b85b54434b130f7369135",
-            "0x68ae49eabec1060627b311577c243f67fb64edec33248302ca238dde2e13e5d1",
-            "0x318e7cca7132aa885bacb15c933f3a3278bb09e671c99d1789ec87512f25adf2",
+            "0xb4416514f6beaa17a5bd6f6af751874edddf312d060810a00c2f355c49a02ba0",
+            "0x91ce494372951bbd2d7499818f5d500456d84dc4d00a7315e723ff383e164800",
+            "0x9593be8f8fb2664a5ef4be2f5aff729e304cd3ba0141e0d3cb75780887539154",
+            "0xaab7018fdcd2403dfaa1fc3aa6a45378ca114603a0fca79a708610eecda71898",
+            "0xd23141756776c4f9cae0c319fe072d4212428afbf6440f0f4545cc9afef53429",
+            "0xefedac62e46058a934d2e77a37049f9df7e814f185ca6fb3e6329fee8e0a9d86",
             "0x18db273a17fbf1993520d909a238d0dbc16461476c9eef1308edd4b0b3d384d4",
             "0x52b30bb3cb2edf3c150a47ab30174f4deb319b15354db134e4e3699e47235195",
             "0x82e05ff80a9ed2d2d7c5a67f7456781ea0f61878fbd2c62cbeb8a93d66f572c9",
@@ -1651,13 +1729,13 @@
             "0x4d57f2dcfdf3f7dc062908000286d9048ce618518ca3b0be918da7894764895f",
             "0x58995207ce461665eb9920c69aa84c83464943097c68939d0029e353f5df20fe",
             "0x6a24875b8da4c59e4a196c1fd89a55dac8d8a7497f117726109b009086ecc804",
-            "0x20e46729d89ab6d5f379adf9551467651c8f62361d193ec58e56695ba8d1f9b5",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0x5d6d12eebc1a1817453dcde3a7e24f2c9155b5f332e417f7a4aa86da1715bf1c",
+            "0xab03a93aaab6e53e9c3f6e273d0df3682455d7d06604750d9ddea4c2a5ff47d7",
+            "0x9f01e0d08726f65f14cec2a8bae48508fa9c582e7e11f6c0279069e893249abc",
+            "0xa57a2a9149fe24a84608fed4bc295bd76e6bce609834d053641abffe3c8a02bb",
+            "0x27b46c650b58fe8c784ff5a199357b15a0f7e8b7cfa1380da2818a4d6f9f8e11",
+            "0x0440502418efb3f743efa747b3dee80efc2c9579d06410c2c433148ccf183b04",
+            "0x1f11308d1e1451675b29056db1e93ca3845891207388891bbb295a70c44a3fcf",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -1695,17 +1773,17 @@
             "0x08ba0aa6fdbf1b556d2b343b786c8b8aa5720efe1ee8862f2b730fa367f6b758",
             "0x173b38f2b834b7bea114973220f06f6e4d9e75781febc49a26bef7facde69ee1",
             "0xd914fc305d551e16a0e2e1805a9925edafb07f03bd40dbb53cf7a7e5d1a99980",
-            "0xaf4fdc5117b3f2c6c820a2dda87726d418377cdfc3ad99926c7e7145d6c00d22",
-            "0xf954af2bdfa4d6b4d33e0802cc65a20b1cea94ef37214b2676433188947594b0",
-            "0xc80f5d7b9c602cd873a3b3d697f9f74f63c0b3d0e443276a180a24b2747bdb40",
-            "0xe9aa2405f5e1c111ab182441d070f9ef29d700d37e1db3e250278021deadef83",
-            "0xefde57259a3e932c7f015e310ed539ead6bc14408c43db7ebd98a1ad4dc0cbbb",
+            "0x48c51bcf58b0384041a27d154843a686485bdb2d2e66b3bf2fda6638e4535443",
+            "0x32fd0c13b846efae95775eb2c87fa578baf948cf10adbb560b2fb771c6266840",
+            "0x1978aea2311ae6fcb470e0e47f92234e853a69f0576a426f871606cbd5ef003a",
+            "0x7ae08f3058ce83471f4008088bdc39b34ab9f1eb2af05f81fbbea27ec924f04b",
+            "0x002013e8fa53daef05ddd73275a70bfa2c0c0f33ce80b2bca53fa111c8d725c3",
             "0xebc1932289ac7e7329689ee764183b94e86ba698ecbecf8c6157778a47e91a84",
-            "0x3c73d20afccc3fa03b3fb308039dc86aa6833498c1f4b43639c137eced022e63",
-            "0x9ae757f747950e562421d08e2133e4832ac22208cc640093b807143c3e7b4cc2",
-            "0x7a8dc7e9bca5b65c360dc63c5c6074bc1a72961f9a049b658294c07696809cb2",
+            "0xd57a1b1a956152156991f6dc2c1990183321a5a6e9d3be95c6ec74013303e4c5",
+            "0x166403ee9b03a047deea0742add460adac612425aeaf965b8c91beb2f7379c31",
+            "0x365c71417c57fec0eb8ec6418dbcb73a7d8b399e3322091013f894d806f7d376",
             "0x4c1524a8198a5949799fd208e40161a65a41e361108ebe276f2803d7510d1298",
-            "0x2fce1586cc0373e3c94000ca7a4f12ed04215c06626ed7bb1621b2a4398ba280",
+            "0x332d520f9bb98335122eccedc5f4c3a1f8cfdb4339f2330823ebed0aaeb7e39f",
             "0x334f7d306d64828b292626101394bd257dfc747275553c700e5e1e0fe35c428f",
             "0x224f4dc5feb58e29053039de8acf82a449e2c3d22d0e828014bbd280fbb67642",
             "0x082d1ea322ba092f1214e5f40d0ac9b939a12f09bb18aa9528c32456530f0270",
@@ -1750,18 +1828,18 @@
             "0x5d0a3c2e6c1fe0d5cdd9d206f69efe6621ac187d8bee0df80960c411c1041d79",
             "0xded2102fdebe874641bcecf28ff65ec2037f34ac47a365905ad95da8a7513751",
             "0x4dbb831489eb6682e237e5ec9e0053305a25de917504bc1d74a928a7461495a1",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0x5917462b0c8412b10f0164e7491fe32681ff0d5a98780200ac9fcd1d5c0415b7",
+            "0xc52c2f096bb84ef90f811a2751251fc9e32a3c7dd4fd337147a195d53b04f17b",
+            "0x12e60346a04b82999d8680425a9a4cba96411993283a19744e4b22d5340103e3",
+            "0x729b56751b114f850868ea193035975db87b594aa942ddfff7d5a2987e0f7c0f",
+            "0x0fe1e39c6201068f15e5ea164190bac33e1a535f1e0815c9109fc7985af898d1",
+            "0xe91902fded169a6a91c57eeaf670747e052d31bc2af5f3fb4d00bb5255fa7e9d",
+            "0xd85d431b2010c83875df5a776b4474741fa7865da80f9c694b2b7ef350b06c0a",
+            "0x59679f84dfc3a93b4842b3ce8d394edafb2d33addfd096a3a7c60414f8a41746",
+            "0xe55d8c4234f6bebe03f2f3be88ab214a6e283804c51292fab7dd5280e7be72bf",
+            "0xcbe424bbf78a71f2ff8bc3c062cf9627f7a50c39dc0b85a7f293ec8d81c3fcb8",
+            "0xbf0c76c2e7040056cf40ff3e88b26518bd27efe094ba90142ef3506101bc5bbc",
+            "0x4e8e569d749c03ae8e1b8b252f33d25732553b505e324eb3a61a7ccdbcaebc45",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/leafs/Berachain/LiquidBeraEth.json
+++ b/leafs/Berachain/LiquidBeraEth.json
@@ -10,10 +10,10 @@
             "Bytes4(TARGET_FUNCTION_SELECTOR)",
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
-        "LeafCount": 30,
-        "ManageRoot": "0x6f4185d7971ed5509002357259a386d49fbd6dd3229191bd842943bdd546bb1d",
+        "LeafCount": 42,
+        "ManageRoot": "0x1fff8158302e424857162adcf4999954039fdfc583a3a8266cfede2e0598adb1",
         "ManagerAddress": "0x62b283d4FeFB2a120e1120dba9f83bE6CA41bCD7",
-        "TreeCapacity": 32
+        "TreeCapacity": 64
     },
     "leafs": [
         {
@@ -34,15 +34,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
             "Description": "Swap iBGT for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xb0677471e817a5f8828e96806103e62d2c1775ed7e4b8707f5703c8b072caa29",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b2f6f07cdcf3588944bf4c42ac74ff24bf56e759083599937c2c9bea0e0e8ac096c6f32e86486b4102242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xadc9832c1d02abafdf6569580f48e3f6c2203eee995e9eb06f772284b2eb6431",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b2f6f07cdcf3588944bf4c42ac74ff24bf56e759083599937c2c9bea0e0e8ac096c6f32e86486b4100e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -50,15 +50,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
             "Description": "Swap iBGT for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xa6ccebad82e9ceffb858656ba4ce7debb24cab072d8260252f5c2346bcbbaf68",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b7dcc39b4d1c53cb31e1abc0e358b43987fef80f783599937c2c9bea0e0e8ac096c6f32e86486b4102242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xbe9054cc06e2aa8fe1b74eaee7f86713362bebddfd067b61a7651cfc0e25c5e1",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b7dcc39b4d1c53cb31e1abc0e358b43987fef80f783599937c2c9bea0e0e8ac096c6f32e86486b4100e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -79,15 +79,15 @@
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
             "Description": "Swap WETH for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x540cb78b330fdf61b50941a2ef133bc56f83e468376cf5c758ba13161d5fc6bb",
-            "PackedArgumentAddresses": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e75907dcc39b4d1c53cb31e1abc0e358b43987fef80f783599937c2c9bea0e0e8ac096c6f32e86486b4102242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xcd31f61c0c7496c36f1e148f1839a9b149d95978e2e8b47b490ec012fd06f806",
+            "PackedArgumentAddresses": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e75907dcc39b4d1c53cb31e1abc0e358b43987fef80f783599937c2c9bea0e0e8ac096c6f32e86486b4100e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -95,15 +95,15 @@
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
             "Description": "Swap weETH for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xe40b39bd1b3a4690ced7db29dec18bbf359af091a071a587ed52cc3e8c576723",
-            "PackedArgumentAddresses": "0x7dcc39b4d1c53cb31e1abc0e358b43987fef80f72f6f07cdcf3588944bf4c42ac74ff24bf56e759083599937c2c9bea0e0e8ac096c6f32e86486b4102242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x431c515c5af0280760ac430374cf244a7e81871565b3c469896bd8a59434bc9a",
+            "PackedArgumentAddresses": "0x7dcc39b4d1c53cb31e1abc0e358b43987fef80f72f6f07cdcf3588944bf4c42ac74ff24bf56e759083599937c2c9bea0e0e8ac096c6f32e86486b4100e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -111,15 +111,15 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
             "Description": "Swap BGT for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xb633d32317e23ce23055ccd2d9a31ed0dbd92b805491accc9a3d66d171b40b13",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba2f6f07cdcf3588944bf4c42ac74ff24bf56e759083599937c2c9bea0e0e8ac096c6f32e86486b4102242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x3c625924b1c191bd30139d01a27540df932726b5dd72efbb56bc95b381a92b8e",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba2f6f07cdcf3588944bf4c42ac74ff24bf56e759083599937c2c9bea0e0e8ac096c6f32e86486b4100e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -140,15 +140,15 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
             "Description": "Swap BGT for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xd98be6fe958f9671e263d5ea750ace7bfa65776dcb16e85bdbc875f246a01f9e",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba7dcc39b4d1c53cb31e1abc0e358b43987fef80f783599937c2c9bea0e0e8ac096c6f32e86486b4102242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xa2c8f782ed4a73e92b85968f9791b6a56ffc44b27498c4fc64c5e2b2d8c73b2e",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba7dcc39b4d1c53cb31e1abc0e358b43987fef80f783599937c2c9bea0e0e8ac096c6f32e86486b4100e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -358,6 +358,146 @@
         },
         {
             "AddressArguments": [
+                "0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Approve Infrared Vault to spend primeLiquidBeraETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x96ef20810ead33b7922aabfc844f958427096678f59b244bafb933684f90cfbf",
+            "PackedArgumentAddresses": "0xc9d8bc7428059219f3d19da7f17ad468254d4d7e",
+            "TargetAddress": "0xB83742330443f7413DBD2aBdfc046dB0474a944e"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Stake primeLiquidBeraETH into Infrared Vault",
+            "FunctionSelector": "0xa694fc3a",
+            "FunctionSignature": "stake(uint256)",
+            "LeafDigest": "0x57f47e2b7fddd033a588b08c003971ef9b70d4e1a44e546f1d979cec2c4b0360",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Withdraw primeLiquidBeraETH from Infrared Vault",
+            "FunctionSelector": "0x2e1a7d4d",
+            "FunctionSignature": "withdraw(uint256)",
+            "LeafDigest": "0xcf3ff072b916d46c0921ad84b1eb47649b03090689fe312fdfabf0439f50079c",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e"
+        },
+        {
+            "AddressArguments": [
+                "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Get Reward for user from primeLiquidBeraETH Infrared Vault",
+            "FunctionSelector": "0xef790a82",
+            "FunctionSignature": "getRewardForUser(address)",
+            "LeafDigest": "0x8a7ff84d770fe3e8bde308d674e0cad2b3521bcba93d5e1d88c0b6a7eb7388ac",
+            "PackedArgumentAddresses": "0x83599937c2c9bea0e0e8ac096c6f32e86486b410",
+            "TargetAddress": "0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Get Reward for primeLiquidBeraETH Infrared Vault",
+            "FunctionSelector": "0x3d18b912",
+            "FunctionSignature": "getReward()",
+            "LeafDigest": "0x30644831d0b39e9c677eadfa356a5448444834cd77ebc425e7f74d1788d8faf2",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Exit from primeLiquidBeraETH Infrared Vault",
+            "FunctionSelector": "0xe9fad8ee",
+            "FunctionSignature": "exit()",
+            "LeafDigest": "0x60c031919f5b37e5d573b9df53540c284dab2e362dcffff76e26384f401915de",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e"
+        },
+        {
+            "AddressArguments": [
+                "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Approve Infrared Vault to spend iBGT",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0xe18d4f507d401d54f221f430e7e78d4465c7286d21b261c834cdc62ced8c2c15",
+            "PackedArgumentAddresses": "0x75f3be06b02e235f6d0e7ef2d462b29739168301",
+            "TargetAddress": "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Stake iBGT into Infrared Vault",
+            "FunctionSelector": "0xa694fc3a",
+            "FunctionSignature": "stake(uint256)",
+            "LeafDigest": "0x0394e2458833351ab01d51d4e7e0fd79ef468d7864a1198d940d1491da031901",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Withdraw iBGT from Infrared Vault",
+            "FunctionSelector": "0x2e1a7d4d",
+            "FunctionSignature": "withdraw(uint256)",
+            "LeafDigest": "0x779c0a4163da66e42cdd65fb484d908e01642512eead5a3cd92111d16261e5ad",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+        },
+        {
+            "AddressArguments": [
+                "0x83599937c2C9bEA0E0E8ac096c6f32e86486b410"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Get Reward for user from iBGT Infrared Vault",
+            "FunctionSelector": "0xef790a82",
+            "FunctionSignature": "getRewardForUser(address)",
+            "LeafDigest": "0xa5bca13261b6d32a6a7ad90aad59db8355eebbd224e72694d3a053a42fe6f1d7",
+            "PackedArgumentAddresses": "0x83599937c2c9bea0e0e8ac096c6f32e86486b410",
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Get Reward for iBGT Infrared Vault",
+            "FunctionSelector": "0x3d18b912",
+            "FunctionSignature": "getReward()",
+            "LeafDigest": "0x5c907f6ab6a6d51d4702b17b3ea13f8d834da6aef11c433978a64c92afc651e5",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x934aF04aBF72B9dB1D5425F0d8bDbf6670E7d2C1",
+            "Description": "Exit from iBGT Infrared Vault",
+            "FunctionSelector": "0xe9fad8ee",
+            "FunctionSignature": "exit()",
+            "LeafDigest": "0xb6ada35a059751ea1c5ca25105e92a05770b917a85682889ec4c467f8afa2046",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x75F3Be06b02E235f6d0E7EF2D462b29739168301"
+        },
+        {
+            "AddressArguments": [
                 "0x04B8136820598A4e50bEe21b8b6a23fE25Df9Bd8"
             ],
             "CanSendValue": false,
@@ -455,38 +595,276 @@
             "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "PackedArgumentAddresses": "0x",
             "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
         }
     ],
     "MerkleTree": {
         "0": [
-            "0x6f4185d7971ed5509002357259a386d49fbd6dd3229191bd842943bdd546bb1d"
+            "0x1fff8158302e424857162adcf4999954039fdfc583a3a8266cfede2e0598adb1"
         ],
         "1": [
-            "0x316516a81c17f3d97ae3c825d73770b57eea139448cac647f2db178e77df0ae7",
-            "0x0327d599ba9b3334b2a4695dda94f0588ff615fb86c802dce6ec4bb38e597cba"
+            "0x258bd63cf0f9b3f269547a3f94abca0d996e6175cc24733a1a2f7808de14b97c",
+            "0x198da4c1721512573dbd5c34313aa4851a26769f96b3d84a15b2c76532cfd2a9"
         ],
         "2": [
-            "0xa1e80bd239c1e8b2203c5dd66c8bceb536b44691c0679c35c2d38553b8ecfaa2",
-            "0x74bc65607d0e4949bb402e4bf87095df4d6ca080c5abcad682c978345fc8103e",
-            "0xccd211cff5113abc5a89b19a7ace84586fefd10a3593f8b3bc895234142c5154",
-            "0x2ac11361bf882dfeee6bde8a6ba49657f76941b58f845759adf798eee0c1a129"
+            "0xd42875f5ec2b7644aa6a53c8955b6fed3aaf17dd9218967c588440c7c1f739c5",
+            "0xa7e2a3f2ec8de9be68d9d0593fd59e04b90591439845b8aedd22532866ff4de6",
+            "0xf4e7082dda325b70bf66d791e94fdb0897de529375ff58189be5b6e434f7e2d7",
+            "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
         "3": [
-            "0x20f4119d339f065e24127b4cbd47337a277bf0aa61b87f41e8694c45ba0db5b9",
-            "0x827e4af7649d61a5efe78e025b8efa255bd36960ab781c2c7473fcb8f8642438",
-            "0x9d194aa000a51f7b5484212dade910b77a44f7c9db20b3ef4f8c7c5652b3a482",
+            "0x8bf481cb390490c487b1f2120a89d7ea50e112f7f15a6e09e1acb58f5476c3e3",
+            "0x353d429b939ecc5e97cb4d61c07f6e0ae60133e09c89a72905f5a12dcde67f53",
+            "0xccd211cff5113abc5a89b19a7ace84586fefd10a3593f8b3bc895234142c5154",
+            "0x6a4932d28c63115b055f43fb5698ed77c5060a175bd3d9528154e3b25a024e47",
+            "0x2177d38e0f719916d4f72db9ddbad5396b6d7dcf59a1b29c99d1e8273248f943",
+            "0xf0b34d6a3a8a3847ba8f60b3905e8f62c4caeec83e19be627a1460205c00e445",
+            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
+            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
+        ],
+        "4": [
+            "0xe3d1e612c62036b2b00cbd550c5cb66ef11d21a97238017da2b81206a6816cc1",
+            "0x3e0e1ba895ff3e64056e15a59b38541d2c4162b7d9585f403a681335d208cd2a",
+            "0x5338a5581bfbcf4ab98c360c2b3cc77453ff5027c3ae14e92cc57881cc4a32b8",
             "0x2db908b9012765c6252fa2c28279002bffdd16b2ea7dfb97eb77a3ad867e8f59",
             "0x8248fc72afee5f72aaad83b482f5080d62b3cd91e425b833b1835a38fa2d0b66",
             "0xe2d34c6921cda32265261427e1cbd62ff9ca4d064b81bce7d0ed3d8fd2b74413",
+            "0xc02249a09889f1218c9487ec7f74f0207a8a57a5f04cec4b9a993dc27a28d0c0",
+            "0x3354f113f39093e83f407f676a5bfe2cd5c20b834bd613f9df91a30ca731f1ec",
+            "0xe69055641d26a43f24c38e38c9734d1cff3c8014b65e786bd6f0cbdf95970e04",
             "0x6bc85011b796a5dd9606f6137970a7086710a831e8f46c2256f3a7efb90c5335",
-            "0x349c3c7111acfbc98ccf26a2d91fa7075b4a4f2b84c3e03cea3dc43394fd680f"
+            "0x349c3c7111acfbc98ccf26a2d91fa7075b4a4f2b84c3e03cea3dc43394fd680f",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe"
         ],
-        "4": [
-            "0xb17b6a1c3e4871d26a2bcb6af90534818fc7d1d569ff416f5d12eb90ba9c6a60",
-            "0xd5bf1db691c436df9baa4b68d4c5c0a3df14ef8be30ffaf7269019a85045f1ea",
-            "0x2d782bd0c15500016b195e16c60217be88382df4a3379eb029dfffb39a8eb449",
-            "0xc304eef842c4a6e43a5aaf4a86d2cc0ec1356bcca3c119e891b5193bbae53e2c",
-            "0xfd4635f092ecd6725ed6285c47887dd81a29b9f1d338c566fb0780ab808e7f79",
+        "5": [
+            "0x19be9d3014b18f36593a264d6c35ae2c1c8b9037195167d10877d25c957928fa",
+            "0xb92b5f7f31bc4e12c6b00ca105b44d7cfe2f6fe254eacc5a26b554a13da466d1",
+            "0x1884602775304cf64c40dfa15f6c0c1e31f97c642533c21c2e79d16fab4c33f1",
+            "0x23fc41eaa983aabc2d8eaf8537a0c623393e36978eb2ef6050331ab551fc2354",
+            "0x21b0b1f437ffd72af991f74bcef57fdbd0feb90b1552d164ba96826b5f0d4c83",
             "0x2c6c2590813cbca54099c22f13ebb77342bcba0b21ceda5d757b8e8064d85484",
             "0x39f36ebb8581001d96a667dfceff977b5929702ba4b3852486534e68c9cf7058",
             "0x2494f71db3779dfc8676dd63085deb839d4f76f34589d676fa7b545ed3787edb",
@@ -494,21 +872,37 @@
             "0x7d531d92810e0960343ec1803223dd1f26dff21800a81b91e5de70ca1fa21e0c",
             "0x51468945a8cf6c15a5526b803431f6c57e71fdccef9d29aa7f74c839ea684c7e",
             "0xae4bb8e9d8f560565385de54e0f91de4cd0a5232ac75afe381f4ef628a56d9fa",
+            "0x057fd4aec6aac1de783f4e2f6b6a914789e572786ccad39775f74a7d842da28c",
+            "0xa86580324e26ed8aaa34a9c7367f6972f0c804a690826cb0d4b32a6c1c2d32ee",
+            "0x850c5118156b3f499805cda16cda09cdca01a5ff6681c96ac91a5d3c5ae408da",
+            "0xd75c43ee8fee63dc53c69c95f468affb006826be86e7b785d79b47f5019c6b14",
+            "0x945ef2b48f875e4ff9687832a405023f7ab9deeb0575fe0c073abbef42400eb2",
+            "0x65df390e8b82d0560d653e468e4809be6ae607e799e9b98c46131f4a109996ae",
             "0x5bba3658463a9edd55bbd76ab6116379bb77e7fec02915e99d774d5b237b4a40",
             "0x802fc5c1d5e4442b5b18cb1065df52e0b74d2ac481ece70607537ecd0eca3ded",
             "0x3c9d33b992617077508b4ae6b82672640636f4cb8332d6c2e95236bd48426d5a",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba"
         ],
-        "5": [
+        "6": [
             "0xca7318cf9d634536541e39fae7f7de138336b6e389a2325317a709d88d6f63fc",
-            "0xb0677471e817a5f8828e96806103e62d2c1775ed7e4b8707f5703c8b072caa29",
-            "0xa6ccebad82e9ceffb858656ba4ce7debb24cab072d8260252f5c2346bcbbaf68",
+            "0xadc9832c1d02abafdf6569580f48e3f6c2203eee995e9eb06f772284b2eb6431",
+            "0xbe9054cc06e2aa8fe1b74eaee7f86713362bebddfd067b61a7651cfc0e25c5e1",
             "0x85d0cf2b0c1586369eebf3693fd5689d7a44b6d0a88dcf6d1db2986bfb488e6f",
-            "0x540cb78b330fdf61b50941a2ef133bc56f83e468376cf5c758ba13161d5fc6bb",
-            "0xe40b39bd1b3a4690ced7db29dec18bbf359af091a071a587ed52cc3e8c576723",
-            "0xb633d32317e23ce23055ccd2d9a31ed0dbd92b805491accc9a3d66d171b40b13",
+            "0xcd31f61c0c7496c36f1e148f1839a9b149d95978e2e8b47b490ec012fd06f806",
+            "0x431c515c5af0280760ac430374cf244a7e81871565b3c469896bd8a59434bc9a",
+            "0x3c625924b1c191bd30139d01a27540df932726b5dd72efbb56bc95b381a92b8e",
             "0x9bdd8446256b7bd345752c5ed40da4fc70a9d52ea3f76044a38a6065a697b4bb",
-            "0xd98be6fe958f9671e263d5ea750ace7bfa65776dcb16e85bdbc875f246a01f9e",
+            "0xa2c8f782ed4a73e92b85968f9791b6a56ffc44b27498c4fc64c5e2b2d8c73b2e",
             "0xc5e8dbc19e3774f0d23ac1b58e8ec99dfd71eae093e5cd18a0a08693b0d25944",
             "0x7808a353beedcfff4d71df6b76ec2ad7138052411701b7f92f8ef8a36fdc45e9",
             "0xf90bd330b1c7ab19b611f51f489455d173a52aed3afddf8c0dca0431fd7f17c5",
@@ -524,12 +918,44 @@
             "0x0f5740043405d77d0b8a6ee607464db375fd4ef93a02b2201821c7fa7c9bd36e",
             "0xf5699caeebcd7cd4f940bd7d4c437c5a658de10c318b6ef8331dddc0d668ec4e",
             "0x9149f244999c271996622cdf7606190817e304946ac5f9d1b2a5e442ea3e1997",
+            "0x96ef20810ead33b7922aabfc844f958427096678f59b244bafb933684f90cfbf",
+            "0x57f47e2b7fddd033a588b08c003971ef9b70d4e1a44e546f1d979cec2c4b0360",
+            "0xcf3ff072b916d46c0921ad84b1eb47649b03090689fe312fdfabf0439f50079c",
+            "0x8a7ff84d770fe3e8bde308d674e0cad2b3521bcba93d5e1d88c0b6a7eb7388ac",
+            "0x30644831d0b39e9c677eadfa356a5448444834cd77ebc425e7f74d1788d8faf2",
+            "0x60c031919f5b37e5d573b9df53540c284dab2e362dcffff76e26384f401915de",
+            "0xe18d4f507d401d54f221f430e7e78d4465c7286d21b261c834cdc62ced8c2c15",
+            "0x0394e2458833351ab01d51d4e7e0fd79ef468d7864a1198d940d1491da031901",
+            "0x779c0a4163da66e42cdd65fb484d908e01642512eead5a3cd92111d16261e5ad",
+            "0xa5bca13261b6d32a6a7ad90aad59db8355eebbd224e72694d3a053a42fe6f1d7",
+            "0x5c907f6ab6a6d51d4702b17b3ea13f8d834da6aef11c433978a64c92afc651e5",
+            "0xb6ada35a059751ea1c5ca25105e92a05770b917a85682889ec4c467f8afa2046",
             "0x69ac05ee6aa3085893048f6377cc59fadbf36bc585439a826d68a883ac3354ce",
             "0x57a3e6089f6cfd0d3ea60a9e6dac0cf9cfc80009e43c0a40f39f5672aa9f309f",
             "0x52c2b5f64c66db7aae308dae34c64bd0c84cb19e73fa77726d73eaaea19b5460",
             "0xc268338f487a194af5673b4f896837dbb185d078c8774592f42a60e02d54783a",
             "0x2b3a5ae0cbe42b505f4dc30d0e2e9f64c1fc747aa8f2182b7184643869138d93",
             "0xb2b80ac78fdc23708ec5935e1666ebf2e97ee49888bc44fb66821a2b15fe9d8e",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400"
         ]

--- a/leafs/Berachain/PrimeLiquidBeraBtc.json
+++ b/leafs/Berachain/PrimeLiquidBeraBtc.json
@@ -11,13 +11,15 @@
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
         "LeafCount": 104,
-        "ManageRoot": "0x9d9e09c19f75232bc1022b83cd1932126d0d875bcfca6aed2fa601321af961fc",
+        "ManageRoot": "0x060a9cdd3595c08ecf14ba131413d45b5c609c0aaf365147108532c4e08f2e61",
         "ManagerAddress": "0x7280E05ccF01066C715aDc936f860BD65510f816",
         "TreeCapacity": 128
     },
     "leafs": [
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve ether.fi BTC, to spend WBTC",
@@ -56,7 +58,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit WBTC into ether.fi BTC",
@@ -67,7 +71,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve ether.fi BTC, to spend LBTC",
@@ -106,7 +112,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0xecAc9C5F704e954931349Da37F60E39f515c11c1"],
+            "AddressArguments": [
+                "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit LBTC into ether.fi BTC",
@@ -117,7 +125,9 @@
             "TargetAddress": "0x6Ee3aaCcf9f2321E49063C4F8da775DdBd407268"
         },
         {
-            "AddressArguments": ["0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"],
+            "AddressArguments": [
+                "0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve UniswapV3 Router to spend WBTC",
@@ -128,7 +138,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"],
+            "AddressArguments": [
+                "0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve UniswapV3 Router to spend LBTC",
@@ -139,7 +151,9 @@
             "TargetAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
         },
         {
-            "AddressArguments": ["0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"],
+            "AddressArguments": [
+                "0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve UniswapV3 NonFungible Position Manager to spend WBTC",
@@ -150,7 +164,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"],
+            "AddressArguments": [
+                "0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve UniswapV3 NonFungible Position Manager to spend LBTC",
@@ -222,7 +238,9 @@
             "TargetAddress": "0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"
         },
         {
-            "AddressArguments": ["0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"],
+            "AddressArguments": [
+                "0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve UniswapV3 Router to spend eBTC",
@@ -233,7 +251,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"],
+            "AddressArguments": [
+                "0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve UniswapV3 NonFungible Position Manager to spend eBTC",
@@ -305,7 +325,9 @@
             "TargetAddress": "0xEd158C4b336A6FCb5B193A5570e3a571f6cbe690"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Remove liquidity from UniswapV3 position",
@@ -341,7 +363,9 @@
             "TargetAddress": "0xFE5E8C83FFE4d9627A75EaA7Fee864768dB989bD"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend WBTC",
@@ -352,7 +376,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend eBTC",
@@ -363,7 +389,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend KODI WBTC-eBTC",
@@ -402,7 +430,9 @@
             "TargetAddress": "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend LBTC",
@@ -413,7 +443,9 @@
             "TargetAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend KODI eBTC-LBTC",
@@ -452,7 +484,9 @@
             "TargetAddress": "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend eBTC-OT",
@@ -463,7 +497,9 @@
             "TargetAddress": "0x96284cCFd80E546b8239b44f653b4B5Db3f21371"
         },
         {
-            "AddressArguments": ["0x679a7C63FC83b6A4D9C1F931891d705483d4791F"],
+            "AddressArguments": [
+                "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Kodiak router to spend KODI eBTC-eBTC-OT",
@@ -502,7 +538,9 @@
             "TargetAddress": "0x679a7C63FC83b6A4D9C1F931891d705483d4791F"
         },
         {
-            "AddressArguments": ["0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D"],
+            "AddressArguments": [
+                "0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Dolomite DepositWithdraw Router to spend WBTC",
@@ -513,7 +551,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit WBTC into Dolomite DepositWithdraw Router Market ID: 4",
@@ -524,7 +564,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit WBTC into Dolomite DepositWithdraw Router Market ID: 4 Default Account",
@@ -535,7 +577,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw WBTC from Dolomite DepositWithdraw Router Market ID: 4",
@@ -546,7 +590,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw WBTC from Dolomite DepositWithdraw Router Market ID: 4 default account",
@@ -557,7 +603,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit Par scaled WBTC into Dolomite DepositWithdraw Router Market ID: 4",
@@ -568,7 +616,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit Par scaled WBTC into Dolomite DepositWithdraw Router Market ID: 4 in default account",
@@ -579,7 +629,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw Par scaled WBTC from Dolomite DepositWithdraw Router Market ID: 4",
@@ -590,7 +642,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw Par scaled WBTC from Dolomite DepositWithdraw Router Market ID: 4",
@@ -601,7 +655,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D"],
+            "AddressArguments": [
+                "0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Dolomite DepositWithdraw Router to spend eBTC",
@@ -612,7 +668,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit eBTC into Dolomite DepositWithdraw Router Market ID: 28",
@@ -623,7 +681,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit eBTC into Dolomite DepositWithdraw Router Market ID: 28 Default Account",
@@ -634,7 +694,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw eBTC from Dolomite DepositWithdraw Router Market ID: 28",
@@ -645,7 +707,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw eBTC from Dolomite DepositWithdraw Router Market ID: 28 default account",
@@ -656,7 +720,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit Par scaled eBTC into Dolomite DepositWithdraw Router Market ID: 28",
@@ -667,7 +733,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit Par scaled eBTC into Dolomite DepositWithdraw Router Market ID: 28 in default account",
@@ -678,7 +746,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw Par scaled eBTC from Dolomite DepositWithdraw Router Market ID: 28",
@@ -689,7 +759,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Withdraw Par scaled eBTC from Dolomite DepositWithdraw Router Market ID: 28",
@@ -700,7 +772,9 @@
             "TargetAddress": "0xd6a31B6AeA4d26A19bF479b5032D9DDc481187e6"
         },
         {
-            "AddressArguments": ["0x29cF6e8eCeFb8d3c9dd2b727C1b7d1df1a754F6f"],
+            "AddressArguments": [
+                "0x29cF6e8eCeFb8d3c9dd2b727C1b7d1df1a754F6f"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve dWBTC to spend WBTC",
@@ -711,7 +785,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit WBTC for dWBTC",
@@ -736,7 +812,9 @@
             "TargetAddress": "0x29cF6e8eCeFb8d3c9dd2b727C1b7d1df1a754F6f"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Mint dWBTC using WBTC",
@@ -761,7 +839,9 @@
             "TargetAddress": "0x29cF6e8eCeFb8d3c9dd2b727C1b7d1df1a754F6f"
         },
         {
-            "AddressArguments": ["0x6B21026e1Fe8be7F23660B5fBFb1885dbd1147E6"],
+            "AddressArguments": [
+                "0x6B21026e1Fe8be7F23660B5fBFb1885dbd1147E6"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve deBTC to spend eBTC",
@@ -772,7 +852,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Deposit eBTC for deBTC",
@@ -797,7 +879,9 @@
             "TargetAddress": "0x6B21026e1Fe8be7F23660B5fBFb1885dbd1147E6"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Mint deBTC using eBTC",
@@ -822,7 +906,9 @@
             "TargetAddress": "0x6B21026e1Fe8be7F23660B5fBFb1885dbd1147E6"
         },
         {
-            "AddressArguments": ["0x0c3F856b93d6D7B46C76296f073A1357738d238C"],
+            "AddressArguments": [
+                "0x0c3F856b93d6D7B46C76296f073A1357738d238C"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve 0x0c3F856b93d6D7B46C76296f073A1357738d238C to spend eBTC",
@@ -833,7 +919,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x0c3F856b93d6D7B46C76296f073A1357738d238C"],
+            "AddressArguments": [
+                "0x0c3F856b93d6D7B46C76296f073A1357738d238C"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve 0x0c3F856b93d6D7B46C76296f073A1357738d238C to spend eBTC-OT",
@@ -844,7 +932,9 @@
             "TargetAddress": "0x96284cCFd80E546b8239b44f653b4B5Db3f21371"
         },
         {
-            "AddressArguments": ["0x0c3F856b93d6D7B46C76296f073A1357738d238C"],
+            "AddressArguments": [
+                "0x0c3F856b93d6D7B46C76296f073A1357738d238C"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve 0x0c3F856b93d6D7B46C76296f073A1357738d238C to spend eBTC-YT",
@@ -921,7 +1011,9 @@
             "TargetAddress": "0x0c3F856b93d6D7B46C76296f073A1357738d238C"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Ooga Booga Router to spend iBGT",
@@ -936,15 +1028,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap iBGT for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xa71366c4428b9412bf238d34d24bbe04a6c600ff098bbf4bb015ab81f8d3cbd7",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b0555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x1b6046b5886358af1b59fe60622891a80a29de524ec898fd8129bff647d3f9ec",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b0555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -952,15 +1044,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap iBGT for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x920e8cb5cf1ff91e2725cec21c5b1d66e39d73c289db9f436428dff0e5a981dc",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xa518e049ab03559a89e2ac0b759325ce959f437934479d55d16f1060ed0a8d0c",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -968,19 +1060,21 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap iBGT for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x32cd9ca8a90d1098c0008d6c5dd6bee3011cec631ace9c94674c8d8214bc3410",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6becac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x500f6c768f95113580d090dad367a13a00add57a0fc3d17020641e10eecf5a9f",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6becac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Ooga Booga Router to spend WBTC",
@@ -995,15 +1089,15 @@
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap WBTC for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xc3323931f9797f707a4357f0f18faeec0ccc0bf192d3bbaf4586704e8f99a677",
-            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9c657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x11e8a7373d1d610847f777e51f5484de578e18de0cfe927e6a24993b8eae20ec",
+            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9c657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1011,15 +1105,15 @@
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap eBTC for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xe49045606174f517bba273a690e8c4d47d3224a26165cae74f6623bbf198472c",
-            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c6420555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xddda912f50ac67e6f442ee145c991bf02356d0625dc6756c0331181a30bf3ad3",
+            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c6420555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1027,15 +1121,15 @@
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap WBTC for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xefbce32b7f11eb4e31bf01e6fd5baf0717f07bb2a6725f938c82a9b7fb5fb5c8",
-            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9cecac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x07cdfb4a20d409876a491aded9737eb8e54e8c5ebcc1ae75ff5982f7f261dcd2",
+            "PackedArgumentAddresses": "0x0555e30da8f98308edb960aa94c0db47230d2b9cecac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1043,15 +1137,15 @@
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap LBTC for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xf090d90482983741cc65d8780ca31ae3099a569f80a6275fd1a3ba7652672e98",
-            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c10555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x55c54e65969d2942c8c4eaee104374396e97d899fab84f952779858e8fba7e8d",
+            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c10555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1059,19 +1153,21 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap BGT for WBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xaad7b310a7c529a66e3159b679bda400481571c08ad829987b41886ecbdb96a0",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba0555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x46b031f57fee6fb9bbe3b8014295a74d5a7b5b60ab4d9bae2c4b6f2249d81f9c",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba0555e30da8f98308edb960aa94c0db47230d2b9c46fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Ooga Booga Router to spend eBTC",
@@ -1086,15 +1182,15 @@
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap eBTC for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x27be76af2a24311c8b8fc9b3c74e7a48e043b42717986478b26248a40b0b6445",
-            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642ecac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x298f6eb39b60e91a66584678141c6bac813bb18a3359c519c155b1be4161395c",
+            "PackedArgumentAddresses": "0x657e8c867d8b37dcc18fa4caead9c45eb088c642ecac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1102,15 +1198,15 @@
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap LBTC for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x1d66086967151af5547d9621803bd2027034ef4d10c1b116d60c1e7ac1be1cb6",
-            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c1657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xda4f5f9b8bd85bcc106c9818a323088a7fe54feb671541118a6866f416367a0e",
+            "PackedArgumentAddresses": "0xecac9c5f704e954931349da37f60e39f515c11c1657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1118,19 +1214,21 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap BGT for eBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x19e17967198c186b825add6fbf93a47c2e2890b38f225fbd27bc01b90bfc6ee3",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x6e1b45269d17632d5a542a2f49907a03bf282d43d8c1b29d7aae3ca077ddc70f",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba657e8c867d8b37dcc18fa4caead9c45eb088c64246fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Ooga Booga Router to spend LBTC",
@@ -1145,19 +1243,21 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0xecAc9C5F704e954931349Da37F60E39f515c11c1",
                 "0x46fcd35431f5B371224ACC2e2E91732867B1A77e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap BGT for LBTC",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x40af628f6db0f806ac0e3a03ee60ac495e7b027a9ff00eae694bc4f045c4e4cc",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dbaecac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xd67670d00e8b52fe568dbddfc2c7b623afd106ed621c7732e63a7035c02f0a27",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dbaecac9c5f704e954931349da37f60e39f515c11c146fcd35431f5b371224acc2e2e91732867b1a77e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
-            "AddressArguments": ["0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"],
+            "AddressArguments": [
+                "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Ooga Booga Router to spend BGT",
@@ -1168,7 +1268,9 @@
             "TargetAddress": "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba"
         },
         {
-            "AddressArguments": ["0x5C5FCb568a98DA28C9D2DF4852b102aa814c3a4c"],
+            "AddressArguments": [
+                "0x5C5FCb568a98DA28C9D2DF4852b102aa814c3a4c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Infrared Vault to spend KODI WBTC-eBTC",
@@ -1201,7 +1303,9 @@
             "TargetAddress": "0x5C5FCb568a98DA28C9D2DF4852b102aa814c3a4c"
         },
         {
-            "AddressArguments": ["0x46fcd35431f5B371224ACC2e2E91732867B1A77e"],
+            "AddressArguments": [
+                "0x46fcd35431f5B371224ACC2e2E91732867B1A77e"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Get Reward for user from KODI WBTC-eBTC Infrared Vault",
@@ -1234,7 +1338,9 @@
             "TargetAddress": "0x5C5FCb568a98DA28C9D2DF4852b102aa814c3a4c"
         },
         {
-            "AddressArguments": ["0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"],
+            "AddressArguments": [
+                "0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Accountant to spend WBTC",
@@ -1245,7 +1351,9 @@
             "TargetAddress": "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
         },
         {
-            "AddressArguments": ["0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"],
+            "AddressArguments": [
+                "0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Approve Accountant to spend eBTC",
@@ -1256,7 +1364,9 @@
             "TargetAddress": "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Claim fees in WBTC",
@@ -1267,7 +1377,9 @@
             "TargetAddress": "0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"
         },
         {
-            "AddressArguments": ["0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"],
+            "AddressArguments": [
+                "0x0555E30da8f98308EdB960aa94C0Db47230d2B9c"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Claim yield in WBTC",
@@ -1278,7 +1390,9 @@
             "TargetAddress": "0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Claim fees in eBTC",
@@ -1289,7 +1403,9 @@
             "TargetAddress": "0x88ea516DCb9f79CAFA9D0d19909A4dbd7B6890c8"
         },
         {
-            "AddressArguments": ["0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"],
+            "AddressArguments": [
+                "0x657e8C867D8B37dCC18fA4Caead9C45EB088C642"
+            ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Claim yield in eBTC",
@@ -1566,16 +1682,16 @@
     ],
     "MerkleTree": {
         "0": [
-            "0x9d9e09c19f75232bc1022b83cd1932126d0d875bcfca6aed2fa601321af961fc"
+            "0x060a9cdd3595c08ecf14ba131413d45b5c609c0aaf365147108532c4e08f2e61"
         ],
         "1": [
             "0x95cf9c236adf7f19cf8447757e13350bbffc183376dc84ea64e5d954ac67ec49",
-            "0x12e54accc016cf88d08cc3cd7398f4ef45ec798f3b82a3882f71a2f450e5dce2"
+            "0x91f662a11ba22396daa3b586696846bb11ceeb86b0f62068ec17556e7e3abf0f"
         ],
         "2": [
             "0x8ed2955649be4a67fa16b555c9300ea5de443ccd02f46e94d5d94e8cc90aeda8",
             "0x045fab52cbc488369918b5079b0c6e36c533adccfcf09add4bd048a43603dcf4",
-            "0x449e2ebea6249b8a4128e54399467a603b0fec75932043aafd22b561e9d535e1",
+            "0xa120438c5205e8211d2f990ec3f3ec365705a76d674501d83f1482fd7f5f3167",
             "0x62fd80711c5306bb9d4041c802e49d688fe2f38b3740d47b734a360c1fcf0c04"
         ],
         "3": [
@@ -1583,8 +1699,8 @@
             "0xe5201866982c962bd4d64a983ff6234acdef882a3087c11deb238762198d9adc",
             "0x4d444415e8de02cb50b682aa3734dc88006e2f237789d5f76de531756702f98c",
             "0x8aab5871fd434756780fb3eafc464185fa4e93aec81c1fd13428f55abb00500b",
-            "0xf244ef2d992d43ef52b2d0950e51064f6731f8f49a6559f12f184271e8d6db13",
-            "0x12710e328781c4b9eea16543675aa6945109b68a1f34d6b3e25bb5a80c13c959",
+            "0x372914f6a0ef118ed4f96bd2f943c935a77c447d32dd064a410e75316b926308",
+            "0x023e79a73b5e7de806d1e8485cee25265c47862fd51472b67ba68c669de4f6ed",
             "0x572dc2b9901d2a10d9cc6c53e1587d84d3dc414563e72ef138f1d931707095ed",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
@@ -1598,9 +1714,9 @@
             "0x678e6f5485534e4624f8b4107eb790e600162fa40171a4be54a28af88bbc2122",
             "0x8f3712ea375023c5f1b2085106c7f98b2ecbb539fff6a1cef7b6d89a3bf9c71e",
             "0x5f3721f7cb91998078fda444caeda2be7e1a97ed4150831f46c047f4edb02b26",
-            "0xea521d06fd919e797cc0d295e86db11db7797929fb3d2221b5f73338821f82cd",
-            "0x2e6e91eb1d8440c7114bc065cc6c2b699c53b929fa7698ca08c045b72ec0c6d4",
-            "0xf962acaa7b2c24a7d46a3f554df67a6f98df6346bb5958e7c61b1c00529e415c",
+            "0x6c482555f44c54aa0eb627d11ea61c49600f718230c127a42f4d98510a5c873f",
+            "0x2dd86f6a6b6c3f8e3c851884c706b1c74c22f3d92305f8772b803237f3eb4a2c",
+            "0x63d708432670df1c25552e51fa5898e2e0dd87db3f52db5c6a2ec485f22b6e54",
             "0x6b56103a85a1ed5f3115c2601f5923503323dbb7c068b776b88b1f82e438881c",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
@@ -1626,10 +1742,10 @@
             "0x4243c3af3c9201fe09a2077ba2ce3fa0298a31a0d84290c123a14882ef4e8974",
             "0xa57568d48e7724aa5366bdb1a6649b08fa9de44551f982c1c1c4b82600d9f264",
             "0x84716ac4ac225ebd526e51f06ae5f2cb1a5e0031f457f0c3dd8b7eb185f9027e",
-            "0xf17506266cd162974abcf2b54502a08eba6684faa80e7b8cfbc86d7defd63464",
-            "0xb9a513ce8ab0ebf1788a9e44b1d1ee7d05b3ac9d70f862a26b7b00e3331b6492",
-            "0xc3f75f56bdc94c8a394b133f289a6ffd85831074b761a8f33230836ba11df390",
-            "0x89fef973756478b078f4d6d6a9290806cb45d46355b42219f59ef7d9db121807",
+            "0x01cc93fe8bea54963f545fc3ddbdab9b0999df99c44dacb1cff02afa4bc95da0",
+            "0x88dd8e111b1788b80065fbc4864e7530f7880d8fd51f455fe86c4b0dce5eec57",
+            "0x6c35c4b7b274b5d417b0194122bdcc4e0be26a0c3087b6d5ba10a08f10956e30",
+            "0x411852ecfe18e64a4716a54fb13c494f342104a7fe91ff1ec78aaa096933b668",
             "0x047dcbc8fbc0d4a43df040e6476900bb4b065e016f188c8731042ed9ec79c822",
             "0x32f96ea0271272a65756c1d0683c245fb1d30f401d9fb92c749061e5cb0f6856",
             "0x34c6ccf0114fffb417136002fb5a02418ffad9732a56592f1ff77b11f2a3ca63",
@@ -1679,14 +1795,14 @@
             "0xc3cf0bee57cd09491d3c357e3f054a9338efae605e3c0e2a55741e0fde907df7",
             "0x341eaf39c9e9a5d3462292c0ab771cc9d5c90adab1a9bbae4005477b1feb8e4f",
             "0x430daa2de2f0e83ced0f846c3c9c2d50b9171749e117b90ccc6174cfde195792",
-            "0xee85d6cc9733183bd38f754a6df46d99d8098f240a44710fd31b6eb205b9a4ba",
-            "0x5b39919643e1fc291e851f9deb71e10e0a9529fc19041b4d64e8ce373faab087",
-            "0x6c58c25dfae93f0d4127df4a00de5cc6aa1aaf21a769dd9467691262dbdbf3af",
-            "0xb653ef4de38c608bdfd0f2d3dc4b949d175f867a693b16c74879c78cc50b0978",
-            "0xfb11d8aecade0216e7169279dc0b6ac418fd84fca2865338f22484e4a9594caa",
-            "0x1e13418924a79e367b2993cd58bfe0f093c39e6962924f98c81bd41ceb3c860b",
-            "0x72f3920812cc9e39fc8322d3c4af4520523b21b74be5ed10c07d4d042aec2895",
-            "0x48027e59df3a4be8bccd40b9c547e3845f84896ee4cd46d923d721569f9f8e9b",
+            "0xbdd2728b9b9a2b0dc6826154900803b5b37e1462241c6ace980f96906c344a80",
+            "0xeff1e6aefaac967372b28e318e82cdd0fbcc32204c9ae7a5be910c958630654d",
+            "0x226a7478f4bab428cfb9d21f6a5cf35b072ed495befdfe9947b739312784a6f0",
+            "0xee505d4eafb1f91cc93ffe9b375a822dd71032bee3be5c279f35bd12eec133da",
+            "0x2d493c0c6e53c9cc9ef0f99f37549d4817290cf8a1538a51c4af66514b92c32d",
+            "0x848418d21d4930ddfcc837dea35779457d59a7b61195f35b85637da082cc1008",
+            "0xf6faa7e0e596ef772c081ed6a37f044f89e2e69445b205de2e923ee24eb451fd",
+            "0x6efbc89b941168e84eafe6223edffd483aad1314fa9e51fb3994a8112d2f13ca",
             "0xd0e48207ed8aa2d721779c81379f0bed42c57ec2a1994b97739ac96d6de4fdb9",
             "0x2c6cb339d82875917ac3c423f1beec41363d0495a351b86d5e01c43fb1b3fa5c",
             "0x1d409fee83a9597ee56511d9f5f7a07a27eab932d27edbc66fbc517b8caf2aa8",
@@ -1783,21 +1899,21 @@
             "0x185afb53e6b740bfeeefe586e23b22ea4a38656c4301562ae72cde739f016372",
             "0xb9b25fd57034f51b70e8581bd4c82c2ad7a9b92efea72753857b03a34b04a9e1",
             "0x280239e81ff011edf3cf6a6191442411d809c8f8053f2d0abe424fb7b13fe42a",
-            "0xa71366c4428b9412bf238d34d24bbe04a6c600ff098bbf4bb015ab81f8d3cbd7",
-            "0x920e8cb5cf1ff91e2725cec21c5b1d66e39d73c289db9f436428dff0e5a981dc",
-            "0x32cd9ca8a90d1098c0008d6c5dd6bee3011cec631ace9c94674c8d8214bc3410",
+            "0x1b6046b5886358af1b59fe60622891a80a29de524ec898fd8129bff647d3f9ec",
+            "0xa518e049ab03559a89e2ac0b759325ce959f437934479d55d16f1060ed0a8d0c",
+            "0x500f6c768f95113580d090dad367a13a00add57a0fc3d17020641e10eecf5a9f",
             "0x1d4b334f43032793616ae30c103ad6cb6f8f357dcc8283e269383131a89daa5b",
-            "0xc3323931f9797f707a4357f0f18faeec0ccc0bf192d3bbaf4586704e8f99a677",
-            "0xe49045606174f517bba273a690e8c4d47d3224a26165cae74f6623bbf198472c",
-            "0xefbce32b7f11eb4e31bf01e6fd5baf0717f07bb2a6725f938c82a9b7fb5fb5c8",
-            "0xf090d90482983741cc65d8780ca31ae3099a569f80a6275fd1a3ba7652672e98",
-            "0xaad7b310a7c529a66e3159b679bda400481571c08ad829987b41886ecbdb96a0",
+            "0x11e8a7373d1d610847f777e51f5484de578e18de0cfe927e6a24993b8eae20ec",
+            "0xddda912f50ac67e6f442ee145c991bf02356d0625dc6756c0331181a30bf3ad3",
+            "0x07cdfb4a20d409876a491aded9737eb8e54e8c5ebcc1ae75ff5982f7f261dcd2",
+            "0x55c54e65969d2942c8c4eaee104374396e97d899fab84f952779858e8fba7e8d",
+            "0x46b031f57fee6fb9bbe3b8014295a74d5a7b5b60ab4d9bae2c4b6f2249d81f9c",
             "0x34e70f4435b68e87112851fab183589bdbcd6f626d3ca112641fd9c9f0a2d9be",
-            "0x27be76af2a24311c8b8fc9b3c74e7a48e043b42717986478b26248a40b0b6445",
-            "0x1d66086967151af5547d9621803bd2027034ef4d10c1b116d60c1e7ac1be1cb6",
-            "0x19e17967198c186b825add6fbf93a47c2e2890b38f225fbd27bc01b90bfc6ee3",
+            "0x298f6eb39b60e91a66584678141c6bac813bb18a3359c519c155b1be4161395c",
+            "0xda4f5f9b8bd85bcc106c9818a323088a7fe54feb671541118a6866f416367a0e",
+            "0x6e1b45269d17632d5a542a2f49907a03bf282d43d8c1b29d7aae3ca077ddc70f",
             "0x5946ae79959dd6865a44a98edbe290f7009599b98c40fd45f98d3557c72bcc11",
-            "0x40af628f6db0f806ac0e3a03ee60ac495e7b027a9ff00eae694bc4f045c4e4cc",
+            "0xd67670d00e8b52fe568dbddfc2c7b623afd106ed621c7732e63a7035c02f0a27",
             "0xd255e2005f4faf7443abc3683ebb1c16f179442cc159c12342a27a7a4bafdd30",
             "0x48dba8251c12f8b477623f996c1b8830b2a0c6fea366f4088d20820a4b91ee6d",
             "0xf7c3b11a71ac3cda165d403a02d748db22d276d8884933d3ff54c9c57af717ca",

--- a/leafs/Berachain/PrimeLiquidBeraEth.json
+++ b/leafs/Berachain/PrimeLiquidBeraEth.json
@@ -11,7 +11,7 @@
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
         "LeafCount": 116,
-        "ManageRoot": "0x50b305689d992148821cba200cbf4a9ff03e71a15be217ee9533e6d02b7c3aef",
+        "ManageRoot": "0x83ee46f65e55ba954d51b7df55a815903e757b5241352f20ae9675ba9aece36b",
         "ManagerAddress": "0x58d32BCfa335B1EE9E25A291408409ceA890Be6b",
         "TreeCapacity": 128
     },
@@ -1190,15 +1190,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap iBGT for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x3c8b88ea36e50fdfe2821dbe142264501e2560d5554960a93850e29f70b04dec",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b2f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x623db5c328721b4470a0d8f5aed84ecf5c73dcd193591b37e28b179abe6efcf5",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b2f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1206,15 +1206,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap iBGT for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x1c2e18c34f70c94636677ebb0ac8a42ad4088fddacce5aef031b4bf9f303db22",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b7dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x0433a69f3a0c7adb3d5ec138386d759b0a888407e4a5e964405753b0367a23ea",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b7dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1222,15 +1222,15 @@
                 "0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b",
                 "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap iBGT for beraETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x3082743fc1382353ebff83ef07de5efa1921e818a2c128cccb1db5474f043661",
-            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b6fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x760a5a419edb38f4f9867548690c9562269b7925d434a8afbdf59d9fc20cd5ef",
+            "PackedArgumentAddresses": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b6fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1251,15 +1251,15 @@
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap WETH for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x3c2e3e208dc820e8531cee1529c3544a2505a832723b3800fd840993500b8c11",
-            "PackedArgumentAddresses": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e75907dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x4db8c5ecf72ff119178031315b2bafea971fd6e1272bf5327e700195ef7c8c7d",
+            "PackedArgumentAddresses": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e75907dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1267,15 +1267,15 @@
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap weETH for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x1fdf4e4c11e0f7b12f4aed39984eec5ec0cda5508142d6e9301614f87b4c9bd4",
-            "PackedArgumentAddresses": "0x7dcc39b4d1c53cb31e1abc0e358b43987fef80f72f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xea3b6e543990aeaddeab51d410ddb9911bc6d900c2afd3110151f869a20032ca",
+            "PackedArgumentAddresses": "0x7dcc39b4d1c53cb31e1abc0e358b43987fef80f72f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1283,15 +1283,15 @@
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap WETH for beraETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xee4829e18fdbbf432cc967fd0070aecb1c81113fbb46c01f41856cc3906e23d1",
-            "PackedArgumentAddresses": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e75906fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x2238b9ef9f09096e5641d8c3807d0da969621b756f19c4e0917a16d8e9090a7b",
+            "PackedArgumentAddresses": "0x2f6f07cdcf3588944bf4c42ac74ff24bf56e75906fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1299,15 +1299,15 @@
                 "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap beraETH for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x7c60d571ac4eb358a26e03512fb37dc561b3c0b0805670505b6a6613996cf3d4",
-            "PackedArgumentAddresses": "0x6fc6545d5cde268d5c7f1e476d444f39c995120d2f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xe1fc67d638de85a25bee44ca19646aebcaa986effadf7e93daec2ed02a6d70df",
+            "PackedArgumentAddresses": "0x6fc6545d5cde268d5c7f1e476d444f39c995120d2f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1315,15 +1315,15 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap BGT for WETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x7b36e2298e891155aecad7fb348c0d74db8e7ee14826e912e8f718287146e344",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba2f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xd840006ad46851ab03d3666bd63b4778322d6001652bb7b3db9bee0f2529b93a",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba2f6f07cdcf3588944bf4c42ac74ff24bf56e7590b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1344,15 +1344,15 @@
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap weETH for beraETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0xe0dddb99f5e934afe7d48f8c1a466759512a4fbcd3450e91383ac031cd9c5b47",
-            "PackedArgumentAddresses": "0x7dcc39b4d1c53cb31e1abc0e358b43987fef80f76fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xf318a8f6c5ae54a96addfa86d4e6c9edacb246bd2a0a00c6477696af144c84ae",
+            "PackedArgumentAddresses": "0x7dcc39b4d1c53cb31e1abc0e358b43987fef80f76fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1360,15 +1360,15 @@
                 "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap beraETH for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x1789ceb24d9c134e35786cee4865325f0f995303392908dfd554926243e67822",
-            "PackedArgumentAddresses": "0x6fc6545d5cde268d5c7f1e476d444f39c995120d7dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xcce14f829eaa6518af340a202b17f91ee55e61b97d01225f3dc55d48d12396ee",
+            "PackedArgumentAddresses": "0x6fc6545d5cde268d5c7f1e476d444f39c995120d7dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1376,15 +1376,15 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap BGT for weETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x231bbd9d05be9454da4686859594599cc978a999db0ae50ac19988201005259f",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba7dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0x928b0e895014437b9a90a2dae36c038f25e62395039f57c11023c55c6ac675da",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba7dcc39b4d1c53cb31e1abc0e358b43987fef80f7b83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1405,15 +1405,15 @@
                 "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
                 "0x6fc6545d5cDE268D5C7f1e476D444F39c995120d",
                 "0xB83742330443f7413DBD2aBdfc046dB0474a944e",
-                "0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6"
+                "0x0e29aD2925079f313817D09Fcadbdf3A91125654"
             ],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x661B04bF5C0D66F8D923fEC2FCD0C9b20C96c150",
             "Description": "Swap BGT for beraETH",
             "FunctionSelector": "0xd46cadbc",
             "FunctionSignature": "swap((address,uint256,address,uint256,uint256,address),bytes,address,uint32)",
-            "LeafDigest": "0x81fd2fcd4f25aea8e745e34f5ad2d9de9d69a30f5f8aac2d4f37d12f65fa6d9f",
-            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba6fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e2242b1c1b429c799d5584dc4b59732fb6b1a6be6",
+            "LeafDigest": "0xb64cc0c0a04b175bd1ecd7abe2a690a1cea9ca6dac0f29bb3c745644ef8f99de",
+            "PackedArgumentAddresses": "0x656b95e550c07a9ffe548bd4085c72418ceb1dba6fc6545d5cde268d5c7f1e476d444f39c995120db83742330443f7413dbd2abdfc046db0474a944e0e29ad2925079f313817d09fcadbdf3a91125654",
             "TargetAddress": "0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7"
         },
         {
@@ -1712,17 +1712,17 @@
     ],
     "MerkleTree": {
         "0": [
-            "0x50b305689d992148821cba200cbf4a9ff03e71a15be217ee9533e6d02b7c3aef"
+            "0x83ee46f65e55ba954d51b7df55a815903e757b5241352f20ae9675ba9aece36b"
         ],
         "1": [
             "0x738b8edb205e012b02b236c0f8f819e3076e83f0fa2e17a5320c613fd724fe77",
-            "0xd616bbecf5b0396f37f99c38e41ae63679221aa6b60302296013cfc20c03a709"
+            "0x12bcdf74b53b0bc7d9316f8ce77286b943bb288041b874479ccdc4b410ae7305"
         ],
         "2": [
             "0x6b7e989c8a7ce9a88c436d803f34ea9940dfea4949b4709749cf794d9a0721c8",
             "0xf9b4873d4ea72ba930605b42f887416b44d97b4508ff5d578f04e2871536e2b1",
-            "0x0d44d122cad1a75e65f05f1126e507be557cd88a4a5211db3ba573c410bad5ab",
-            "0x729a5950740454bac891ffd68b544f06df1055b6002b42ff7527f662c9b929eb"
+            "0xd969d3385ae4a07c382946bb1be3b50c88df831e66d024831a976e42e62cf6ad",
+            "0x14ce93facbc38b5b29237963f911a7acce8bdaaf0dda3d795b530ed7e7ef1d8d"
         ],
         "3": [
             "0xe08b82933cf1e975d4aafbc28cc6ceae4b6d1a5c5fc5cbc94e6a63a20a168e3e",
@@ -1730,8 +1730,8 @@
             "0xa8a6dd0ff20f487a4baa5ab83aba836329f07bbecb580742cc65121b908320fc",
             "0x029c40d80306818ac93045dd8ba53e90114765ec9c156fdcc63599a947ee847c",
             "0x7cedc26d96567ba5164b6767c3184ea8ae1864efbdf54ede5ba7679dd8d418de",
-            "0x02c9fd977e9ae7daf88568f33e176fd638134ec8b09192b6a29621b628c0d5f5",
-            "0xee3a46aa8dcfbaafb2985578def26b498198956e7f6129c4ea05036fc316a2f6",
+            "0xed7ffc52e0b5b603f96fa19d7ec940cc45617e77f4cc6cd9a90faf0f27427713",
+            "0xe28e9eefd39b66d620d295ebd5a37486ab7bd33d94fb695ad8a7ec7e67469dbf",
             "0x9b4b160cc0519c38259b9bc290fd88cacafea7d4ff62ae3e4f5ae16211357458"
         ],
         "4": [
@@ -1746,8 +1746,8 @@
             "0x6d758e6079d75137789e51b2fb98488ac0ff66f4fd2525879d2f34862f715cbf",
             "0x702de0bfbcc679b642c5e07fa9803917462f31bb351888857c1c5fc22994c473",
             "0x9f73cc07b56443c826169a99eff11bbab2de2d9afc80385cc13e1d0736c629ac",
-            "0xf1f1c810fd9337bc60904de773c1860dadafe42112b18c9c8d1d86a2f802ceee",
-            "0xdec961bbc3d84a999655a48075ee2a44439ebc07ae31ebc17ca0ebcfc4cbee0e",
+            "0x251545b68539d4de8b21b4e3338c75343bd9c902e7302db96cf1c025f1e968a9",
+            "0x92e4dbe8b73e9b1450d99958101323cb26747eab64735ac566502b5fadf25266",
             "0x3696fdf9cc76c87e517f6db2ba9ab3606faa00ceb855ad0e6e508b87da5c8371",
             "0xae16f82bc477f4cf0a4393585a87bb7c2810a2f028dd1aba8e329b988812cbd3",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
@@ -1775,10 +1775,10 @@
             "0xc12cc7529b9a85843067e9a55b369f1306853617fd7e426e968098597316a2a5",
             "0xb09eba0f0b2ebb65815762ba540f33948f594e04103905565b4af6c3e036cd8c",
             "0x5f15bc2303837c6f80d8be85d5d86825c69d930c4ffe464fd9626641e34ac5b2",
-            "0x04f34880efd64da7f59404795a4cec6e944f0cb0598d48f6e7807ee7bacef275",
-            "0xd2d19838d1b446f9780818331e9e4f8738da6b4854c742026ff543ffb4060dad",
-            "0x87dcbaf9565d1bed50f20b67771c68acc027ae96c5d1329f8179ed6e7c711315",
-            "0x24c3bcac99759fc12f927ff6807cdc6693d4bfa653d7e35c1756f825c0a8578e",
+            "0x4ae0005e904c72e42f73c1b2f09058bfcc9f92890731264cb5be69c7aa33b093",
+            "0x6a6c6dd72ef63a095c305383a98f2c93e87783ed41d804620c6a03445ffad60b",
+            "0x8b71d08eb703883bb293d3455a73784a8816fffd9fd31c18ad581be22d063349",
+            "0xbc300f671540efaa86617e06f99ff6c1d8f17466ecd6f7b45994855f08610231",
             "0x795dc3e1e45781cfefdbc1a779cdb5ababc659563c3b8d54e586bead2b84deb4",
             "0x6d41e30802f277bf4498edbb35808357ffb3e2d15cd4298ff0b0bcabdc81ef83",
             "0x6c814101b43446834cc49083667673ee0dcd741f7c13992d58cfac4f6586c840",
@@ -1831,14 +1831,14 @@
             "0x46d42440fc61054060c351195e7432a8ec3dbcbc1089a52c4dde40ac32e8d258",
             "0xc0c0a22fc20486866a7483d363bd933235cb13076ca12f7f72b22e5b79d6213d",
             "0x70212c1817f897281f760c48168c7638a05153e645ecfa48bc336c36c35e3d47",
-            "0xa2c571c4bd7acb12c8c2c215ae455b8060d8876d661be7ab35084e525ac38368",
-            "0x0d9d47dbad4cadf9b8dff378d11b669535e5aef029cc2ec2e0fb58f2a00c55fe",
-            "0xa7fbde62fe58dcc4249c8d163e1cc8ff6a06e8e3a1642141e3f6b82b1b0bf68f",
-            "0x25db6b908a46090a4e6aa6fa639f8307718205b56480bc432c16d5a6522e6b08",
-            "0x3cad9be44cf8ae7f1197d29aa18da8c60bd73fe2d995b1f8481ff4cb64f7e227",
-            "0x65eece3bc0bbb9b4e729decb9abf3e9e569d5ab34a84a85213d5b8c9d3859848",
-            "0xbe81bac970a8639f94c19e650f1b65f53727b2386edc51ed349d09a1ebb82ae8",
-            "0x2805417f0a67a8f10cb882852597d5d7ecdf2c88d671f3f935e8f4ee3a49acf5",
+            "0xa772faf10af602d67abb432f88dd8417e210747d92348f4368602142c0f89643",
+            "0x020ba1a04c60ab05f868736cfc6fd1dc8676b037ec7b2e3a812e21f869c3148b",
+            "0x45d8f0b4e13deb0fe062c967a7af22e8f263e4b3ccc61dcf830f71508eed236e",
+            "0x6ad1230650a336eb5327ae01feef5895146d3c4422fc7abf9551fee6749f1ae8",
+            "0xb652daba4dc3a288cb4d943e3c29d1d707eb3e1fdd75c33cb97ef75e896a1017",
+            "0x58ba6681a4c254a291fce1cbbb0a978832a98cba83f479179e56f01cadf261be",
+            "0x15e983ece9873b98c974e20bdede1678702423e3652e6177d7855d3811afa9ba",
+            "0x7e122c8477bde83036b6204759eff30fd46d1ceb40a19f2e7f4a0f607ee2c9c6",
             "0xf77510fb7ca835518f32da284946d319bdca417aa78922b9d44b54bd26bc72c1",
             "0x1f92047910d99aaf64cac5e9da0a91de8737a6f84b515765e172a031d248602b",
             "0x4904ea731541b4cf5cbcf74abdafb960963cc3f5849d701750ec97337009422b",
@@ -1941,21 +1941,21 @@
             "0xad23c1db8f5ae3c9ed3a6dc138b48cc566fb398aa6dc134809bbc8e98013b7af",
             "0xbab93438977c8f79aab54c3ecaf3c1f8a78acdd826422f183f2a5cd4642b4a87",
             "0x280239e81ff011edf3cf6a6191442411d809c8f8053f2d0abe424fb7b13fe42a",
-            "0x3c8b88ea36e50fdfe2821dbe142264501e2560d5554960a93850e29f70b04dec",
-            "0x1c2e18c34f70c94636677ebb0ac8a42ad4088fddacce5aef031b4bf9f303db22",
-            "0x3082743fc1382353ebff83ef07de5efa1921e818a2c128cccb1db5474f043661",
+            "0x623db5c328721b4470a0d8f5aed84ecf5c73dcd193591b37e28b179abe6efcf5",
+            "0x0433a69f3a0c7adb3d5ec138386d759b0a888407e4a5e964405753b0367a23ea",
+            "0x760a5a419edb38f4f9867548690c9562269b7925d434a8afbdf59d9fc20cd5ef",
             "0x6111b324be162832c95194100fc788555f02960d49487bcec8684cc22175b318",
-            "0x3c2e3e208dc820e8531cee1529c3544a2505a832723b3800fd840993500b8c11",
-            "0x1fdf4e4c11e0f7b12f4aed39984eec5ec0cda5508142d6e9301614f87b4c9bd4",
-            "0xee4829e18fdbbf432cc967fd0070aecb1c81113fbb46c01f41856cc3906e23d1",
-            "0x7c60d571ac4eb358a26e03512fb37dc561b3c0b0805670505b6a6613996cf3d4",
-            "0x7b36e2298e891155aecad7fb348c0d74db8e7ee14826e912e8f718287146e344",
+            "0x4db8c5ecf72ff119178031315b2bafea971fd6e1272bf5327e700195ef7c8c7d",
+            "0xea3b6e543990aeaddeab51d410ddb9911bc6d900c2afd3110151f869a20032ca",
+            "0x2238b9ef9f09096e5641d8c3807d0da969621b756f19c4e0917a16d8e9090a7b",
+            "0xe1fc67d638de85a25bee44ca19646aebcaa986effadf7e93daec2ed02a6d70df",
+            "0xd840006ad46851ab03d3666bd63b4778322d6001652bb7b3db9bee0f2529b93a",
             "0xf3c4d75a760874c30b734651a1f151ccc6944c82454624c38543bbc02d18de1f",
-            "0xe0dddb99f5e934afe7d48f8c1a466759512a4fbcd3450e91383ac031cd9c5b47",
-            "0x1789ceb24d9c134e35786cee4865325f0f995303392908dfd554926243e67822",
-            "0x231bbd9d05be9454da4686859594599cc978a999db0ae50ac19988201005259f",
+            "0xf318a8f6c5ae54a96addfa86d4e6c9edacb246bd2a0a00c6477696af144c84ae",
+            "0xcce14f829eaa6518af340a202b17f91ee55e61b97d01225f3dc55d48d12396ee",
+            "0x928b0e895014437b9a90a2dae36c038f25e62395039f57c11023c55c6ac675da",
             "0xe0b4ff29b9247a0c47424c797d1a414f25d6ae80e634d036c16aeb0f8d906650",
-            "0x81fd2fcd4f25aea8e745e34f5ad2d9de9d69a30f5f8aac2d4f37d12f65fa6d9f",
+            "0xb64cc0c0a04b175bd1ecd7abe2a690a1cea9ca6dac0f29bb3c745644ef8f99de",
             "0xd255e2005f4faf7443abc3683ebb1c16f179442cc159c12342a27a7a4bafdd30",
             "0xccfb7ec45a88bf9820033071d20c49c129a74e2e4d7c0f9ccdb44aca12c8f63c",
             "0x01cec3ade4b3392372ca4a5f678aa989d30962f1446e274e8a2a2faaf5b10853",

--- a/script/MerkleRootCreation/Berachain/CreateLiquidBeraBtcMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Berachain/CreateLiquidBeraBtcMerkleRoot.s.sol
@@ -107,6 +107,22 @@ contract CreateLiquidBeraBtcMerkleRoot is Script, MerkleTreeHelper {
         _addCrossChainTellerLeafs(leafs, eBTCTellerLZ, depositAssets, feeAssets, abi.encode(layerZeroMainnetEndpointId));  
         }
 
+        // ========================== Infrared ==========================
+        _addInfraredVaultLeafs(leafs, getAddress(sourceChain, "infrared_vault_primeLiquidBeraBTC"));
+        _addInfraredVaultLeafs(leafs, getAddress(sourceChain, "infrared_vault_iBGT"));
+
+        // ========================== BeraBorrow ==========================
+        // TODO
+        // {
+        //     address[] memory collateralAssets = new address[](2);
+
+        //     address[] memory borrowAssets = new address[](2);
+
+        //     address[] memory denManagers = new address[](2);
+
+
+        //     _addBeraborrowLeafs(leafs, collateralAssets, borrowAssets, denManagers, false);
+        // }
         // ========================== Verify ==========================
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);
 

--- a/script/MerkleRootCreation/Berachain/CreateLiquidBeraEthMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Berachain/CreateLiquidBeraEthMerkleRoot.s.sol
@@ -37,7 +37,7 @@ contract CreateLiquidBeraEthMerkleRoot is Script, MerkleTreeHelper {
         setAddress(false, berachain, "accountantAddress", accountantAddress);
         setAddress(false, berachain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](32);
+        ManageLeaf[] memory leafs = new ManageLeaf[](64);
 
         // ========================== Ooga Booga ==========================
         address[] memory assets = new address[](4); 

--- a/script/MerkleRootCreation/Berachain/CreateLiquidBeraEthMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Berachain/CreateLiquidBeraEthMerkleRoot.s.sol
@@ -71,7 +71,21 @@ contract CreateLiquidBeraEthMerkleRoot is Script, MerkleTreeHelper {
         _addRoycoWithdrawMerkleDepositLeafs(leafs, weirollWallets);
 
         // ========================== Infrared ==========================
-        // To be added after correct vaults are listed
+        _addInfraredVaultLeafs(leafs, getAddress(sourceChain, "infrared_vault_primeLiquidBeraETH"));
+        _addInfraredVaultLeafs(leafs, getAddress(sourceChain, "infrared_vault_iBGT"));
+
+        //============================ BeraBorrow ==========================
+        // TODO
+        // {
+        //     address[] memory collateralAssets = new address[](2);
+
+        //     address[] memory borrowAssets = new address[](2);
+
+        //     address[] memory denManagers = new address[](2);
+
+
+        //     _addBeraborrowLeafs(leafs, collateralAssets, borrowAssets, denManagers, false);
+        // }
 
         // ========================== Fee Claiming ==========================
         ERC20[] memory feeAssets = new ERC20[](2);

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -2209,6 +2209,9 @@ contract ChainValues {
         values[berachain]["infrared_vault_wbtc_ebtc"] = 0x5C5FCb568a98DA28C9D2DF4852b102aa814c3a4c.toBytes32();
         values[berachain]["infrared_vault_weth_weeth"] = 0x16ed36cB22b298085d10b119030408C7BbfFC24E.toBytes32();
         values[berachain]["infrared_vault_rUSD_honey"] = 0x1C5879B75be9E817B1607AFb6f24F632eE6F8820.toBytes32();
+        values[berachain]["infrared_vault_primeLiquidBeraETH"] = .toBytes32();
+        values[berachain]["infrared_vault_primeLiquidBeraBTC"] = .toBytes32();
+        values[berachain]["infrared_vault_iBGT"] = 0x75F3Be06b02E235f6d0E7EF2D462b29739168301.toBytes32();
 
         // Dolomite
         values[berachain]["dolomiteMargin"] = 0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D.toBytes32();

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -2209,8 +2209,8 @@ contract ChainValues {
         values[berachain]["infrared_vault_wbtc_ebtc"] = 0x5C5FCb568a98DA28C9D2DF4852b102aa814c3a4c.toBytes32();
         values[berachain]["infrared_vault_weth_weeth"] = 0x16ed36cB22b298085d10b119030408C7BbfFC24E.toBytes32();
         values[berachain]["infrared_vault_rUSD_honey"] = 0x1C5879B75be9E817B1607AFb6f24F632eE6F8820.toBytes32();
-        values[berachain]["infrared_vault_primeLiquidBeraETH"] = .toBytes32();
-        values[berachain]["infrared_vault_primeLiquidBeraBTC"] = .toBytes32();
+        values[berachain]["infrared_vault_primeLiquidBeraETH"] = 0xc9d8Bc7428059219f3D19Da7F17ad468254D4D7e.toBytes32();
+        values[berachain]["infrared_vault_primeLiquidBeraBTC"] = 0x4bA0a69621eA72870F9fcf2D974D39B8609343cC.toBytes32();
         values[berachain]["infrared_vault_iBGT"] = 0x75F3Be06b02E235f6d0E7EF2D462b29739168301.toBytes32();
 
         // Dolomite
@@ -2260,7 +2260,7 @@ contract ChainValues {
 
         // Ooga Booga
         values[berachain]["OBRouter"] = 0xFd88aD4849BA0F729D6fF4bC27Ff948Ab1Ac3dE7.toBytes32();
-        values[berachain]["OBExecutor"] = 0x2242B1c1B429c799D5584dC4B59732fb6B1A6BE6.toBytes32();
+        values[berachain]["OBExecutor"] = 0x0e29aD2925079f313817D09Fcadbdf3A91125654.toBytes32();
 
 
         // Royco


### PR DESCRIPTION
- add infrared prime vault enter/exit, reward claiming to non-prime leafs
- update ooga booga executor to 0x0e29aD2925079f313817D09Fcadbdf3A91125654 in all leafs
- same decoders as previous root updates