### PR TITLE
deploy golden goose vaults

### DIFF
--- a/deployments/addresses/Mainnet/GoldenGoose.json
+++ b/deployments/addresses/Mainnet/GoldenGoose.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0xc873F2b7b3BA0a7faA2B56e210E3B965f2b618f5",
+    "BoringOnChainQueue": "0xe39682c3C44b73285A2556D4869041e674d1a6B7",
+    "BoringVault": "0xef417FCE1883c6653E7dC6AF7c6F85CCDE84Aa09",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0x5F341B1cf8C5949d6bE144A725c22383a5D3880B",
+    "Pauser": "0xf1B76D43d95553f6b1e0F7303007B0375e7AB60c",
+    "QueueSolver": "0xAC20dba743CDCd883f6E5309954C05b76d41e080",
+    "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
+    "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
+    "Timelock": "0x0000000000000000000000000000000000000000"
+  }
+}

--- a/deployments/addresses/UniChain/GoldenGoose.json
+++ b/deployments/addresses/UniChain/GoldenGoose.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0xc873F2b7b3BA0a7faA2B56e210E3B965f2b618f5",
+    "BoringOnChainQueue": "0xe39682c3C44b73285A2556D4869041e674d1a6B7",
+    "BoringVault": "0xef417FCE1883c6653E7dC6AF7c6F85CCDE84Aa09",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0x5F341B1cf8C5949d6bE144A725c22383a5D3880B",
+    "Pauser": "0xf1B76D43d95553f6b1e0F7303007B0375e7AB60c",
+    "QueueSolver": "0xAC20dba743CDCd883f6E5309954C05b76d41e080",
+    "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
+    "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
+    "Timelock": "0x0000000000000000000000000000000000000000"
+  }
+}

