### PR TITLE
Oracle Rate Provider

### DIFF
--- a/src/helper/OracleRateProvider.sol
+++ b/src/helper/OracleRateProvider.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {IRateProvider} from "src/interfaces/IRateProvider.sol";
+import {AggregatorV3Interface} from "lib/ccip/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+contract OracleRateProvider is IRateProvider {
+    //============================== STRUCTS ===============================
+    struct ChainlinkResponse {
+        uint80 roundId;
+        int256 answer;
+        uint256 timestamp;
+        bool success;
+        uint8 decimals;
+    }
+
+    //============================== ERRORS ===============================
+    error OracleRateProvider__BadChainlinkResponse(); 
+    error OracleRateProvider__PriceChangeOutOfBounds(); 
+    error OracleRateProvider__PriceOutOfBounds(); 
+    error OracleRateProvider__PriceIsStale(); 
+
+    //============================== IMMUTABLES ===============================
+    AggregatorV3Interface public immutable oracle; // Chainlink PriceAggregatorV3 oracle
+    uint256 public immutable priceBoundLower;
+    uint256 public immutable priceBoundUpper;
+    uint32 public immutable timeout;
+    uint8 public immutable outputDecimals;
+    // Maximum deviation allowed between two consecutive Chainlink oracle prices in BPS.
+    uint32 public immutable maxDeviationFromPreviousRound;
+
+    constructor(
+        address _oracle,
+        uint256 _priceBoundLower,
+        uint256 _priceBoundUpper,
+        uint32 _timeout,
+        uint8 _outputDecimals,
+        uint32 _maxDeviation
+    ) {
+        oracle = AggregatorV3Interface(_oracle);
+        priceBoundLower = _priceBoundLower;
+        priceBoundUpper = _priceBoundUpper;
+        timeout = _timeout;
+        outputDecimals = _outputDecimals;
+        maxDeviationFromPreviousRound = _maxDeviation;
+    }
+
+    // ========================================= RATE FUNCTION =========================================
+
+    /**
+     * @notice Get the rate of some asset using Chainlink, and revert if any of the strict requirements are not met.
+     */
+    function getRate() public override view returns (uint256) {
+        ChainlinkResponse memory currentResponse = _getCurrentChainlinkResponse();
+        ChainlinkResponse memory prevResponse = _getPrevChainlinkResponse(currentResponse.roundId, currentResponse.decimals);
+
+        if (_chainlinkIsBroken(currentResponse, prevResponse)) revert OracleRateProvider__BadChainlinkResponse();
+        // previous line ensures `currentResponse.answer` is positive
+        uint256 price = uint256(currentResponse.answer);
+        price = _scaleChainlinkPriceByDecimals(price, currentResponse.decimals);
+
+        if (price < priceBoundLower || price > priceBoundUpper) revert OracleRateProvider__PriceOutOfBounds();
+        if (_chainlinkIsFrozen(currentResponse)) revert OracleRateProvider__PriceIsStale();
+        if (_chainlinkPriceChangeAboveMax(currentResponse, prevResponse)) revert OracleRateProvider__PriceChangeOutOfBounds();
+
+        return price;
+    }
+
+    // --- Helper functions ---
+
+    /**
+      * @notice Returns true if either current or previous Chainlink response contains invalid data.
+      */
+    function _chainlinkIsBroken(ChainlinkResponse memory _currentResponse, ChainlinkResponse memory _prevResponse) internal view returns (bool) {
+        /* Chainlink is considered broken if its current or previous round data is in any way bad. We check the previous round
+        * for two reasons:
+        *
+        * 1) It is necessary data for the price deviation check,
+        * and
+        * 2) Chainlink is the preferred primary oracle - having two consecutive valid round responses adds
+        * peace of mind when using or returning to Chainlink.
+        */
+        return _badChainlinkResponse(_currentResponse) || _badChainlinkResponse(_prevResponse);
+    }
+
+    /**
+      * @notice Checks single response for bad data
+      */
+    function _badChainlinkResponse(ChainlinkResponse memory _response) internal view returns (bool) {
+         // Check for response call reverted
+        if (!_response.success) {return true;}
+        // Check for an invalid roundId that is 0
+        if (_response.roundId == 0) {return true;}
+        // Check for an invalid timeStamp that is 0, or in the future
+        if (_response.timestamp == 0 || _response.timestamp > block.timestamp) {return true;}
+        // Check for non-positive price
+        if (_response.answer <= 0) {return true;}
+
+        return false;
+    }
+
+    /**
+      @notice Returns true if response is older than `timeout`
+      */
+    function _chainlinkIsFrozen(ChainlinkResponse memory _response) internal view returns (bool) {
+        return (block.timestamp - _response.timestamp) > timeout;
+    }
+
+    /**
+      @notice Returns true if % change in price from previous round to current is above `maxDeviationFromPreviousRound`.
+      If maxDeviationFromPreviousRound is e.g. 5_000 (50%), return true if price has more than doubled, or more than halved.
+      */
+    function _chainlinkPriceChangeAboveMax(ChainlinkResponse memory _currentResponse, ChainlinkResponse memory _prevResponse) internal view returns (bool) {
+        uint currentScaledPrice = _scaleChainlinkPriceByDecimals(uint256(_currentResponse.answer), _currentResponse.decimals);
+        uint prevScaledPrice = _scaleChainlinkPriceByDecimals(uint256(_prevResponse.answer), _prevResponse.decimals);
+
+        uint minPrice = Math.min(currentScaledPrice, prevScaledPrice);
+        uint maxPrice = Math.max(currentScaledPrice, prevScaledPrice);
+
+        /*
+        * Use the larger price as the denominator:
+        * - If price decreased, the percentage deviation is in relation to the the previous price.
+        * - If price increased, the percentage deviation is in relation to the current price.
+        */
+        uint percentDeviation = (maxPrice - minPrice) * 10_000 / maxPrice;
+
+        return percentDeviation > maxDeviationFromPreviousRound;
+    }
+
+    /**
+      @notice Scales `_price` to `outputDecimals`
+      @param _price ChainlinkResponse.answer
+      @param _answerDecimals ChainlinkResponse.decimals
+      */
+    function _scaleChainlinkPriceByDecimals(uint _price, uint _answerDecimals) internal view returns (uint) {
+        uint price;
+        if (_answerDecimals >= outputDecimals) {
+            price = _price / (10 ** (_answerDecimals - outputDecimals));
+        }
+        else if (_answerDecimals < outputDecimals) {
+            price = _price * (10 ** (outputDecimals - _answerDecimals));
+        }
+        return price;
+    }
+
+    // --- Oracle response wrapper functions ---
+
+    /**
+      @notice Gets latest Chainlink response
+      */
+    function _getCurrentChainlinkResponse() internal view returns (ChainlinkResponse memory chainlinkResponse) {
+        // First, try to get current decimal precision:
+        try oracle.decimals() returns (uint8 decimals) {
+            // If call to Chainlink succeeds, record the current decimal precision
+            chainlinkResponse.decimals = decimals;
+        } catch {
+            // If call to Chainlink aggregator reverts, return a zero response with success = false
+            return chainlinkResponse;
+        }
+
+        // Secondly, try to get latest price data:
+        try oracle.latestRoundData() returns
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 /* startedAt */,
+            uint256 timestamp,
+            uint80 /* answeredInRound */
+        )
+        {
+            // If call to Chainlink succeeds, return the response and success = true
+            chainlinkResponse.roundId = roundId;
+            chainlinkResponse.answer = answer;
+            chainlinkResponse.timestamp = timestamp;
+            chainlinkResponse.success = true;
+            return chainlinkResponse;
+        } catch {
+            // If call to Chainlink aggregator reverts, return a zero response with success = false
+            return chainlinkResponse;
+        }
+    }
+
+    /**
+      @notice Gets historical response from oracle using roundId immediately before latest
+      @param _currentRoundId currentResponse.roundId
+      @param _currentDecimals currentResponse.decimals
+      */
+    function _getPrevChainlinkResponse(uint80 _currentRoundId, uint8 _currentDecimals) internal view returns (ChainlinkResponse memory prevChainlinkResponse) {
+        /*
+        * NOTE: Chainlink only offers a current decimals() value - there is no way to obtain the decimal precision used in a 
+        * previous round.  We assume the decimals used in the previous round are the same as the current round.
+        */
+
+        // Try to get the price data from the previous round:
+        try oracle.getRoundData(_currentRoundId - 1) returns
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 /* startedAt */,
+            uint256 timestamp,
+            uint80 /* answeredInRound */
+        )
+        {
+            // If call to Chainlink succeeds, return the response and success = true
+            prevChainlinkResponse.roundId = roundId;
+            prevChainlinkResponse.answer = answer;
+            prevChainlinkResponse.timestamp = timestamp;
+            prevChainlinkResponse.decimals = _currentDecimals;
+            prevChainlinkResponse.success = true;
+            return prevChainlinkResponse;
+        } catch {
+            // If call to Chainlink aggregator reverts, return a zero response with success = false
+            return prevChainlinkResponse;
+        }
+    }
+}

