### PR TITLE
add stakestone decoder

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+
+abstract contract SwellDecoderAndSanitizer is BaseDecoderAndSanitizer {
+    //============================== StoneVault ===============================
+
+    function deposit() external pure virtual returns (bytes memory addressesFound) {
+        // Nothing to sanitize or return
+        return addressesFound;
+    }
+
+    function instantWithdraw(uint256 /*_amount*/, uint256 /*_shares*/) external pure virtual returns (bytes memory addressesFound) {
+        // Nothing to sanitize or return
+        return addressesFound;
+    }
+
+    function requestWithdraw(uint256 /*_shares*/) external pure virtual returns (bytes memory addressesFound) {
+        // Nothing to sanitize or return
+        return addressesFound;
+    }
+}

--- a/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
@@ -20,4 +20,9 @@ abstract contract StakeStoneDecoderAndSanitizer is BaseDecoderAndSanitizer {
         // Nothing to sanitize or return
         return addressesFound;
     }
+
+    function cancelWithdraw(uint256 /*_shares*/) external pure virtual returns (bytes memory addressesFound) {
+        // Nothing to sanitize or return
+        return addressesFound;
+    }
 }

--- a/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 
-abstract contract SwellDecoderAndSanitizer is BaseDecoderAndSanitizer {
+abstract contract StakeStoneDecoderAndSanitizer is BaseDecoderAndSanitizer {
     //============================== StoneVault ===============================
 
     function deposit() external pure virtual returns (bytes memory addressesFound) {

--- a/test/integrations/StakeStoneIntegration.t.sol
+++ b/test/integrations/StakeStoneIntegration.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ERC4626} from "@solmate/tokens/ERC4626.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {StakeStoneDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol";
+import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+contract StakeStoneIntegrationTest is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    ManagerWithMerkleVerification public manager;
+    BoringVault public boringVault;
+    address public rawDataDecoderAndSanitizer;
+    RolesAuthority public rolesAuthority;
+
+    uint8 public constant MANAGER_ROLE = 1;
+    uint8 public constant STRATEGIST_ROLE = 2;
+    uint8 public constant MANGER_INTERNAL_ROLE = 3;
+    uint8 public constant ADMIN_ROLE = 4;
+    uint8 public constant BORING_VAULT_ROLE = 5;
+    uint8 public constant BALANCER_VAULT_ROLE = 6;
+
+    function setUp() external {
+        setSourceChainName("mainnet");
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 22470437;
+
+        _startFork(rpcKey, blockNumber);
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 18);
+
+        manager =
+            new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
+
+        rawDataDecoderAndSanitizer = address(new FullStakeStoneDecoderAndSanitizer());
+
+        setAddress(false, sourceChain, "boringVault", address(boringVault));
+        setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
+        setAddress(false, sourceChain, "manager", address(manager));
+        setAddress(false, sourceChain, "managerAddress", address(manager));
+        setAddress(false, sourceChain, "accountantAddress", address(1));
+
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+        boringVault.setAuthority(rolesAuthority);
+        manager.setAuthority(rolesAuthority);
+
+        // Setup roles authority.
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address,bytes,uint256)"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address[],bytes[],uint256[])"))),
+            true
+        );
+
+        rolesAuthority.setRoleCapability(
+            STRATEGIST_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANGER_INTERNAL_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(manager), ManagerWithMerkleVerification.setManageRoot.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BORING_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.flashLoan.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BALANCER_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.receiveFlashLoan.selector, true
+        );
+
+        // Grant roles
+        rolesAuthority.setUserRole(address(this), STRATEGIST_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANGER_INTERNAL_ROLE, true);
+        rolesAuthority.setUserRole(address(this), ADMIN_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANAGER_ROLE, true);
+        rolesAuthority.setUserRole(address(boringVault), BORING_VAULT_ROLE, true);
+        rolesAuthority.setUserRole(getAddress(sourceChain, "vault"), BALANCER_VAULT_ROLE, true);
+
+        // Allow the boring vault to receive ETH.
+        rolesAuthority.setPublicCapability(address(boringVault), bytes4(0), true);
+    }
+
+    function testStakeStoneIntegration() external {
+        deal(address(boringVault), 1_000e18);
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](4);
+        _addStoneLeafs(leafs);
+
+        //string memory filePath = "./TestTEST.json";
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        //_generateLeafs(filePath, leafs, manageTree[manageTree.length - 1][0], manageTree);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](4);
+        manageLeafs[0] = leafs[0]; //deposit ETH -> STONE
+        manageLeafs[1] = leafs[1]; //instantWithdraw STONE -> ETH
+        manageLeafs[2] = leafs[2]; //approve StoneVault to spend STONE
+        manageLeafs[3] = leafs[3]; //requestWithdraw STONE -> ETH
+
+        (bytes32[][] memory manageProofs) = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](4);
+        targets[0] = getAddress(sourceChain, "stoneVault");
+        targets[1] = getAddress(sourceChain, "stoneVault");
+        targets[2] = getAddress(sourceChain, "STONE");
+        targets[3] = getAddress(sourceChain, "stoneVault");
+        bytes[] memory targetData = new bytes[](4);
+        targetData[0] = abi.encodeWithSignature("deposit()");
+        targetData[1] = abi.encodeWithSignature("instantWithdraw(uint256,uint256)", 0, 1e15);
+        targetData[2] = abi.encodeWithSelector(ERC20.approve.selector, getAddress(sourceChain, "stoneVault"), type(uint256).max);
+        targetData[3] = abi.encodeWithSignature("requestWithdraw(uint256)", 100e18);
+
+        uint256[] memory values = new uint256[](4);
+        values[0] = 1_000e18;
+
+        address[] memory decodersAndSanitizers = new address[](4);
+        for (uint256 i = 0; i < decodersAndSanitizers.length; i++) {
+            decodersAndSanitizers[i] = rawDataDecoderAndSanitizer;
+        }
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+        console.log("Boring Vault balance after instantWithdraw: ", address(boringVault).balance);
+        assertGt(address(boringVault).balance, 1e15);
+    }
+
+    // ========================================= HELPER FUNCTIONS =========================================
+
+    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+        forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+        vm.selectFork(forkId);
+    }
+}
+
+contract FullStakeStoneDecoderAndSanitizer is StakeStoneDecoderAndSanitizer {}