--- a/deployments/configurations/Mainnet/GoldenGoose.json
+++ b/deployments/configurations/Mainnet/GoldenGoose.json
@@ -1,0 +1,267 @@
+{
+    "deploymentParameters": {
+      "logLevel": 4,
+      "privateKeyEnvName": "BORING_DEVELOPER",
+      "chainName": "mainnet",
+      "evmVersion": "cancun",
+      "desiredNumberOfDeploymentTxs": 4,
+      "txBundlerAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "txBundlerAddress"
+      },
+      "setupRoles": true,
+      "setupTestUser": true,
+      "saveDeploymentDetails": true,
+      "testUserAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "dev1Address"
+      },
+      "deployerContractAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "deployerAddress"
+      },
+      "nativeWrapperAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "WETH"
+      },
+      "deploymentOwnerAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "txBundlerAddress"
+      },
+      "deploymentFileName": "addresses/Mainnet/GoldenGoose.json"
+    },
+    "rolesAuthorityConfiguration": {
+      "rolesAuthorityDeploymentName": "Golden Goose Roles Authority V0.3"
+    },
+    "lensConfiguration": {
+      "lensDeploymentName": "Arctic Architecture Lens V0.0"
+    },
+    "boringVaultConfiguration": {
+      "boringVaultDeploymentName": "Golden Goose Boring Vault V0.3",
+      "boringVaultName": "Golden Goose Vault",
+      "boringVaultSymbol": "GG",
+      "boringVaultDecimals": 18
+    },
+    "managerConfiguration": {
+      "managerDeploymentName": "Golden Goose Manager V0.3",
+      "balancerVaultAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "balancerVault"
+      }
+    },
+    "accountantConfiguration": {
+      "accountantDeploymentName": "Golden Goose Accountant V0.3",
+      "accountantParameters": {
+        "kind": {
+          "variableRate": true,
+          "fixedRate": false
+        },
+        "payoutConfiguration": {
+          "payoutTo": "0x0000000000000000000000000000000000000000",
+          "optionalPaymentSplitterName": "Golden Goose Payment Splitter V0.3",
+          "splits": []
+        },
+        "accountantDeploymentParameters": {
+          "allowedExchangeRateChangeLower": 9900,
+          "allowedExchangeRateChangeUpper": 10100,
+          "baseAddressOrName": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "name": "WETH"
+          },
+          "minimumUpateDelayInSeconds": 21600,
+          "performanceFee": 1000,
+          "platformFee": 0,
+          "startingExchangeRate": 1000000000000000000
+        }
+      }
+    },
+    "tellerConfiguration": {
+      "tellerDeploymentName": "Golden Goose Teller V0.3",
+      "tellerParameters": {
+        "allowPublicDeposits": true,
+        "shareLockPeriod": 0,
+        "kind": {
+          "teller": false,
+          "tellerWithRemediation": false,
+          "tellerWithCcip": false,
+          "tellerWithLayerZero": true,
+          "tellerWithLayerZeroRateLimiting": false
+        },
+        "layerZero": {
+          "endpointAddressOrName": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "name": "LayerZeroEndPoint"
+          },
+          "lzChains": [
+            {
+                "allowMessagesFrom": true,
+                "allowMessagesTo": true,
+                "chainId": 30320,
+                "messageGasLimit": 100000,
+                "targetTellerOrSelf": {
+                    "address": "0x0000000000000000000000000000000000000000",
+                    "self": true
+                }
+            }
+          ],
+          "lzTokenAddressOrName": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "name": "ZRO"
+          }
+        }
+      }
+    },
+    "boringQueueConfiguration": {
+      "boringQueueDeploymentName": "Golden Goose Boring Queue V0.3",
+      "boringQueueSolverName": "Golden Goose Boring Solver V0.3",
+      "excessToSolverNonSelfSolve": true,
+      "queueParameters": {
+        "allowPublicWithdrawals": true,
+        "allowPublicSelfWithdrawals": true,
+        "kind": {
+          "boringQueue": true,
+          "boringQueueWithTracking": false
+        }
+      }
+    },
+    "droneConfiguration": {
+      "droneDeploymentBaseName": "Golden Goose Drone V0.3",
+      "droneCount": 0,
+      "safeGasToForwardNative": 21000
+    },
+    "pauserConfiguration": {
+      "shouldDeploy": true,
+      "pauserDeploymentName": "Golden Goose Pauser V0.3",
+      "makeGenericPauser": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "makeGenericUnpauser": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "makePauseAll": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "makeUnpauseAll": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "senderToPausable": [
+        {
+          "sender": "0x0000000000000000000000000000000000000000",
+          "pausable": "0x0000000000000000000000000000000000000000"
+        }
+      ]
+    },
+    "timelockConfiguration": {
+      "shouldDeploy": false,
+      "timelockDeploymentName": "Golden Goose Timelock V0.3",
+      "timelockParameters": {
+        "executors": [
+            "0xf8553c8552f906C19286F21711721E206EE4909E"
+        ],
+        "minDelay": 0,
+        "proposers": [
+          "0xf8553c8552f906C19286F21711721E206EE4909E"
+        ]
+      }
+    },
+    "accountantAssets": [
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WSTETH"
+        },
+        "isPeggedToBase": false,
+        "rateProvider": "0x8A4207Bfc6fc475F172F929468aCDD4A2c4C3C19"
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "STETH"
+          },
+        "isPeggedToBase": true,
+        "rateProvider": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "ETH"
+        },
+        "isPeggedToBase": true,
+        "rateProvider": "0x0000000000000000000000000000000000000000"
+      }
+    ],
+    "depositAssets": [
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WSTETH"
+        },
+        "allowDeposits": true,
+        "allowWithdraws": true,
+        "sharePremium": 0
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "STETH"
+        },
+        "allowDeposits": true,
+        "allowWithdraws": true,
+        "sharePremium": 0
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "ETH"
+        },
+        "allowDeposits": true,
+        "allowWithdraws": true,
+        "sharePremium": 0
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WETH"
+        },
+        "allowDeposits": true,
+        "allowWithdraws": true,
+        "sharePremium": 0
+      }
+    ],
+    "withdrawAssets": [
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WSTETH"
+        },
+        "maxDiscount": 10,
+        "minDiscount": 1,
+        "minimumSecondsToDeadline": 259200,
+        "minimumShares": 0,
+        "secondsToMaturity": 172800
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "STETH"
+        },
+        "maxDiscount": 10,
+        "minDiscount": 1,
+        "minimumSecondsToDeadline": 259200,
+        "minimumShares": 0,
+        "secondsToMaturity": 172800
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WETH"
+        },
+        "maxDiscount": 10,
+        "minDiscount": 1,
+        "minimumSecondsToDeadline": 259200,
+        "minimumShares": 0,
+        "secondsToMaturity": 172800
+      }
+    ]
+  }
+  

