### PR TITLE
add ultra yield decoder and sanitizer

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol
@@ -9,4 +9,20 @@ abstract contract UltraYieldDecoderAndSanitizer is BaseDecoderAndSanitizer, ERC4
     function requestRedeem(uint256 /*shares*/) external pure virtual returns (bytes memory addressesFound) {
         return addressesFound;
     }
+
+    function deposit(uint256 /*assets*/) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+    function mint(uint256 /*shares*/) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+    function withdraw(uint256 /*assets*/) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+    function redeem(uint256 /*shares*/) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
 }

--- a/src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
+
+
+abstract contract UltraYieldDecoderAndSanitizer is BaseDecoderAndSanitizer, ERC4626DecoderAndSanitizer {
+    function requestRedeem(uint256 /*shares*/) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+}

--- a/test/integrations/UltraYieldIntegration.t.sol
+++ b/test/integrations/UltraYieldIntegration.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ERC4626} from "@solmate/tokens/ERC4626.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {UltraYieldDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol";
+import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+contract UltraYieldIntegrationTest is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    ManagerWithMerkleVerification public manager;
+    BoringVault public boringVault;
+    address public rawDataDecoderAndSanitizer;
+    RolesAuthority public rolesAuthority;
+
+    uint8 public constant MANAGER_ROLE = 1;
+    uint8 public constant STRATEGIST_ROLE = 2;
+    uint8 public constant MANGER_INTERNAL_ROLE = 3;
+    uint8 public constant ADMIN_ROLE = 4;
+    uint8 public constant BORING_VAULT_ROLE = 5;
+    uint8 public constant BALANCER_VAULT_ROLE = 6;
+
+    function setUp() external {
+        setSourceChainName("mainnet");
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 22041784;
+
+        _startFork(rpcKey, blockNumber);
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 18);
+
+        manager =
+            new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
+
+        rawDataDecoderAndSanitizer = address(new FullUltraYieldDecoderAndSanitizer());
+
+        setAddress(false, sourceChain, "boringVault", address(boringVault));
+        setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
+        setAddress(false, sourceChain, "manager", address(manager));
+        setAddress(false, sourceChain, "managerAddress", address(manager));
+        setAddress(false, sourceChain, "accountantAddress", address(1));
+
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+        boringVault.setAuthority(rolesAuthority);
+        manager.setAuthority(rolesAuthority);
+
+        // Setup roles authority.
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address,bytes,uint256)"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address[],bytes[],uint256[])"))),
+            true
+        );
+
+        rolesAuthority.setRoleCapability(
+            STRATEGIST_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            MANGER_INTERNAL_ROLE,
+            address(manager),
+            ManagerWithMerkleVerification.manageVaultWithMerkleVerification.selector,
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(manager), ManagerWithMerkleVerification.setManageRoot.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BORING_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.flashLoan.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            BALANCER_VAULT_ROLE, address(manager), ManagerWithMerkleVerification.receiveFlashLoan.selector, true
+        );
+
+        // Grant roles
+        rolesAuthority.setUserRole(address(this), STRATEGIST_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANGER_INTERNAL_ROLE, true);
+        rolesAuthority.setUserRole(address(this), ADMIN_ROLE, true);
+        rolesAuthority.setUserRole(address(manager), MANAGER_ROLE, true);
+        rolesAuthority.setUserRole(address(boringVault), BORING_VAULT_ROLE, true);
+        rolesAuthority.setUserRole(getAddress(sourceChain, "vault"), BALANCER_VAULT_ROLE, true);
+
+        // Allow the boring vault to receive ETH.
+        rolesAuthority.setPublicCapability(address(boringVault), bytes4(0), true);
+    }
+
+    function testUltraYieldIntegration() external {
+        deal(getAddress(sourceChain, "cmETH"), address(boringVault), 100_000e18);
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
+        _addUltraYieldLeafs(leafs);
+
+        //string memory filePath = "./TestTEST.json";
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+
+        //_generateLeafs(filePath, leafs, manageTree[manageTree.length - 1][0], manageTree);
+
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](10);
+        manageLeafs[0] = leafs[0]; //approve syrupRouter (USDC) to spend USDC
+        manageLeafs[1] = leafs[1]; //approve syrupRouter (USDT) to spend USDT
+        manageLeafs[2] = leafs[2]; //USDC -> syrupUSDC
+        manageLeafs[3] = leafs[3]; //USDT -> syrupUSDT
+        manageLeafs[4] = leafs[4]; //approve syrupUSDC to spend syrupUSDC
+        manageLeafs[5] = leafs[5]; //approve syrupUSDT to spend syrupUSDT
+        manageLeafs[6] = leafs[6]; //request redeem syrupUSDC
+        manageLeafs[7] = leafs[7]; //request redeem syrupUSDT
+        manageLeafs[8] = leafs[8]; //cancel redeem syrupUSDC
+        manageLeafs[9] = leafs[9]; //cancel redeem syrupUSDT
+
+        (bytes32[][] memory manageProofs) = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](10);
+        targets[0] = getAddress(sourceChain, "USDC"); //approve USDC router
+        targets[1] = getAddress(sourceChain, "USDT"); //approve USDT router
+        targets[2] = getAddress(sourceChain, "syrupRouterUSDC"); //convert USDC to syrupUSDC
+        targets[3] = getAddress(sourceChain, "syrupRouterUSDT"); //convert USDT to syrupUSDT
+        targets[4] = getAddress(sourceChain, "syrupUSDC"); //approve syrupUSDC
+        targets[5] = getAddress(sourceChain, "syrupUSDT"); //approve syrupUSDT
+        targets[6] = getAddress(sourceChain, "syrupUSDC"); //request redeem syrupUSDC
+        targets[7] = getAddress(sourceChain, "syrupUSDT"); //request redeem syrupUSDT
+        targets[8] = getAddress(sourceChain, "syrupUSDC"); //cancel redeem syrupUSDC
+        targets[9] = getAddress(sourceChain, "syrupUSDT"); //cancel redeem syrupUSDT
+
+        bytes[] memory targetData = new bytes[](10);
+        targetData[0] =
+            abi.encodeWithSelector(ERC20.approve.selector, getAddress(sourceChain, "syrupRouterUSDC"), type(uint256).max);
+        targetData[1] =
+            abi.encodeWithSelector(ERC20.approve.selector, getAddress(sourceChain, "syrupRouterUSDT"), type(uint256).max);
+        targetData[2] =
+            abi.encodeWithSignature("deposit(uint256,bytes32)", 100e6, bytes32("0:vtl"));
+        targetData[3] =
+            abi.encodeWithSignature("deposit(uint256,bytes32)", 100e6, bytes32("0:vtl"));
+        targetData[4] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "syrupUSDC"), type(uint256).max
+        );
+        targetData[5] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "syrupUSDT"), type(uint256).max
+        );
+        targetData[6] =
+            abi.encodeWithSignature("requestRedeem(uint256,address)", 90e6, getAddress(sourceChain, "boringVault"));
+        targetData[7] =
+            abi.encodeWithSignature("requestRedeem(uint256,address)", 90e6, getAddress(sourceChain, "boringVault"));
+        targetData[8] = abi.encodeWithSignature(
+            "removeShares(uint256,address)", 50e6, getAddress(sourceChain, "boringVault")
+        );
+        targetData[9] = abi.encodeWithSignature(
+            "removeShares(uint256,address)", 50e6, getAddress(sourceChain, "boringVault")
+        );
+
+        uint256[] memory values = new uint256[](10);
+
+        address[] memory decodersAndSanitizers = new address[](10);
+        for (uint256 i = 0; i < decodersAndSanitizers.length; i++) {
+            decodersAndSanitizers[i] = rawDataDecoderAndSanitizer;
+        }
+
+        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
+
+    // ========================================= HELPER FUNCTIONS =========================================
+
+    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+        forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+        vm.selectFork(forkId);
+    }
+}
+
+contract FullUltraYieldDecoderAndSanitizer is UltraYieldDecoderAndSanitizer {}

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -2029,6 +2029,9 @@ contract ChainValues {
         values[sepolia]["USDC"] = 0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590.toBytes32();
         values[sepolia]["ZRO"] = address(1).toBytes32();
         values[sepolia]["CrispyCoin"] = 0x0c959E3AA0A74E972d1A8F759c198e660CcCebcB.toBytes32();
+        values[sepolia]["WETH9"] = 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14.toBytes32();
+
+        values[sepolia]["UltraYieldWETH"] = 0x22C24D6C6CF64B799ce936f86aBfA8984F3F804d.toBytes32();
 
         values[sepolia]["balancerVault"] = address(1).toBytes32();
 

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -12540,6 +12540,19 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex] = ManageLeaf(
             vault,
             false,
+            "approve(address,uint256)",
+            new address[](1),
+            string.concat("Approve UltraYield Vault ", ERC20(vault).symbol(), " to spend", ERC20(vault).symbol()),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = vault;
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            vault,
+            false,
             "requestRedeem(uint256)",
             new address[](0),
             string.concat("Request redeem from UltraYield Vault ", ERC20(vault).symbol()),

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -12484,6 +12484,69 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault"); 
     }
 