--- a/src/helper/OracleRateProvider.sol
+++ b/src/helper/OracleRateProvider.sol
@@ -141,7 +141,7 @@ contract OracleRateProvider is IRateProvider {
       @param _answerDecimals ChainlinkResponse.decimals
       */
     function _scaleChainlinkPriceByDecimals(uint _price, uint _answerDecimals) internal view returns (uint) {
-        uint price;
+        uint price = _price;
         if (_answerDecimals >= outputDecimals) {
             price = _price / (10 ** (_answerDecimals - outputDecimals));
         }

--- a/src/helper/OracleRateProvider.sol
+++ b/src/helper/OracleRateProvider.sol
@@ -24,7 +24,7 @@ contract OracleRateProvider is IRateProvider {
 
     //============================== IMMUTABLES ===============================
     AggregatorV3Interface public immutable oracle; // Chainlink PriceAggregatorV3 oracle
-    GenericRateProviderWithDecimalScaling rateProvider; // We use this type to include outputDecimals function
+    GenericRateProviderWithDecimalScaling public immutable rateProvider; // We use this type to include outputDecimals function
     uint256 public immutable exchangeRateLowerBound;
     uint256 public immutable exchangeRateUpperBound;
     uint32 public immutable heartbeat;

--- a/test/AccountantWithOracleRateProvider.t.sol
+++ b/test/AccountantWithOracleRateProvider.t.sol
@@ -72,7 +72,7 @@ contract AccountantWithOracleRateProviderTest is Test, MerkleTreeHelper {
             address(0), // No additional rate provider
             0.95e6, // Lower bound: 0.95 USD
             1.05e6, // Upper bound: 1.05 USD
-            2 days, // 24 hour heartbeat
+            2 days, // 48 hour heartbeat
             6, // 6 decimals output
             5000 // 50% max deviation
         );
@@ -83,7 +83,7 @@ contract AccountantWithOracleRateProviderTest is Test, MerkleTreeHelper {
             address(0), // No additional rate provider
             0.95e18, // Lower bound: 0.95 USD
             1.05e18, // Upper bound: 1.05 USD
-            2 days, // 24 hour heartbeat
+            2 days, // 48 hour heartbeat
             18, // 18 decimals output
             5000 // 50% max deviation
         );
@@ -94,7 +94,7 @@ contract AccountantWithOracleRateProviderTest is Test, MerkleTreeHelper {
             address(daiOracleRateProvider), // Uses DAI rate provider
             0.95e18, // Lower bound: 0.95 USD (same as DAI)
             1.20e18, // Upper bound: 1.20 USD (higher than DAI due to savings rate)
-            2 days, // 24 hour heartbeat
+            2 days, // 48 hour heartbeat
             18, // 18 decimals output
             5000 // 50% max deviation
         );

--- a/test/AccountantWithOracleRateProvider.t.sol
+++ b/test/AccountantWithOracleRateProvider.t.sol
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {OracleRateProvider} from "src/helper/OracleRateProvider.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {RolesAuthority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {MockAggregator} from "test/mocks/MockAggregator.sol";
+
+import {Test, stdStorage, StdStorage, stdError} from "@forge-std/Test.sol";
+
+contract AccountantWithOracleRateProviderTest is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    BoringVault public boringVault;
+    AccountantWithRateProviders public accountant;
+    OracleRateProvider public usdtOracleRateProvider;
+    OracleRateProvider public daiOracleRateProvider;
+    address public payoutAddress = vm.addr(7777777);
+    RolesAuthority public rolesAuthority;
+
+    address public usdcWhale = 0x28C6c06298d514Db089934071355E5743bf21d60;
+
+    uint8 public constant MINTER_ROLE = 1;
+    uint8 public constant ADMIN_ROLE = 2;
+    uint8 public constant UPDATE_EXCHANGE_RATE_ROLE = 3;
+    uint8 public constant BORING_VAULT_ROLE = 4;
+
+    ERC20 internal USDC;
+    ERC20 internal USDT;
+    ERC20 internal DAI;
+    
+    // Chainlink oracle addresses for Ethereum mainnet
+    MockAggregator internal usdtOracle;
+    MockAggregator internal daiOracle;
+
+    function setUp() external {
+        setSourceChainName("mainnet");
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 19618964;
+        _startFork(rpcKey, blockNumber);
+
+        USDC = getERC20(sourceChain, "USDC");
+        USDT = getERC20(sourceChain, "USDT");
+        DAI = getERC20(sourceChain, "DAI");
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 6);
+
+        accountant = new AccountantWithRateProviders(
+            address(this), address(boringVault), payoutAddress, 1e6, address(USDC), 1.001e4, 0.999e4, 1, 0, 0
+        );
+
+        usdtOracle = new MockAggregator();
+        daiOracle = new MockAggregator();
+
+        // Create Oracle Rate Providers for USDT and DAI
+        // USDT Oracle Rate Provider (6 decimals output)
+        usdtOracleRateProvider = new OracleRateProvider(
+            address(usdtOracle),
+            address(0), // No additional rate provider
+            0.95e6, // Lower bound: 0.95 USD
+            1.05e6, // Upper bound: 1.05 USD
+            2 days, // 24 hour heartbeat
+            6, // 6 decimals output
+            5000 // 50% max deviation
+        );
+
+        // DAI Oracle Rate Provider (18 decimals output)
+        daiOracleRateProvider = new OracleRateProvider(
+            address(daiOracle),
+            address(0), // No additional rate provider
+            0.95e18, // Lower bound: 0.95 USD
+            1.05e18, // Upper bound: 1.05 USD
+            2 days, // 24 hour heartbeat
+            18, // 18 decimals output
+            5000 // 50% max deviation
+        );
+
+        vm.startPrank(usdcWhale);
+        USDC.safeTransfer(address(this), 1_000_000e6);
+        vm.stopPrank();
+        USDC.safeApprove(address(boringVault), 1_000_000e6);
+        boringVault.enter(address(this), USDC, 1_000_000e6, address(this), 1_000_000e6);
+
+        // Set rate provider data
+        accountant.setRateProviderData(USDT, false, address(usdtOracleRateProvider));
+        accountant.setRateProviderData(DAI, false, address(daiOracleRateProvider));
+
+        // Start accounting so we can claim fees during a test.
+        accountant.updatePlatformFee(0.01e4);
+
+        //vm.rollFork(19619262); // cast find-block 19618964 + 1 hour
+        skip(1 hours);
+        // Increase exchange rate by 5 bps.
+        uint96 newExchangeRate = uint96(1.0005e6);
+        accountant.updateExchangeRate(newExchangeRate);
+
+        //vm.rollFork(19626407); // cast find-block 19618964 + 25 hours
+        skip(1 days);
+
+        accountant.updateExchangeRate(newExchangeRate);
+
+        //vm.rollFork(19633555); // cast find-block 19618964 + 49 hours
+        skip(1 days);
+
+        _initOracle(usdtOracle);
+        _initOracle(daiOracle);
+    }
+
+    function testClaimFeesUsingBase() external {
+        // Set exchangeRate back to 1e6.
+        uint96 newExchangeRate = uint96(1e6);
+        accountant.updateExchangeRate(newExchangeRate);
+
+        (,, uint128 feesOwed,,,,,,,,,) = accountant.accountantState();
+
+        vm.startPrank(address(boringVault));
+        USDC.safeApprove(address(accountant), type(uint256).max);
+        // Claim fees.
+        accountant.claimFees(USDC);
+        vm.stopPrank();
+
+        assertEq(USDC.balanceOf(payoutAddress), feesOwed, "Should have claimed fees in USDC");
+    }
+
+    function testClaimFeesUsingUSDTWithOracle() external {
+        // Set exchangeRate back to 1e6.
+        uint96 newExchangeRate = uint96(1e6);
+        accountant.updateExchangeRate(newExchangeRate);
+
+        (,, uint128 feesOwed,,,,,,,,,) = accountant.accountantState();
+
+        deal(address(USDT), address(boringVault), 1_000_000e6);
+        vm.startPrank(address(boringVault));
+        USDT.safeApprove(address(accountant), type(uint256).max);
+        // Claim fees.
+        accountant.claimFees(USDT);
+        vm.stopPrank();
+
+        uint256 usdtRate = usdtOracleRateProvider.getRate();
+        uint256 expectedFeesOwed = uint256(feesOwed).mulDivDown(1e6, usdtRate);
+        uint256 actualUsdtFees = USDT.balanceOf(payoutAddress);
+        
+        assertApproxEqRel(actualUsdtFees, expectedFeesOwed, 0.01e18, "Should have claimed fees in USDT using oracle rate");
+    }
+
+    function testClaimFeesUsingDAIWithOracle() external {
+        // Set exchangeRate back to 1e6.
+        uint96 newExchangeRate = uint96(1e6);
+        accountant.updateExchangeRate(newExchangeRate);
+
+        (,, uint128 feesOwed,,,,,,,,,) = accountant.accountantState();
+
+        deal(address(DAI), address(boringVault), 1_000_000e18);
+        vm.startPrank(address(boringVault));
+        DAI.safeApprove(address(accountant), type(uint256).max);
+        // Claim fees.
+        accountant.claimFees(DAI);
+        vm.stopPrank();
+
+        uint256 daiRate = daiOracleRateProvider.getRate();
+        uint256 expectedFeesOwed = uint256(feesOwed).mulDivDown(1e18, 1e6); // Convert to 18 decimals
+        expectedFeesOwed = expectedFeesOwed.mulDivDown(1e18, daiRate); // Apply DAI rate
+        uint256 actualDaiFees = DAI.balanceOf(payoutAddress);
+        
+        assertApproxEqRel(actualDaiFees, expectedFeesOwed, 0.01e18, "Should have claimed fees in DAI using oracle rate");
+    }
+
+    function testRatesWithOracle() external {
+        // Set exchangeRate back to 1e6.
+        uint96 newExchangeRate = uint96(1e6);
+        accountant.updateExchangeRate(newExchangeRate);
+
+        // getRate and getRate in quote should work.
+        uint256 rate = accountant.getRate();
+        uint256 expected_rate = 1e6;
+        assertEq(rate, expected_rate, "Rate should be expected rate");
+        rate = accountant.getRateSafe();
+        assertEq(rate, expected_rate, "Rate should be expected rate");
+
+        uint256 rateInQuote = accountant.getRateInQuote(USDC);
+        expected_rate = 1e6;
+        assertEq(rateInQuote, expected_rate, "Rate should be expected rate");
+
+        // For USDT with oracle
+        rateInQuote = accountant.getRateInQuote(USDT);
+        uint256 usdtOracleRate = usdtOracleRateProvider.getRate();
+        expected_rate = uint256(1e6).mulDivDown(usdtOracleRate, 1e6);
+        assertApproxEqRel(rateInQuote, expected_rate, 0.001e18 /* 0.1% */, "Rate should be expected rate for USDT with oracle");
+
+        // For DAI with oracle
+        rateInQuote = accountant.getRateInQuote(DAI);
+        uint256 daiOracleRate = daiOracleRateProvider.getRate();
+        expected_rate = uint256(1e18).mulDivDown(daiOracleRate, 1e18);
+        assertApproxEqRel(rateInQuote, expected_rate, 0.001e18 /* 0.1% */, "Rate should be expected rate for DAI with oracle");
+    }
+
+    function testOracleRateProviderDirectly() external view {
+        // Test USDT Oracle Rate Provider
+        uint256 usdtRate = usdtOracleRateProvider.getRate();
+        assertGt(usdtRate, 0, "USDT rate should be greater than 0");
+        assertGe(usdtRate, 0.95e6, "USDT rate should be within lower bound");
+        assertLe(usdtRate, 1.05e6, "USDT rate should be within upper bound");
+
+        // Test DAI Oracle Rate Provider
+        uint256 daiRate = daiOracleRateProvider.getRate();
+        assertGt(daiRate, 0, "DAI rate should be greater than 0");
+        assertGe(daiRate, 0.95e18, "DAI rate should be within lower bound");
+        assertLe(daiRate, 1.05e18, "DAI rate should be within upper bound");
+
+        // Verify oracle responses are fresh
+        (, , , uint256 usdtTimestamp, ) = usdtOracle.latestRoundData();
+        assertGt(usdtTimestamp, 0, "USDT oracle timestamp should be valid");
+        assertLe(block.timestamp - usdtTimestamp, 86400, "USDT oracle data should be fresh");
+
+        (, , , uint256 daiTimestamp, ) = daiOracle.latestRoundData();
+        assertGt(daiTimestamp, 0, "DAI oracle timestamp should be valid");
+        assertLe(block.timestamp - daiTimestamp, 86400, "DAI oracle data should be fresh");
+    }
+
+    function testOracleRateProviderRevertConditions() external {
+        // Test with invalid oracle address - should revert when getting rate
+        OracleRateProvider invalidOracleProvider = new OracleRateProvider(
+            address(0x123), // Invalid oracle address
+            address(0),
+            0.95e6,
+            1.05e6,
+            86400,
+            6,
+            5000
+        );
+
+        vm.expectRevert();
+        invalidOracleProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_LatestRoundDataReverts() external {
+        // Initialize oracle first
+        _initOracle(usdtOracle);
+        
+        // Make latestRoundData revert
+        usdtOracle.setLatestRevert();
+        
+        // This will cause arithmetic underflow when trying to get previous round data
+        vm.expectRevert(stdError.arithmeticError);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_GetRoundDataReverts() external {
+        // Make getRoundData revert
+        usdtOracle.setPrevRevert();
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_DecimalsReverts() external {
+        // Initialize oracle first
+        _initOracle(usdtOracle);
+        
+        // Make decimals() revert
+        usdtOracle.setDecimalsRevert();
+        
+        // This will cause arithmetic underflow when trying to get previous round with invalid decimals
+        vm.expectRevert(stdError.arithmeticError);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_ZeroRoundId() external {
+        // Initialize oracle first
+        _initOracle(usdtOracle);
+        
+        // Set roundId to 0 - this will cause arithmetic underflow when trying to get previous round
+        usdtOracle.setLatestRoundId(0);
+        
+        // This will actually cause an arithmetic underflow panic, not BadChainlinkResponse
+        vm.expectRevert(stdError.arithmeticError);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_ZeroTimestamp() external {
+        // Set timestamp to 0
+        usdtOracle.setUpdateTime(0);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_FutureTimestamp() external {
+        // Set timestamp in the future
+        usdtOracle.setUpdateTime(block.timestamp + 1 hours);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_ZeroPrice() external {
+        // Set price to 0
+        usdtOracle.setPrice(0);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_NegativePrice() external {
+        // Set price to negative value
+        usdtOracle.setPrice(-1e8);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_PrevRoundZeroRoundId() external {
+        // Set previous round ID to 0
+        usdtOracle.setPrevRoundId(0);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_PrevRoundZeroPrice() external {
+        // Set previous price to 0
+        usdtOracle.setPrevPrice(0);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testBadChainlinkResponse_PrevRoundNegativePrice() external {
+        // Set previous price to negative value
+        usdtOracle.setPrevPrice(-1e8);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__BadChainlinkResponse.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testPriceIsStale() external {
+        // Initialize oracle with fresh data
+        _initOracle(usdtOracle);
+        
+        // Move forward in time beyond the heartbeat (2 days)
+        skip(2 days + 1 hours);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceIsStale.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testPriceChangeOutOfBounds_PriceIncreaseAboveMax() external {
+        // Initialize oracle
+        _initOracle(usdtOracle);
+        
+        // Set current price much higher than previous (more than 50% deviation)
+        // but still within the bounds (0.95-1.05)
+        // Previous price: 1e8 (1.0 USD), new price: 1.8e8 (1.8 USD) 
+        // This is 80% increase, above 50% max, but 1.8 is above upper bound of 1.05
+        // Let's use 1.04 and 0.65 to trigger price change bounds
+        usdtOracle.setPrice(1.04e8); // 1.04 USD (within bounds)
+        usdtOracle.setPrevPrice(0.65e8); // 0.65 USD (below bounds but that's OK for prev)
+        
+        // This should trigger PriceChangeOutOfBounds because (1.04-0.65)/1.04 * 10000 = 3750 < 5000
+        // Actually let's try the reverse: 1.04 -> 0.65 is 37.5% decrease
+        // Let's use values that will trigger > 50% change
+        usdtOracle.setPrice(1.02e8); // 1.02 USD (within bounds)
+        usdtOracle.setPrevPrice(0.49e8); // 0.49 USD - this creates > 50% change
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceChangeOutOfBounds.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testPriceChangeOutOfBounds_PriceDecreaseAboveMax() external {
+        // Initialize oracle
+        _initOracle(usdtOracle);
+        
+        // Set current price much lower than previous (more than 50% deviation)
+        // Previous price: 2e8, new price: 1e8 (50% decrease, exactly at limit)
+        // Let's make it 60% decrease to trigger the revert
+        usdtOracle.setPrice(8e7); // 0.8 * 1e8
+        usdtOracle.setPrevPrice(2e8); // 2 * 1e8
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceChangeOutOfBounds.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testPriceOutOfBounds_BelowLowerBound() external {
+        // Initialize oracle
+        _initOracle(usdtOracle);
+        
+        // Set price below lower bound (0.95e6 for 6 decimals)
+        // Price of 0.9e8 in 8 decimals should scale to 0.9e6 in 6 decimals, which is below 0.95e6
+        usdtOracle.setPrice(0.9e8);
+        usdtOracle.setPrevPrice(0.9e8);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceOutOfBounds.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testPriceOutOfBounds_AboveUpperBound() external {
+        // Initialize oracle
+        _initOracle(usdtOracle);
+        
+        // Set price above upper bound (1.05e6 for 6 decimals)
+        // Price of 1.1e8 in 8 decimals should scale to 1.1e6 in 6 decimals, which is above 1.05e6
+        usdtOracle.setPrice(1.1e8);
+        usdtOracle.setPrevPrice(1.1e8);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceOutOfBounds.selector);
+        usdtOracleRateProvider.getRate();
+    }
+
+    function testPriceOutOfBounds_DAI_BelowLowerBound() external {
+        // Initialize oracle
+        _initOracle(daiOracle);
+        
+        // Set price below lower bound (0.95e18 for 18 decimals)
+        // Price of 0.9e8 in 8 decimals should scale to 0.9e18 in 18 decimals, which is below 0.95e18
+        daiOracle.setPrice(0.9e8);
+        daiOracle.setPrevPrice(0.9e8);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceOutOfBounds.selector);
+        daiOracleRateProvider.getRate();
+    }
+
+    function testPriceOutOfBounds_DAI_AboveUpperBound() external {
+        // Initialize oracle
+        _initOracle(daiOracle);
+        
+        // Set price above upper bound (1.05e18 for 18 decimals)
+        // Price of 1.1e8 in 8 decimals should scale to 1.1e18 in 18 decimals, which is above 1.05e18
+        daiOracle.setPrice(1.1e8);
+        daiOracle.setPrevPrice(1.1e8);
+        
+        vm.expectRevert(OracleRateProvider.OracleRateProvider__PriceOutOfBounds.selector);
+        daiOracleRateProvider.getRate();
+    }
+
+    function testSuccessfulGetRate_WithinBounds() external {
+        // Initialize oracle with valid data
+        _initOracle(usdtOracle);
+        
+        // Set price within bounds and deviation limits
+        usdtOracle.setPrice(1e8); // 1.0 USD
+        usdtOracle.setPrevPrice(1.01e8); // 1.01 USD (1% change, within 50% limit)
+        
+        uint256 rate = usdtOracleRateProvider.getRate();
+        assertEq(rate, 1e6, "Rate should be 1e6 for 1 USD with 6 decimals");
+    }
+
+    function testSuccessfulGetRate_MaxAllowedDeviation() external {
+        // Initialize oracle with valid data
+        _initOracle(usdtOracle);
+        
+        // Set price with deviation just under 50% and within bounds
+        // From 1e8 to 1.04e8 = 4% increase (well within 50% limit and 1.04 < 1.05 upper bound)
+        usdtOracle.setPrice(1.04e8);
+        usdtOracle.setPrevPrice(1e8);
+        
+        uint256 rate = usdtOracleRateProvider.getRate();
+        assertEq(rate, 1.04e6, "Rate should be 1.04e6 for 1.04 USD with 6 decimals");
+    }
+
+    // ========================================= HELPER FUNCTIONS =========================================
+
+    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+        if (blockNumber == 0) {
+            forkId = vm.createFork(vm.envString(rpcKey)); // Use latest block
+        } else {
+            forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+        }
+        vm.selectFork(forkId);
+    }
+
+    function _initOracle(MockAggregator oracle) internal {
+        oracle.setPrice(1e8);
+        oracle.setPrevPrice(1e8);
+        oracle.setUpdateTime(block.timestamp);
+        oracle.setPrevUpdateTime(block.timestamp - 1 days);
+        oracle.setLatestRoundId(2);
+        oracle.setPrevRoundId(1);
+    }
+} 

--- a/test/mocks/MockAggregator.sol
+++ b/test/mocks/MockAggregator.sol
@@ -90,7 +90,7 @@ contract MockAggregator is AggregatorV3Interface {
     }
 
     function getRoundData(
-        uint80
+        uint80 /* roundId */
     )
         external
         view

--- a/test/mocks/MockAggregator.sol
+++ b/test/mocks/MockAggregator.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {AggregatorV3Interface} from "lib/ccip/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+contract MockAggregator is AggregatorV3Interface {
+    // storage variables to hold the mock data
+    uint8 private decimalsVal = 8;
+    int private price;
+    int private prevPrice;
+    uint private updateTime;
+    uint private prevUpdateTime;
+
+    uint80 private latestRoundId;
+    uint80 private prevRoundId;
+
+    bool latestRevert;
+    bool prevRevert;
+    bool decimalsRevert;
+
+    // --- Functions ---
+
+    function setDecimals(uint8 _decimals) external {
+        decimalsVal = _decimals;
+    }
+
+    function setPrice(int _price) external {
+        price = _price;
+    }
+
+    function setPrevPrice(int _prevPrice) external {
+        prevPrice = _prevPrice;
+    }
+
+    function setPrevUpdateTime(uint _prevUpdateTime) external {
+        prevUpdateTime = _prevUpdateTime;
+    }
+
+    function setUpdateTime(uint _updateTime) external {
+        updateTime = _updateTime;
+    }
+
+    function setLatestRevert() external {
+        latestRevert = !latestRevert;
+    }
+
+    function setPrevRevert() external {
+        prevRevert = !prevRevert;
+    }
+
+    function setDecimalsRevert() external {
+        decimalsRevert = !decimalsRevert;
+    }
+
+    function setLatestRoundId(uint80 _latestRoundId) external {
+        latestRoundId = _latestRoundId;
+    }
+
+    function setPrevRoundId(uint80 _prevRoundId) external {
+        prevRoundId = _prevRoundId;
+    }
+
+    // --- Getters that adhere to the AggregatorV3 interface ---
+
+    function decimals() external view override returns (uint8) {
+        if (decimalsRevert) {
+            require(1 == 0, "decimals reverted");
+        }
+
+        return decimalsVal;
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        if (latestRevert) {
+            require(1 == 0, "latestRoundData reverted");
+        }
+
+        return (latestRoundId, price, 0, updateTime, 0);
+    }
+
+    function getRoundData(
+        uint80
+    )
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        if (prevRevert) {
+            require(1 == 0, "getRoundData reverted");
+        }
+
+        return (prevRoundId, prevPrice, 0, prevUpdateTime, 0);
+    }
+
+    function description() external pure override returns (string memory) {
+        return "";
+    }
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+}


### PR DESCRIPTION
First draft of the implementation of the OracleRateProvider contract outlined in the software design document, complete with tests. Includes all requested features with the following discrepancies:

- no `baseToken` or `quoteToken`. Unclear why these were requested, perhaps for decimal conversions? Instead input decimals are retrieved directly from the oracle (Chainlink) and output decimals are specified by `outputDecimals` immutable.
- an additional safety measure for percentage price change between two latest Chainlink rounds has been added (similar to the check in Liquity's PriceFeed contract)
- OracleRateProvider now contains a `rateProvider` which can be used to optionally daisy chain between e.g. stETH > ETH > USD > USDC