--- a/deployments/configurations/UniChain/GoldenGoose.json
+++ b/deployments/configurations/UniChain/GoldenGoose.json
@@ -1,0 +1,211 @@
+{
+    "deploymentParameters": {
+      "logLevel": 4,
+      "privateKeyEnvName": "BORING_DEVELOPER",
+      "chainName": "unichain",
+      "evmVersion": "cancun",
+      "desiredNumberOfDeploymentTxs": 16,
+      "txBundlerAddressOrName": {
+        "address": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+        "name": "txBundlerAddress"
+      },
+      "setupRoles": true,
+      "setupTestUser": true,
+      "saveDeploymentDetails": true,
+      "testUserAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "dev1Address"
+      },
+      "deployerContractAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "deployerAddress"
+      },
+      "nativeWrapperAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "WETH"
+      },
+      "deploymentOwnerAddressOrName": {
+        "address": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+        "name": "txBundlerAddress"
+      },
+      "deploymentFileName": "addresses/UniChain/GoldenGoose.json"
+    },
+    "rolesAuthorityConfiguration": {
+      "rolesAuthorityDeploymentName": "Golden Goose Roles Authority V0.3"
+    },
+    "lensConfiguration": {
+      "lensDeploymentName": "Arctic Architecture Lens V0.0"
+    },
+    "boringVaultConfiguration": {
+      "boringVaultDeploymentName": "Golden Goose Boring Vault V0.3",
+      "boringVaultName": "Golden Goose Vault",
+      "boringVaultSymbol": "GG",
+      "boringVaultDecimals": 18
+    },
+    "managerConfiguration": {
+      "managerDeploymentName": "Golden Goose Manager V0.3",
+      "balancerVaultAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "balancerVault"
+      }
+    },
+    "accountantConfiguration": {
+      "accountantDeploymentName": "Golden Goose Accountant V0.3",
+      "accountantParameters": {
+        "kind": {
+          "variableRate": true,
+          "fixedRate": false
+        },
+        "payoutConfiguration": {
+          "payoutTo": "0x0000000000000000000000000000000000000000",
+          "optionalPaymentSplitterName": "Golden Goose Payment Splitter V0.3",
+          "splits": []
+        },
+        "accountantDeploymentParameters": {
+          "allowedExchangeRateChangeLower": 9900,
+          "allowedExchangeRateChangeUpper": 10100,
+          "baseAddressOrName": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "name": "WETH"
+          },
+          "minimumUpateDelayInSeconds": 21600,
+          "performanceFee": 1000,
+          "platformFee": 0,
+          "startingExchangeRate": 1000000000000000000
+        }
+      }
+    },
+    "tellerConfiguration": {
+      "tellerDeploymentName": "Golden Goose Teller V0.3",
+      "tellerParameters": {
+        "allowPublicDeposits": false,
+        "shareLockPeriod": 0,
+        "kind": {
+          "teller": false,
+          "tellerWithRemediation": false,
+          "tellerWithCcip": false,
+          "tellerWithLayerZero": true,
+          "tellerWithLayerZeroRateLimiting": false
+        },
+        "layerZero": {
+          "endpointAddressOrName": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "name": "LayerZeroEndPoint"
+          },
+          "lzChains": [
+            {
+                "allowMessagesFrom": true,
+                "allowMessagesTo": true,
+                "chainId": 30101,
+                "messageGasLimit": 100000,
+                "targetTellerOrSelf": {
+                    "address": "0x0000000000000000000000000000000000000000",
+                    "self": true
+                }
+            }
+          ],
+          "lzTokenAddressOrName": {
+            "address": "0x0000000000000000000000000000000000000000",
+            "name": "ZRO"
+          }
+        }
+      }
+    },
+    "boringQueueConfiguration": {
+      "boringQueueDeploymentName": "Golden Goose Boring Queue V0.3",
+      "boringQueueSolverName": "Golden Goose Boring Solver V0.3",
+      "excessToSolverNonSelfSolve": true,
+      "queueParameters": {
+        "allowPublicWithdrawals": false,
+        "allowPublicSelfWithdrawals": false,
+        "kind": {
+          "boringQueue": true,
+          "boringQueueWithTracking": false
+        }
+      }
+    },
+    "droneConfiguration": {
+      "droneDeploymentBaseName": "Golden Goose Drone V0.3",
+      "droneCount": 0,
+      "safeGasToForwardNative": 21000
+    },
+    "pauserConfiguration": {
+      "shouldDeploy": true,
+      "pauserDeploymentName": "Golden Goose Pauser V0.3",
+      "makeGenericPauser": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "makeGenericUnpauser": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "makePauseAll": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "makeUnpauseAll": [
+        "0x0000000000000000000000000000000000000000"
+      ],
+      "senderToPausable": [
+        {
+          "sender": "0x0000000000000000000000000000000000000000",
+          "pausable": "0x0000000000000000000000000000000000000000"
+        }
+      ]
+    },
+    "timelockConfiguration": {
+      "shouldDeploy": false,
+      "timelockDeploymentName": "Golden Goose Timelock V0.3",
+      "timelockParameters": {
+        "executors": [
+            "0xf8553c8552f906C19286F21711721E206EE4909E"
+        ],
+        "minDelay": 0,
+        "proposers": [
+          "0xf8553c8552f906C19286F21711721E206EE4909E"
+        ]
+      }
+    },
+    "accountantAssets": [
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "ETH"
+        },
+        "isPeggedToBase": true,
+        "rateProvider": "0x0000000000000000000000000000000000000000"
+      }
+    ],
+    "depositAssets": [
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "ETH"
+        },
+        "allowDeposits": true,
+        "allowWithdraws": true,
+        "sharePremium": 0
+      },
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WETH"
+        },
+        "allowDeposits": true,
+        "allowWithdraws": true,
+        "sharePremium": 0
+      }
+    ],
+    "withdrawAssets": [
+      {
+        "addressOrName": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "WETH"
+        },
+        "maxDiscount": 10,
+        "minDiscount": 1,
+        "minimumSecondsToDeadline": 259200,
+        "minimumShares": 0,
+        "secondsToMaturity": 172800
+      }
+    ]
+  }
+  