--- a/test/integrations/StakeStoneIntegration.t.sol
+++ b/test/integrations/StakeStoneIntegration.t.sol
@@ -109,7 +109,7 @@ contract StakeStoneIntegrationTest is Test, MerkleTreeHelper {
     function testStakeStoneIntegration() external {
         deal(address(boringVault), 1_000e18);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](4);
+        ManageLeaf[] memory leafs = new ManageLeaf[](8);
         _addStoneLeafs(leafs);
 
         //string memory filePath = "./TestTEST.json";
@@ -120,29 +120,33 @@ contract StakeStoneIntegrationTest is Test, MerkleTreeHelper {
 
         manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
 
-        ManageLeaf[] memory manageLeafs = new ManageLeaf[](4);
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](5);
         manageLeafs[0] = leafs[0]; //deposit ETH -> STONE
         manageLeafs[1] = leafs[1]; //instantWithdraw STONE -> ETH
         manageLeafs[2] = leafs[2]; //approve StoneVault to spend STONE
         manageLeafs[3] = leafs[3]; //requestWithdraw STONE -> ETH
+        manageLeafs[4] = leafs[4]; //cancelWithdraw STONE -> ETH
 
         (bytes32[][] memory manageProofs) = _getProofsUsingTree(manageLeafs, manageTree);
 
-        address[] memory targets = new address[](4);
+        address[] memory targets = new address[](5);
         targets[0] = getAddress(sourceChain, "stoneVault");
         targets[1] = getAddress(sourceChain, "stoneVault");
         targets[2] = getAddress(sourceChain, "STONE");
         targets[3] = getAddress(sourceChain, "stoneVault");
-        bytes[] memory targetData = new bytes[](4);
+        targets[4] = getAddress(sourceChain, "stoneVault");
+
+        bytes[] memory targetData = new bytes[](5);
         targetData[0] = abi.encodeWithSignature("deposit()");
         targetData[1] = abi.encodeWithSignature("instantWithdraw(uint256,uint256)", 0, 1e15);
         targetData[2] = abi.encodeWithSelector(ERC20.approve.selector, getAddress(sourceChain, "stoneVault"), type(uint256).max);
         targetData[3] = abi.encodeWithSignature("requestWithdraw(uint256)", 100e18);
+        targetData[4] = abi.encodeWithSignature("cancelWithdraw(uint256)", 50e18);
 
-        uint256[] memory values = new uint256[](4);
+        uint256[] memory values = new uint256[](5);
         values[0] = 1_000e18;
 
-        address[] memory decodersAndSanitizers = new address[](4);
+        address[] memory decodersAndSanitizers = new address[](5);
         for (uint256 i = 0; i < decodersAndSanitizers.length; i++) {
             decodersAndSanitizers[i] = rawDataDecoderAndSanitizer;
         }

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -1350,6 +1350,9 @@ contract ChainValues {
 
         // King
         values[mainnet]["kingMerkleDistributor"] = 0x6Db24Ee656843E3fE03eb8762a54D86186bA6B64.toBytes32();
+
+        // STONE
+        values[mainnet]["stoneVault"] = 0xA62F9C5af106FeEE069F38dE51098D9d81B90572.toBytes32();
     }
 
     function _addBaseValues() private {

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -12484,6 +12484,59 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault"); 
     }
 
+    // ========================================= StakeStone =========================================
+
+    function _addStoneLeafs(ManageLeaf[] memory leafs) internal {
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "stoneVault"),
+            true,
+            "deposit()",
+            new address[](0),
+            string.concat("Deposit Native ETH to STONE"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "stoneVault"),
+            false,
+            "instantWithdraw(uint256,uint256)",
+            new address[](0),
+            string.concat("Instant withdraw Native ETH from STONE"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "STONE"),
+            false,
+            "approve(address,uint256)",
+            new address[](1),
+            string.concat("Approve StoneVault to spend STONE for requestWithdraw"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "stoneVault");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "stoneVault"),
+            false,
+            "requestWithdraw(uint256)",
+            new address[](0),
+            string.concat("Request Withdraw Native ETH from STONE"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+    }
+
     // ========================================= JSON FUNCTIONS =========================================
     // TODO this should pass in a bool or something to generate leafs indicating that we want leaf indexes printed.
     bool addLeafIndex = false;

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -12535,6 +12535,18 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
             string.concat("Request Withdraw Native ETH from STONE"),
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "stoneVault"),
+            false,
+            "cancelWithdraw(uint256)",
+            new address[](0),
+            string.concat("Cancel ETH withdraw request from STONE"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
     }
 
     // ========================================= JSON FUNCTIONS =========================================


### PR DESCRIPTION
Add for ETH <-> STONE entry/exit, add tests

Note: additional functions may be needed for Stone Vaults that don't use the native asset, but for now we are only concerned with STONE.