+    function _addUltraYieldLeafs(ManageLeaf[] memory leafs, address vault) internal {
+        _addERC4626Leafs(leafs, ERC4626(vault));
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            vault,
+            false,
+            "deposit(uint256)",
+            new address[](0),
+            string.concat("Deposit to UltraYield Vault ", ERC20(vault).symbol()),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            vault,
+            false,
+            "withdraw(uint256)",
+            new address[](0),
+            string.concat("Withdraw from UltraYield Vault ", ERC20(vault).symbol()),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            vault,
+            false,
+            "mint(uint256)",
+            new address[](0),
+            string.concat("Redeem from UltraYield Vault ", ERC20(vault).symbol()),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            vault,
+            false,
+            "redeem(uint256)",
+            new address[](0),
+            string.concat("Redeem from UltraYield Vault ", ERC20(vault).symbol()),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            vault,
+            false,
+            "requestRedeem(uint256)",
+            new address[](0),
+            string.concat("Request redeem from UltraYield Vault ", ERC20(vault).symbol()),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+    }
+
     // ========================================= JSON FUNCTIONS =========================================
     // TODO this should pass in a bool or something to generate leafs indicating that we want leaf indexes printed.
     bool addLeafIndex = false;


### PR DESCRIPTION
Add decoder for UltraYield Vaults

Tested on Sepolia since that had the only available "live" contracts

Ultra Yield Vaults are ERC7540 async vaults, which use the ERC4626 functions in non-standard ways and adds requestRedeem for withdrawal requests, which must be fulfilled by an operator.  They also expose versions of deposit/withdraw/mint/redeem without address arguments that default to msg.sender.

For ultrayield's contracts, see here: https://github.com/UltraYield/contracts