--- a/foundry.toml
+++ b/foundry.toml
@@ -49,24 +49,24 @@ ink = "${INK_RPC_URL}"
 #bob = { key = "${BOBSCAN_KEY}", chain = 60808, url = "https://explorer.gobob.xyz/api?"}
 #corn = { key = "${CORNSCAN_KEY}", chain = 21000000, url = "https://api.routescan.io/v2/network/mainnet/evm/21000000/etherscan" }
 #arbitrum = { key = "${ARBISCAN_KEY}" }
-#mainnet = { key = "${ETHERSCAN_KEY}" }
+mainnet = { key = "${ETHERSCAN_KEY}" }
 #polygon = { key = "${POLYGONSCAN_KEY}" }
 #bsc = { key = "${BSCSCAN_KEY}" }
 #avalanche = { key = "${SNOWTRACE_KEY}" }
 #optimism = { key = "${OPTIMISMSCAN_KEY}" }
 #base = { key = "${BASESCAN_KEY}" }
 #scroll = { key = "${SCROLLSCAN_KEY}" }
-sonicMainnet = { key = "${SONICSCAN_KEY}", chain = 146, url = "https://api.sonicscan.org/api" }
+#sonicMainnet = { key = "${SONICSCAN_KEY}", chain = 146, url = "https://api.sonicscan.org/api" }
 #swell = { key = "${SWELLSCAN_KEY}", chain = 1923, url = "https://explorer.swellnetwork.io:443/api/" }
 #sonicMainnet = { key = "${SONICSCAN_KEY}", chain = 146, url = "https://api.sonicscan.org/api" }
-swell = { key = "${SWELLSCAN_KEY}", chain = 1923, url = "https://explorer.swellnetwork.io:443/api/" }
+#swell = { key = "${SWELLSCAN_KEY}", chain = 1923, url = "https://explorer.swellnetwork.io:443/api/" }
 #berachainTestnet = { key = "${BERASCAN_TESTNET_KEY}", chain = 80000, url = "https://api.routescan.io/v2/network/testnet/evm/80000/etherscan" }
 #sepolia = { key = "${ETHERSCAN_KEY}" }
 #berachain = { key = "${BERASCAN_KEY}", chain = 80094, url = "https://api.berascan.com/api" }
 #bob = { key = "${BOBSCAN_KEY}", chain = 60808, url = "https://explorer.gobob.xyz/api?"}
 unichain = { key = "${UNISCAN_KEY}", chain = 130, url = "https://api.uniscan.xyz/api" }
 #unichain = { key = "${UNISCAN_KEY}", chain = 130, url = "https://api.uniscan.xyz/api" }
-flare = {key = "${FLARESCAN_KEY}", chain = 14, url = "https://api.routescan.io/v2/network/mainnet/evm/14/etherscan" }
+#flare = {key = "${FLARESCAN_KEY}", chain = 14, url = "https://api.routescan.io/v2/network/mainnet/evm/14/etherscan" }
 #hyperEVM = { key = "${HYPER_EVM_KEY}, chain = 999, url = "https://hyperscan.gas.zip/" }
 
 

--- a/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
@@ -859,7 +859,9 @@ contract DeployArcticArchitectureWithConfigScript is Script, ChainValues {
         queueSolver = BoringSolver(deployedAddress);
         if (!isDeployed) {
             creationCode = type(BoringSolver).creationCode;
-            constructorArgs = abi.encode(deploymentOwner, address(0), address(queue));
+            // Read config to determine excessToSolverNonSelfSolve constructor argument.
+            bool excessToSolverNonSelfSolve = vm.parseJsonBool(rawJson, ".boringQueueConfiguration.excessToSolverNonSelfSolve");
+            constructorArgs = abi.encode(deploymentOwner, address(0), address(queue), excessToSolverNonSelfSolve);
             _log("Boring solver deployment TX added", 3);
             _log(string.concat("Boring queue address: ", vm.toString(address(queue))), 4);
             _addTx(

--- a/script/DeployQueueOnly.s.sol
+++ b/script/DeployQueueOnly.s.sol
@@ -5,25 +5,25 @@ import {Deployer} from "src/helper/Deployer.sol";
 import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
 import {ContractNames} from "resources/ContractNames.sol";
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
-import {BoringSolver} from "src/base/Roles/BoringQueue/BoringSolver.sol";
+import {BoringOnChainQueue} from "src/base/Roles/BoringQueue/BoringOnChainQueue.sol";
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 import "forge-std/Test.sol";
 
 /**
- *  source .env && forge script script/DeploySolver.s.sol:DeploySolver --broadcast --verify
+ *  source .env && forge script script/DeployQueueOnly.s.sol:DeployQueueOnly --broadcast --verify
  *
  * @dev Optionally can change `--with-gas-price` to something more reasonable
  */
-contract DeploySolver is Script, ContractNames, Test {
+contract DeployQueueOnly is Script, ContractNames, Test {
     uint256 public privateKey;
     
     Deployer deployer = Deployer(0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d);
 
-    address owner = 0xf8553c8552f906C19286F21711721E206EE4909E;
-    address auth = 0xED8C9A514eB81124e370015878ea1fB3fEF18158;
-    address queue = 0x84D988bA2f2838f6ccF61fDE77fe3EB70dFE284f;
-    bool excessToSolverNonSelfSolve = true;
+    address owner = ;
+    address auth = ;
+    address boringVault = ;
+    address accountant = ;
 
     function setUp() external {
         privateKey = vm.envUint("BORING_DEVELOPER");
@@ -36,9 +36,9 @@ contract DeploySolver is Script, ContractNames, Test {
         bytes memory creationCode;
         vm.startBroadcast(privateKey);
 
-        creationCode = type(BoringSolver).creationCode;
+        creationCode = type(BoringOnChainQueue).creationCode;
 
-        constructorArgs = abi.encode(owner, auth, queue, excessToSolverNonSelfSolve);
+        constructorArgs = abi.encode(owner, auth, boringVault, accountant);
         deployer.deployContract("HyperUSD Boring Solver 0.1", creationCode, constructorArgs, 0);
     }
 }

--- a/script/DeployQueueOnly.s.sol
+++ b/script/DeployQueueOnly.s.sol
@@ -20,14 +20,14 @@ contract DeployQueueOnly is Script, ContractNames, Test {
     
     Deployer deployer = Deployer(0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d);
 
-    address owner = ;
-    address auth = ;
-    address boringVault = ;
-    address accountant = ;
+    address owner = 0x1cdF47387358A1733968df92f7cC14546D9E1047;
+    address auth = 0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF;
+    address payable boringVault = payable(0xef417FCE1883c6653E7dC6AF7c6F85CCDE84Aa09);
+    address accountant = 0xc873F2b7b3BA0a7faA2B56e210E3B965f2b618f5;
 
     function setUp() external {
         privateKey = vm.envUint("BORING_DEVELOPER");
-        vm.createSelectFork("mainnet");
+        vm.createSelectFork("unichain");
     }
 
 
@@ -39,6 +39,6 @@ contract DeployQueueOnly is Script, ContractNames, Test {
         creationCode = type(BoringOnChainQueue).creationCode;
 
         constructorArgs = abi.encode(owner, auth, boringVault, accountant);
-        deployer.deployContract("HyperUSD Boring Solver 0.1", creationCode, constructorArgs, 0);
+        deployer.deployContract("Golden Goose Boring Queue 1.1", creationCode, constructorArgs, 0);
     }
 }

--- a/script/DeploySolver.s.sol
+++ b/script/DeploySolver.s.sol
@@ -20,14 +20,14 @@ contract DeploySolver is Script, ContractNames, Test {
     
     Deployer deployer = Deployer(0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d);
 
-    address owner = 0xf8553c8552f906C19286F21711721E206EE4909E;
-    address auth = 0xED8C9A514eB81124e370015878ea1fB3fEF18158;
-    address queue = 0x84D988bA2f2838f6ccF61fDE77fe3EB70dFE284f;
-    bool excessToSolverNonSelfSolve = true;
+    address owner = 0x1cdF47387358A1733968df92f7cC14546D9E1047;
+    address auth = 0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF;
+    address queue = 0xE32cEB767d187F1d3c81949657CABc50c655f40A;
+    bool excessToSolverNonSelfSolve = false;
 
     function setUp() external {
         privateKey = vm.envUint("BORING_DEVELOPER");
-        vm.createSelectFork("mainnet");
+        vm.createSelectFork("unichain");
     }
 
 
@@ -39,6 +39,6 @@ contract DeploySolver is Script, ContractNames, Test {
         creationCode = type(BoringSolver).creationCode;
 
         constructorArgs = abi.encode(owner, auth, queue, excessToSolverNonSelfSolve);
-        deployer.deployContract("HyperUSD Boring Solver 0.1", creationCode, constructorArgs, 0);
+        deployer.deployContract("Golden Goose Boring Solver 1.1", creationCode, constructorArgs, 0);
     }
 }

--- a/script/DeployTimelock.s.sol
+++ b/script/DeployTimelock.s.sol
@@ -48,7 +48,7 @@ contract DeployTimelockScript is Script, ContractNames, MainnetAddresses {
         TimelockController(payable(deployer.deployContract("alphaSTETH Timelock V0.1", creationCode, constructorArgs, 0)));
 
 
-        //timelock.grantRole(timelock.CANCELLER_ROLE(), canceller);
+        timelock.grantRole(timelock.CANCELLER_ROLE(), canceller);
         timelock.revokeRole(timelock.CANCELLER_ROLE(), proposer);
         timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), tempAdmin);
 


### PR DESCRIPTION
- Deployed Golden Goose Vaults on Mainnet + Unichain
- Updated Deploy Scripts with the new excessToSolveNonSelfSolve constructor parameter (from latest BoringSolver change)
- update lib/OAppAuth for LZ Teller verification
- The solvers deployed in the main script have this flag set to true (old behavior)
- Deployed a second set of queues and solvers on both chains, with this flag set to false (new behavior, excess to vault):
Fast Queue: 0xE32cEB767d187F1d3c81949657CABc50c655f40A
Fast Solver: 0x4086c5a823d5B949738A8C3C2Ebdeda008f66Fd3
