### PR TITLE
Update LiquidKatanaETH Katana Merkle Root

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@
 # This overrides the `auto_detect_solc` value
 solc_version = '0.8.21'
 auto_detect_solc = false 
-evm_version = 'london'
+evm_version = 'cancun'
 optimizer = true
 optimizer_runs = 200 
 fs_permissions = [{ access = "read-write", path = "./" }]

--- a/leafs/Katana/LiquidKatanaETHMerkleRoot.json
+++ b/leafs/Katana/LiquidKatanaETHMerkleRoot.json
@@ -1,255 +1,950 @@
 {
-  "metadata": {
-    "AccountantAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d",
-    "BoringVaultAddress": "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
-    "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-    "DigestComposition": [
-      "Bytes20(DECODER_AND_SANITIZER_ADDRESS)",
-      "Bytes20(TARGET_ADDRESS)",
-      "Bytes1(CAN_SEND_VALUE)",
-      "Bytes4(TARGET_FUNCTION_SELECTOR)",
-      "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
+    "metadata": {
+        "AccountantAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d",
+        "BoringVaultAddress": "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+        "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+        "DigestComposition": [
+            "Bytes20(DECODER_AND_SANITIZER_ADDRESS)",
+            "Bytes20(TARGET_ADDRESS)",
+            "Bytes1(CAN_SEND_VALUE)",
+            "Bytes4(TARGET_FUNCTION_SELECTOR)",
+            "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
+        ],
+        "LeafCount": 34,
+        "ManageRoot": "0x6767adc9cc25ebadd6f5d74ff531b4ac087cfc6679bb03861efafdcb69d3d905",
+        "ManagerAddress": "0x51CdEcC111c21BED72Ab99f415Bab6d35984BfEB",
+        "TreeCapacity": 64
+    },
+    "leafs": [
+        {
+            "AddressArguments": [],
+            "CanSendValue": true,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Wrap Native to vbETH",
+            "FunctionSelector": "0xd0e30db0",
+            "FunctionSignature": "deposit()",
+            "LeafDigest": "0xb5e3ae100a4659f3de86c891bdf4fd5abaf3f471a8f800e446c67f8d1b24a4ac",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Unwrap vbETH to Native",
+            "FunctionSelector": "0x2e1a7d4d",
+            "FunctionSignature": "withdraw(uint256)",
+            "LeafDigest": "0xd06bab1ac977884de89ea7a96b5d7641b0ec700c7fd46ce279c17f1812b7fcbd",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": ["0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve zkEVM Compatible Bridge to spendvbETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x42f2283b62fc9c60dd50f394a76e104b433778d977833c38a6536aefd24aeab3",
+            "PackedArgumentAddresses": "0x2a3dd3eb832af982ec71669e178424b10dca2ede",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": [
+                "0x0000000000000000000000000000000000000000",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Bridge vbETH using zkEVM Compatible Bridge",
+            "FunctionSelector": "0xcd586579",
+            "FunctionSignature": "bridgeAsset(uint32,address,uint256,address,bool,bytes)",
+            "LeafDigest": "0x90fa3238e07f45ee421e57c4ed40e4d0ceef2ece5415e23a21e83d1bd4789e9f",
+            "PackedArgumentAddresses": "0x000000000000000000000000000000000000000069d210d3b60e939bfa6e87cccc4fab7e8f44c16bee7d8bcfb72bc1880d0cf19822eb0a2e6577ab62",
+            "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
+        },
+        {
+            "AddressArguments": [
+                "0x0000000000000000000000000000000000000014",
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x0000000000000000000000000000000000000014",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Claim  vbETH from zkEVM Compatible Bridge",
+            "FunctionSelector": "0xccaa2d11",
+            "FunctionSignature": "claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)",
+            "LeafDigest": "0x6eb2581581b1d6e054bfa79b62c9da0c1a2add156dd2f558c09426cbf5503769",
+            "PackedArgumentAddresses": "0x0000000000000000000000000000000000000014ee7d8bcfb72bc1880d0cf19822eb0a2e6577ab62000000000000000000000000000000000000001469d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
+        },
+        {
+            "AddressArguments": ["0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve zkEVM Compatible Bridge to spendweETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x06a9dab1e1768cc997a344eee16c50713de3158081895bced3f774a62f74fb61",
+            "PackedArgumentAddresses": "0x2a3dd3eb832af982ec71669e178424b10dca2ede",
+            "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
+        },
+        {
+            "AddressArguments": [
+                "0x0000000000000000000000000000000000000000",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Bridge weETH using zkEVM Compatible Bridge",
+            "FunctionSelector": "0xcd586579",
+            "FunctionSignature": "bridgeAsset(uint32,address,uint256,address,bool,bytes)",
+            "LeafDigest": "0x9bf4e87940dab6bae6f3470a8165a2811bf8e62c0ef6f105fbbd9f014750ee26",
+            "PackedArgumentAddresses": "0x000000000000000000000000000000000000000069d210d3b60e939bfa6e87cccc4fab7e8f44c16b9893989433e7a383cb313953e4c2365107dc19a7",
+            "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
+        },
+        {
+            "AddressArguments": [
+                "0x0000000000000000000000000000000000000014",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0x0000000000000000000000000000000000000014",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Claim  weETH from zkEVM Compatible Bridge",
+            "FunctionSelector": "0xccaa2d11",
+            "FunctionSignature": "claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)",
+            "LeafDigest": "0xb7bb3f83025d8977f11ae359a7320b4464361a009c0687442a3dc73ea878bbd0",
+            "PackedArgumentAddresses": "0x00000000000000000000000000000000000000149893989433e7a383cb313953e4c2365107dc19a7000000000000000000000000000000000000001469d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
+        },
+        {
+            "AddressArguments": ["0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve Accountant to spend vbETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x60fee7d206c56b7d8eb44e5a790fdad8812652940de58659fe98a8dcf911742e",
+            "PackedArgumentAddresses": "0xfcb9a6bf02c43f9e38bb102fd960cc1e738e787d",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": ["0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve Accountant to spend weETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x15f322c2f988db45df8fca37067ce8c3f84c728a736a90483ce97dfe57f5d2cc",
+            "PackedArgumentAddresses": "0xfcb9a6bf02c43f9e38bb102fd960cc1e738e787d",
+            "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
+        },
+        {
+            "AddressArguments": ["0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Claim fees in vbETH",
+            "FunctionSelector": "0x15a0ea6a",
+            "FunctionSignature": "claimFees(address)",
+            "LeafDigest": "0x19579e36dd718352aaa57f5bc2294fe312f22ab056e552d747eea95d5e6e1f6d",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab62",
+            "TargetAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"
+        },
+        {
+            "AddressArguments": ["0x9893989433e7a383Cb313953e4c2365107dc19a7"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Claim fees in weETH",
+            "FunctionSelector": "0x15a0ea6a",
+            "FunctionSignature": "claimFees(address)",
+            "LeafDigest": "0x67b4ddf12b6b93804ed2f175983a3ddbbe1e105e629f4e355df8be40cafb1293",
+            "PackedArgumentAddresses": "0x9893989433e7a383cb313953e4c2365107dc19a7",
+            "TargetAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"
+        },
+        {
+            "AddressArguments": ["0x2659C6085D26144117D904C46B48B6d180393d27"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve UniswapV3 Router to spend weETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x5e4ed732b3ba79e90991f75e56229a630a08af6df5fd8bd371b9d51c62c39b6d",
+            "PackedArgumentAddresses": "0x2659c6085d26144117d904c46b48b6d180393d27",
+            "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
+        },
+        {
+            "AddressArguments": ["0x2659C6085D26144117D904C46B48B6d180393d27"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve UniswapV3 Router to spend vbETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x06511ed6cc6874dba8acdada52225d31babe28839bbdd75abcd82d3bfd1e56cf",
+            "PackedArgumentAddresses": "0x2659c6085d26144117d904c46b48b6d180393d27",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": [
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Mint UniswapV3 weETH vbETH position",
+            "FunctionSelector": "0x88316456",
+            "FunctionSignature": "mint((address,address,uint24,int24,int24,uint256,uint256,uint256,uint256,address,uint256))",
+            "LeafDigest": "0xd6babbc90075f38900dc27ef3d4dd5baf1e55728f5e98ecfe4eac90c3a5bfe47",
+            "PackedArgumentAddresses": "0x9893989433e7a383cb313953e4c2365107dc19a7ee7d8bcfb72bc1880d0cf19822eb0a2e6577ab6269d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": [
+                "0x0000000000000000000000000000000000000000",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Add liquidity to UniswapV3 weETH vbETH position",
+            "FunctionSelector": "0x219f5d17",
+            "FunctionSignature": "increaseLiquidity((uint256,uint256,uint256,uint256,uint256,uint256))",
+            "LeafDigest": "0x6a2d184d35f9884da4ee45f897ef8923cd27fa859a2642b566051f315e625fd5",
+            "PackedArgumentAddresses": "0x00000000000000000000000000000000000000009893989433e7a383cb313953e4c2365107dc19a7ee7d8bcfb72bc1880d0cf19822eb0a2e6577ab6269d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": [
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Swap weETH for vbETH using UniswapV3 router",
+            "FunctionSelector": "0xc04b8d59",
+            "FunctionSignature": "exactInput((bytes,address,uint256,uint256,uint256))",
+            "LeafDigest": "0xdd6184f995514fc95d23c0335fe649e84422871dcd2023e8a440e8bc1c7d6444",
+            "PackedArgumentAddresses": "0x9893989433e7a383cb313953e4c2365107dc19a7ee7d8bcfb72bc1880d0cf19822eb0a2e6577ab6269d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Swap vbETH for weETH using UniswapV3 router",
+            "FunctionSelector": "0xc04b8d59",
+            "FunctionSignature": "exactInput((bytes,address,uint256,uint256,uint256))",
+            "LeafDigest": "0x07c2ce4cdaedb9cd980d1eafac1439c74b29d58b5a4fdb6dfb4041a178505ac7",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a769d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": ["0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Remove liquidity from UniswapV3 position",
+            "FunctionSelector": "0x0c49ccbe",
+            "FunctionSignature": "decreaseLiquidity((uint256,uint128,uint256,uint256,uint256))",
+            "LeafDigest": "0x52be092cc24aa556bdfb855f27efab4c6f178b851d22ad549323058c4e0cd3a3",
+            "PackedArgumentAddresses": "0x69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": [
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Collect fees from UniswapV3 position",
+            "FunctionSelector": "0xfc6f7865",
+            "FunctionSignature": "collect((uint256,address,uint128,uint128))",
+            "LeafDigest": "0xa12cbab03835228745f549608b470797ce058c89c4dc0e2aad5d14f120812ae3",
+            "PackedArgumentAddresses": "0x69d210d3b60e939bfa6e87cccc4fab7e8f44c16b69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Burn UniswapV3 position",
+            "FunctionSelector": "0x42966c68",
+            "FunctionSignature": "burn(uint256)",
+            "LeafDigest": "0x2b5f62158a1d206a86fec983045aa30ccb8c64d291e4bd4847104e7c1afae2db",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+        },
+        {
+            "AddressArguments": ["0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve MorhoBlue to spend vbETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x9550c88204c5c374d3d552e6bb399c43abfd500e3d04bd4dbafa38d7ff87eb1b",
+            "PackedArgumentAddresses": "0xd50f2dfffd62f94ee4aed9ca05c61d0753268abc",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xD0457014ae86DF159482Ad6ddaD9bB6827DF4bc9",
+                "0x4F708C0ae7deD3d74736594C2109C2E3c065B428",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Supply vbETH to MorphoBlue weETH/vbETH 91.50 LLTV market",
+            "FunctionSelector": "0xa99aad89",
+            "FunctionSignature": "supply((address,address,address,address,uint256),uint256,uint256,address,bytes)",
+            "LeafDigest": "0xa3b5e217ca88843c77eeb2eac1d8790dc2200c7bc2add643cece29d3a1209de9",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a7d0457014ae86df159482ad6ddad9bb6827df4bc94f708c0ae7ded3d74736594c2109c2e3c065b42869d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xD0457014ae86DF159482Ad6ddaD9bB6827DF4bc9",
+                "0x4F708C0ae7deD3d74736594C2109C2E3c065B428",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Withdraw vbETH from MorphoBlue weETH/vbETH 91.50 LLTV market",
+            "FunctionSelector": "0x5c2bea49",
+            "FunctionSignature": "withdraw((address,address,address,address,uint256),uint256,uint256,address,address)",
+            "LeafDigest": "0x9d5ae5afefbc845cb22df0ff7392fb35e036755443f1e435068707480265f9df",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a7d0457014ae86df159482ad6ddad9bb6827df4bc94f708c0ae7ded3d74736594c2109c2e3c065b42869d210d3b60e939bfa6e87cccc4fab7e8f44c16b69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"
+        },
+        {
+            "AddressArguments": ["0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve MorhoBlue to spend weETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0xeb9720e77a7e214bf5275b5784b022766ea8c33de1add8a04f121b703578bbb2",
+            "PackedArgumentAddresses": "0xd50f2dfffd62f94ee4aed9ca05c61d0753268abc",
+            "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xD0457014ae86DF159482Ad6ddaD9bB6827DF4bc9",
+                "0x4F708C0ae7deD3d74736594C2109C2E3c065B428",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Supply weETH to MorphoBlue weETH/vbETH 91.50 LLTV market",
+            "FunctionSelector": "0x238d6579",
+            "FunctionSignature": "supplyCollateral((address,address,address,address,uint256),uint256,address,bytes)",
+            "LeafDigest": "0xf9af12692d6a2de52cce808d4ac069474d2874579b7739634487ddb01f3d8d57",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a7d0457014ae86df159482ad6ddad9bb6827df4bc94f708c0ae7ded3d74736594c2109c2e3c065b42869d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xD0457014ae86DF159482Ad6ddaD9bB6827DF4bc9",
+                "0x4F708C0ae7deD3d74736594C2109C2E3c065B428",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Borrow vbETH from MorphoBlue weETH/vbETH 91.50 LLTV market",
+            "FunctionSelector": "0x50d8cd4b",
+            "FunctionSignature": "borrow((address,address,address,address,uint256),uint256,uint256,address,address)",
+            "LeafDigest": "0xdf2af44638077928ca110165147e1cbe5a7e631f6f84bdd5aecb17586fc421dc",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a7d0457014ae86df159482ad6ddad9bb6827df4bc94f708c0ae7ded3d74736594c2109c2e3c065b42869d210d3b60e939bfa6e87cccc4fab7e8f44c16b69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xD0457014ae86DF159482Ad6ddaD9bB6827DF4bc9",
+                "0x4F708C0ae7deD3d74736594C2109C2E3c065B428",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Repay vbETH to MorphoBlue weETH/vbETH 91.50 LLTV market",
+            "FunctionSelector": "0x20b76e81",
+            "FunctionSignature": "repay((address,address,address,address,uint256),uint256,uint256,address,bytes)",
+            "LeafDigest": "0xe45a9a423777d60b793a4fadb9c9fb68600c951c232398a2bdf9ee6a2d052dd3",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a7d0457014ae86df159482ad6ddad9bb6827df4bc94f708c0ae7ded3d74736594c2109c2e3c065b42869d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"
+        },
+        {
+            "AddressArguments": [
+                "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
+                "0x9893989433e7a383Cb313953e4c2365107dc19a7",
+                "0xD0457014ae86DF159482Ad6ddaD9bB6827DF4bc9",
+                "0x4F708C0ae7deD3d74736594C2109C2E3c065B428",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Withdraw weETH from MorphoBlue weETH/vbETH 91.50 LLTV market",
+            "FunctionSelector": "0x8720316d",
+            "FunctionSignature": "withdrawCollateral((address,address,address,address,uint256),uint256,address,address)",
+            "LeafDigest": "0x972716d16451f1036307e149aeea1a086b770919a55c5fa8efd0b6c60e0448dd",
+            "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a7d0457014ae86df159482ad6ddad9bb6827df4bc94f708c0ae7ded3d74736594c2109c2e3c065b42869d210d3b60e939bfa6e87cccc4fab7e8f44c16b69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc"
+        },
+        {
+            "AddressArguments": ["0xC5e7AB07030305fc925175b25B93b285d40dCdFf"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve gtWETH to spend vbETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x7d122f163f82d42298d36e6b143e89f0bcec30c2ba60fac2d5fa3f753806dd4b",
+            "PackedArgumentAddresses": "0xc5e7ab07030305fc925175b25b93b285d40dcdff",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": ["0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Deposit vbETH for gtWETH",
+            "FunctionSelector": "0x6e553f65",
+            "FunctionSignature": "deposit(uint256,address)",
+            "LeafDigest": "0x4a3b78d0e42e1f3ff963711c2e0f7f6e4ec235c29cd4b338505c5481a6022e14",
+            "PackedArgumentAddresses": "0x69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xC5e7AB07030305fc925175b25B93b285d40dCdFf"
+        },
+        {
+            "AddressArguments": [
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Withdraw vbETH from gtWETH",
+            "FunctionSelector": "0xb460af94",
+            "FunctionSignature": "withdraw(uint256,address,address)",
+            "LeafDigest": "0xd11b5271a921b24d66d310384f4defb1da3666592b1abb31ab6bc689b7f5790c",
+            "PackedArgumentAddresses": "0x69d210d3b60e939bfa6e87cccc4fab7e8f44c16b69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xC5e7AB07030305fc925175b25B93b285d40dCdFf"
+        },
+        {
+            "AddressArguments": ["0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Mint gtWETH using vbETH",
+            "FunctionSelector": "0x94bf804d",
+            "FunctionSignature": "mint(uint256,address)",
+            "LeafDigest": "0x965d6db9ac146206bb39d4c00a46f7f1c8a4ac7f891807a0d93118911926639c",
+            "PackedArgumentAddresses": "0x69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xC5e7AB07030305fc925175b25B93b285d40dCdFf"
+        },
+        {
+            "AddressArguments": [
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
+                "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Redeem gtWETH for vbETH",
+            "FunctionSelector": "0xba087652",
+            "FunctionSignature": "redeem(uint256,address,address)",
+            "LeafDigest": "0x31d7fdd9bc829c10b4689481403f587e279cf708f576fec34827a0f8e096ef14",
+            "PackedArgumentAddresses": "0x69d210d3b60e939bfa6e87cccc4fab7e8f44c16b69d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
+            "TargetAddress": "0xC5e7AB07030305fc925175b25B93b285d40dCdFf"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
+            "Description": "",
+            "FunctionSelector": "0xc5d24601",
+            "FunctionSignature": "",
+            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x0000000000000000000000000000000000000000"
+        }
     ],
-    "LeafCount": 12,
-    "ManageRoot": "0x0449644fb5bad3c61b25549c6a39e249cd59932c0c81cf5e2014c06926054768",
-    "ManagerAddress": "0x51CdEcC111c21BED72Ab99f415Bab6d35984BfEB",
-    "TreeCapacity": 16
-  },
-  "leafs": [
-    {
-      "AddressArguments": [],
-      "CanSendValue": true,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Wrap Native to vbETH",
-      "FunctionSelector": "0xd0e30db0",
-      "FunctionSignature": "deposit()",
-      "LeafDigest": "0xddf3d0293e509076ceeeba3acf1618b31f38d31abcdd04729ba4e469213b69ab",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Unwrap vbETH to Native",
-      "FunctionSelector": "0x2e1a7d4d",
-      "FunctionSignature": "withdraw(uint256)",
-      "LeafDigest": "0xee7d99d2e9fd00d3f47cbd759c0708dc56c3ec26d2c5972dfd42b00ffe70feba",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
-    },
-    {
-      "AddressArguments": ["0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Approve zkEVM Compatible Bridge to spendvbETH",
-      "FunctionSelector": "0x095ea7b3",
-      "FunctionSignature": "approve(address,uint256)",
-      "LeafDigest": "0x6eddaa181f7383888dfe9ec5044f7fc61bf0dccf767a2991ab30d5e6c1edef90",
-      "PackedArgumentAddresses": "0x2a3dd3eb832af982ec71669e178424b10dca2ede",
-      "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
-    },
-    {
-      "AddressArguments": [
-        "0x0000000000000000000000000000000000000000",
-        "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
-        "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
-      ],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Bridge vbETH using zkEVM Compatible Bridge",
-      "FunctionSelector": "0xcd586579",
-      "FunctionSignature": "bridgeAsset(uint32,address,uint256,address,bool,bytes)",
-      "LeafDigest": "0x59ce08fffd7a2b2065c718953af35b707e57beceb449ecf8c2da8e9a4ab3a742",
-      "PackedArgumentAddresses": "0x000000000000000000000000000000000000000069d210d3b60e939bfa6e87cccc4fab7e8f44c16bee7d8bcfb72bc1880d0cf19822eb0a2e6577ab62",
-      "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
-    },
-    {
-      "AddressArguments": [
-        "0x0000000000000000000000000000000000000014",
-        "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
-        "0x0000000000000000000000000000000000000014",
-        "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
-      ],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Claim  vbETH from zkEVM Compatible Bridge",
-      "FunctionSelector": "0xccaa2d11",
-      "FunctionSignature": "claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)",
-      "LeafDigest": "0x7e1fcbb06dc42242dff94f0815567d236bc7a4ab66dfaec0ce66348c22ec2c62",
-      "PackedArgumentAddresses": "0x0000000000000000000000000000000000000014ee7d8bcfb72bc1880d0cf19822eb0a2e6577ab62000000000000000000000000000000000000001469d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
-      "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
-    },
-    {
-      "AddressArguments": ["0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Approve zkEVM Compatible Bridge to spendweETH",
-      "FunctionSelector": "0x095ea7b3",
-      "FunctionSignature": "approve(address,uint256)",
-      "LeafDigest": "0xf6f5266f332b5cb3d7e0c4c44b497f19865e3db478846c4718f42e8a1c486b7d",
-      "PackedArgumentAddresses": "0x2a3dd3eb832af982ec71669e178424b10dca2ede",
-      "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
-    },
-    {
-      "AddressArguments": [
-        "0x0000000000000000000000000000000000000000",
-        "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B",
-        "0x9893989433e7a383Cb313953e4c2365107dc19a7"
-      ],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Bridge weETH using zkEVM Compatible Bridge",
-      "FunctionSelector": "0xcd586579",
-      "FunctionSignature": "bridgeAsset(uint32,address,uint256,address,bool,bytes)",
-      "LeafDigest": "0x4f656e269eefc989bac8b1373e8908bd5cc2053131e7b3beeabb28f6d1ef0150",
-      "PackedArgumentAddresses": "0x000000000000000000000000000000000000000069d210d3b60e939bfa6e87cccc4fab7e8f44c16b9893989433e7a383cb313953e4c2365107dc19a7",
-      "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
-    },
-    {
-      "AddressArguments": [
-        "0x0000000000000000000000000000000000000014",
-        "0x9893989433e7a383Cb313953e4c2365107dc19a7",
-        "0x0000000000000000000000000000000000000014",
-        "0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"
-      ],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Claim  weETH from zkEVM Compatible Bridge",
-      "FunctionSelector": "0xccaa2d11",
-      "FunctionSignature": "claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)",
-      "LeafDigest": "0xc411bcf73db4aa0e49c89a346cdbc590971150c43c168e430e6786ef4d52aa51",
-      "PackedArgumentAddresses": "0x00000000000000000000000000000000000000149893989433e7a383cb313953e4c2365107dc19a7000000000000000000000000000000000000001469d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
-      "TargetAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
-    },
-    {
-      "AddressArguments": ["0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Approve Accountant to spend vbETH",
-      "FunctionSelector": "0x095ea7b3",
-      "FunctionSignature": "approve(address,uint256)",
-      "LeafDigest": "0x8b217516346b656ed52d472ba1dea0a6dac564dd8e52b4b5d7f8e782fe0249ee",
-      "PackedArgumentAddresses": "0xfcb9a6bf02c43f9e38bb102fd960cc1e738e787d",
-      "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
-    },
-    {
-      "AddressArguments": ["0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Approve Accountant to spend weETH",
-      "FunctionSelector": "0x095ea7b3",
-      "FunctionSignature": "approve(address,uint256)",
-      "LeafDigest": "0x7364ae6d49cba19a72340835f0f79747d42e64207d15e59363b7737c5c987fb5",
-      "PackedArgumentAddresses": "0xfcb9a6bf02c43f9e38bb102fd960cc1e738e787d",
-      "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
-    },
-    {
-      "AddressArguments": ["0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Claim fees in vbETH",
-      "FunctionSelector": "0x15a0ea6a",
-      "FunctionSignature": "claimFees(address)",
-      "LeafDigest": "0x2ec7d9e0c2d9d94e76a8b29ea4b0103c7bb025ad2235bebfc8a3565cebface3b",
-      "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab62",
-      "TargetAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"
-    },
-    {
-      "AddressArguments": ["0x9893989433e7a383Cb313953e4c2365107dc19a7"],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x770B3AAA48096b3fB36876b8dD55789372775bf0",
-      "Description": "Claim fees in weETH",
-      "FunctionSelector": "0x15a0ea6a",
-      "FunctionSignature": "claimFees(address)",
-      "LeafDigest": "0x1a3ea46981994901b131c93fa29b8bd76a955aa4e947ce410c6cdfa0b2cd28e4",
-      "PackedArgumentAddresses": "0x9893989433e7a383cb313953e4c2365107dc19a7",
-      "TargetAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
+    "MerkleTree": {
+        "0": [
+            "0x6767adc9cc25ebadd6f5d74ff531b4ac087cfc6679bb03861efafdcb69d3d905"
+        ],
+        "1": [
+            "0xd36152bb18b3c0f1df8152c55a20f7edf1acb39512ed91cc29b26ee0c0963446",
+            "0x18ce07534f0979629b27ecc6a67129f2cc117bfc40361df8e33ecfe372db2280"
+        ],
+        "2": [
+            "0x1428aaa2a9ec4d97bbc86a1e3881dc14f9e0bea152dac7ff8bfc5324386a0de2",
+            "0x41568cb2ac9a2a0efcac704dcaee8a86630d51275950e15b44a00137e1256490",
+            "0x7c4769f38a5c2fc369ca96c6a431eecf342329c938318d34e2689312e9ef3af1",
+            "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
+        ],
+        "3": [
+            "0x2a35ba588644a8b529cd012c26e6c7ab899b8d5df549229a9d1eecdd62a3d384",
+            "0x258b43e8152128d8be8e0015a7c0abe4d2d1e7cbdb88e9a386306b53f442cadf",
+            "0x60fad99f7fa081dab4613a7d2188d360048df772abba1df1abd2d53072e79ac5",
+            "0x4f7770dd456953c8fd1d8ca8216fd05c78d3f64f557930cf88bcff8849e6f245",
+            "0x263b45ca03d4bbde8f71cde43f5141778bc60167f7e0cbaf6156419d94b0e3c3",
+            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
+            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
+            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
+        ],
+        "4": [
+            "0x624a8dacb2247f937a37612cb55480d85d0749884e4765a01b9ddce0c32a4711",
+            "0x09e97adeeceac8b1e607136eccbcd40d5a617851db10b09fc1831bede1b0eb57",
+            "0x905deeb8157239bc225c99049b087a39e54f9487180d52c25cfecdf319f74647",
+            "0x48b8fef1f635f2969ffcc630c05451689dc910da55f537634f9179d89efa3f48",
+            "0x3a798df6cdea8ae9f1decb2a0a80fed93270511553492e80ede5df9a40d3ef68",
+            "0x3b043a62bbd88581ec66b44982493e3d296be7161ea90392a5a8119a2be9b65b",
+            "0xe890ccfb8113a2366b6fea13d71c02f44c77ba29f53d5a70bf4f24975e5ba5fa",
+            "0x8cf8c081b07e1940bb3f35955e8d12c7692013dce9b220cb22cecae6b2909f2c",
+            "0x213c9cda7fcc24f6f77e6bc9f0d3e8c6fcc398ff805b235d6a733d999f06ed40",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe"
+        ],
+        "5": [
+            "0x09d8955c5e1975c55db1cdb61c0293f65d26a8f07a24580cb94277abb111e29e",
+            "0x427f871d5669956c2203766dc3938049651af056a32dd24f358f66409c4084eb",
+            "0x4f3407abb0ce71ef846e8c2ef996386f224d7a0b937f7d592fb780abc662441f",
+            "0x25cfc605d708ae6cd5cb82dc3974613fa358441832a0076c25648244ceebf47b",
+            "0xdbdbe75c2dc40689ceffd63905beaf12294d0c3779dfe0c13767d66774796f58",
+            "0xed1b11a8b2b3f9e6c50f1e5f15e120f919add79000728cbb01302f0db28619f7",
+            "0xe5130bb86700b34442748f0b70edcec517fc6d2dd766cd5e5bfb64b80f112e1e",
+            "0x4e64225a1be6a11fb44ee62d856726887aedbc75d100fd15280663b0d49eed65",
+            "0x02c547bd224d92295064ba2e621fe3c51a9f1630dd2b03ddbdb5ddca959893f1",
+            "0x13284b354fd1ee97122044cad9df2f44f0c47c5b68d8a57854fd09bd9ea38d16",
+            "0x55ef79c92bcd9059bcccbdd1b29c9bf3311827e89c4fe6b378a15ee43738b088",
+            "0x0eea9a02e47217a803fa70a072af18a7febe68020ca80c0e05a153a1aea0308d",
+            "0xb67539b8c576d52bdd8b93d8cd54ccfc97d6ab58cdf8baa1f9e8616cb1c422fe",
+            "0x86216fb71198cae72b4e16e6d569bd7936352f389b7a666514014e903931c1da",
+            "0x1e1fcac93737d7283617b2729f8d8517041e56130a26dda831f721b758acd5e6",
+            "0x8470ab8ef17f6d69a9a5123b05524ab229b7ab08c16cf33d0b61aef06125d6f4",
+            "0xe5a301b7474f48e10d70dcf6c135b7d3baaa9181a7e403a7b5ff70f8cb3267c5",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba"
+        ],
+        "6": [
+            "0xb5e3ae100a4659f3de86c891bdf4fd5abaf3f471a8f800e446c67f8d1b24a4ac",
+            "0xd06bab1ac977884de89ea7a96b5d7641b0ec700c7fd46ce279c17f1812b7fcbd",
+            "0x42f2283b62fc9c60dd50f394a76e104b433778d977833c38a6536aefd24aeab3",
+            "0x90fa3238e07f45ee421e57c4ed40e4d0ceef2ece5415e23a21e83d1bd4789e9f",
+            "0x6eb2581581b1d6e054bfa79b62c9da0c1a2add156dd2f558c09426cbf5503769",
+            "0x06a9dab1e1768cc997a344eee16c50713de3158081895bced3f774a62f74fb61",
+            "0x9bf4e87940dab6bae6f3470a8165a2811bf8e62c0ef6f105fbbd9f014750ee26",
+            "0xb7bb3f83025d8977f11ae359a7320b4464361a009c0687442a3dc73ea878bbd0",
+            "0x60fee7d206c56b7d8eb44e5a790fdad8812652940de58659fe98a8dcf911742e",
+            "0x15f322c2f988db45df8fca37067ce8c3f84c728a736a90483ce97dfe57f5d2cc",
+            "0x19579e36dd718352aaa57f5bc2294fe312f22ab056e552d747eea95d5e6e1f6d",
+            "0x67b4ddf12b6b93804ed2f175983a3ddbbe1e105e629f4e355df8be40cafb1293",
+            "0x5e4ed732b3ba79e90991f75e56229a630a08af6df5fd8bd371b9d51c62c39b6d",
+            "0x06511ed6cc6874dba8acdada52225d31babe28839bbdd75abcd82d3bfd1e56cf",
+            "0xd6babbc90075f38900dc27ef3d4dd5baf1e55728f5e98ecfe4eac90c3a5bfe47",
+            "0x6a2d184d35f9884da4ee45f897ef8923cd27fa859a2642b566051f315e625fd5",
+            "0xdd6184f995514fc95d23c0335fe649e84422871dcd2023e8a440e8bc1c7d6444",
+            "0x07c2ce4cdaedb9cd980d1eafac1439c74b29d58b5a4fdb6dfb4041a178505ac7",
+            "0x52be092cc24aa556bdfb855f27efab4c6f178b851d22ad549323058c4e0cd3a3",
+            "0xa12cbab03835228745f549608b470797ce058c89c4dc0e2aad5d14f120812ae3",
+            "0x2b5f62158a1d206a86fec983045aa30ccb8c64d291e4bd4847104e7c1afae2db",
+            "0x9550c88204c5c374d3d552e6bb399c43abfd500e3d04bd4dbafa38d7ff87eb1b",
+            "0xa3b5e217ca88843c77eeb2eac1d8790dc2200c7bc2add643cece29d3a1209de9",
+            "0x9d5ae5afefbc845cb22df0ff7392fb35e036755443f1e435068707480265f9df",
+            "0xeb9720e77a7e214bf5275b5784b022766ea8c33de1add8a04f121b703578bbb2",
+            "0xf9af12692d6a2de52cce808d4ac069474d2874579b7739634487ddb01f3d8d57",
+            "0xdf2af44638077928ca110165147e1cbe5a7e631f6f84bdd5aecb17586fc421dc",
+            "0xe45a9a423777d60b793a4fadb9c9fb68600c951c232398a2bdf9ee6a2d052dd3",
+            "0x972716d16451f1036307e149aeea1a086b770919a55c5fa8efd0b6c60e0448dd",
+            "0x7d122f163f82d42298d36e6b143e89f0bcec30c2ba60fac2d5fa3f753806dd4b",
+            "0x4a3b78d0e42e1f3ff963711c2e0f7f6e4ec235c29cd4b338505c5481a6022e14",
+            "0xd11b5271a921b24d66d310384f4defb1da3666592b1abb31ab6bc689b7f5790c",
+            "0x965d6db9ac146206bb39d4c00a46f7f1c8a4ac7f891807a0d93118911926639c",
+            "0x31d7fdd9bc829c10b4689481403f587e279cf708f576fec34827a0f8e096ef14",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400"
+        ]
     }
-  ],
-  "MerkleTree": {
-    "0": ["0x0449644fb5bad3c61b25549c6a39e249cd59932c0c81cf5e2014c06926054768"],
-    "1": [
-      "0xb9192e32a276973bc4ab7ae923a1c017e2264e481a0a4f47cf9710423793c079",
-      "0x0fcece7d3c7ea26905fcd50f1872a5272511b277ee14efc774cd28a6fe3fe324"
-    ],
-    "2": [
-      "0x5550af173b430d95b0761f77e245b2dcf16fad4aad83c9aeec3b073c197b1578",
-      "0x441ff0921990dee8cd4a2c5750447cee8729dcb7513a786012ca69cd71991be1",
-      "0x6faba964d74805e0ee80cf15c1cbdb91478bb9b421b7530f498265903b0efa44",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe"
-    ],
-    "3": [
-      "0x5bef8731637776fc928c75279a2120f46a51fd2ffc7abb6e368d356592bc218b",
-      "0xbbb88cd76e7248336febefac79abf290ef6f687869c8a533aebc9c560f602d08",
-      "0xc366c5476f6de0f3574081211a26561a582e13e0fb4505a2ad3d863464f88f63",
-      "0x629a7b3947eb83c391700e6f2790350f393f4b2297657b7cb2fd010177052de8",
-      "0x66c944a677115282cb59c0e1356a704e46ca25ca84b374b6f373c5226b5ff986",
-      "0xd35de54ad513d9b13d36932d8ecc6f899a5a924c80d1fbe05fa3af3f06f0410e",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba"
-    ],
-    "4": [
-      "0xddf3d0293e509076ceeeba3acf1618b31f38d31abcdd04729ba4e469213b69ab",
-      "0xee7d99d2e9fd00d3f47cbd759c0708dc56c3ec26d2c5972dfd42b00ffe70feba",
-      "0x6eddaa181f7383888dfe9ec5044f7fc61bf0dccf767a2991ab30d5e6c1edef90",
-      "0x59ce08fffd7a2b2065c718953af35b707e57beceb449ecf8c2da8e9a4ab3a742",
-      "0x7e1fcbb06dc42242dff94f0815567d236bc7a4ab66dfaec0ce66348c22ec2c62",
-      "0xf6f5266f332b5cb3d7e0c4c44b497f19865e3db478846c4718f42e8a1c486b7d",
-      "0x4f656e269eefc989bac8b1373e8908bd5cc2053131e7b3beeabb28f6d1ef0150",
-      "0xc411bcf73db4aa0e49c89a346cdbc590971150c43c168e430e6786ef4d52aa51",
-      "0x8b217516346b656ed52d472ba1dea0a6dac564dd8e52b4b5d7f8e782fe0249ee",
-      "0x7364ae6d49cba19a72340835f0f79747d42e64207d15e59363b7737c5c987fb5",
-      "0x2ec7d9e0c2d9d94e76a8b29ea4b0103c7bb025ad2235bebfc8a3565cebface3b",
-      "0x1a3ea46981994901b131c93fa29b8bd76a955aa4e947ce410c6cdfa0b2cd28e4",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400"
-    ]
-  }
 }

--- a/leafs/Katana/LiquidKatanaETHMerkleRoot.json
+++ b/leafs/Katana/LiquidKatanaETHMerkleRoot.json
@@ -10,8 +10,8 @@
             "Bytes4(TARGET_FUNCTION_SELECTOR)",
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
-        "LeafCount": 34,
-        "ManageRoot": "0x6767adc9cc25ebadd6f5d74ff531b4ac087cfc6679bb03861efafdcb69d3d905",
+        "LeafCount": 36,
+        "ManageRoot": "0x519d38fd2d44e7a0c4d3a3b65ceb197114e661b82dcbed6364daaff6eed6dec4",
         "ManagerAddress": "0x51CdEcC111c21BED72Ab99f415Bab6d35984BfEB",
         "TreeCapacity": 64
     },
@@ -167,10 +167,32 @@
             "TargetAddress": "0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d"
         },
         {
-            "AddressArguments": ["0x2659C6085D26144117D904C46B48B6d180393d27"],
+            "AddressArguments": ["0x4e1d81A3E627b9294532e990109e4c21d217376C"],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
             "Description": "Approve UniswapV3 Router to spend weETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0xbffe31a45b248b1f8dc403c60e55275d20eeff2f0ec7bee58008e4ac2b51beae",
+            "PackedArgumentAddresses": "0x4e1d81a3e627b9294532e990109e4c21d217376c",
+            "TargetAddress": "0x9893989433e7a383Cb313953e4c2365107dc19a7"
+        },
+        {
+            "AddressArguments": ["0x4e1d81A3E627b9294532e990109e4c21d217376C"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve UniswapV3 Router to spend vbETH",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x23b451ec3c7fd0b8685bb165873e99df5daea25bfdd3b0bc5afede01ae328298",
+            "PackedArgumentAddresses": "0x4e1d81a3e627b9294532e990109e4c21d217376c",
+            "TargetAddress": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62"
+        },
+        {
+            "AddressArguments": ["0x2659C6085D26144117D904C46B48B6d180393d27"],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
+            "Description": "Approve UniswapV3 NonFungible Position Manager to spend weETH",
             "FunctionSelector": "0x095ea7b3",
             "FunctionSignature": "approve(address,uint256)",
             "LeafDigest": "0x5e4ed732b3ba79e90991f75e56229a630a08af6df5fd8bd371b9d51c62c39b6d",
@@ -181,7 +203,7 @@
             "AddressArguments": ["0x2659C6085D26144117D904C46B48B6d180393d27"],
             "CanSendValue": false,
             "DecoderAndSanitizerAddress": "0x3A70bDe90936625208483DDBf88f6E536A1aa4aC",
-            "Description": "Approve UniswapV3 Router to spend vbETH",
+            "Description": "Approve UniswapV3 NonFungible Position Manager to spend vbETH",
             "FunctionSelector": "0x095ea7b3",
             "FunctionSignature": "approve(address,uint256)",
             "LeafDigest": "0x06511ed6cc6874dba8acdada52225d31babe28839bbdd75abcd82d3bfd1e56cf",
@@ -230,9 +252,9 @@
             "Description": "Swap weETH for vbETH using UniswapV3 router",
             "FunctionSelector": "0xc04b8d59",
             "FunctionSignature": "exactInput((bytes,address,uint256,uint256,uint256))",
-            "LeafDigest": "0xdd6184f995514fc95d23c0335fe649e84422871dcd2023e8a440e8bc1c7d6444",
+            "LeafDigest": "0xfc038851d61df35234180e8923befc4c560ad0524e6e89aec3294b3c5e19e598",
             "PackedArgumentAddresses": "0x9893989433e7a383cb313953e4c2365107dc19a7ee7d8bcfb72bc1880d0cf19822eb0a2e6577ab6269d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
-            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+            "TargetAddress": "0x4e1d81A3E627b9294532e990109e4c21d217376C"
         },
         {
             "AddressArguments": [
@@ -245,9 +267,9 @@
             "Description": "Swap vbETH for weETH using UniswapV3 router",
             "FunctionSelector": "0xc04b8d59",
             "FunctionSignature": "exactInput((bytes,address,uint256,uint256,uint256))",
-            "LeafDigest": "0x07c2ce4cdaedb9cd980d1eafac1439c74b29d58b5a4fdb6dfb4041a178505ac7",
+            "LeafDigest": "0xedb466a5c4f0bd0dd9766e2654d7a2611999d3ba9acb2d9379119f8917e87966",
             "PackedArgumentAddresses": "0xee7d8bcfb72bc1880d0cf19822eb0a2e6577ab629893989433e7a383cb313953e4c2365107dc19a769d210d3b60e939bfa6e87cccc4fab7e8f44c16b",
-            "TargetAddress": "0x2659C6085D26144117D904C46B48B6d180393d27"
+            "TargetAddress": "0x4e1d81A3E627b9294532e990109e4c21d217376C"
         },
         {
             "AddressArguments": ["0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B"],
@@ -780,50 +802,28 @@
             "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "PackedArgumentAddresses": "0x",
             "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
         }
     ],
     "MerkleTree": {
         "0": [
-            "0x6767adc9cc25ebadd6f5d74ff531b4ac087cfc6679bb03861efafdcb69d3d905"
+            "0x519d38fd2d44e7a0c4d3a3b65ceb197114e661b82dcbed6364daaff6eed6dec4"
         ],
         "1": [
-            "0xd36152bb18b3c0f1df8152c55a20f7edf1acb39512ed91cc29b26ee0c0963446",
-            "0x18ce07534f0979629b27ecc6a67129f2cc117bfc40361df8e33ecfe372db2280"
+            "0xde6c113e0d7dccab13d0260e0149c696557d4e3ef6e887f634ad1932344700af",
+            "0x239a6c7428a357728f9c86ed81498ffd6f05d35dbcc265d09eb2c8fe780642e0"
         ],
         "2": [
-            "0x1428aaa2a9ec4d97bbc86a1e3881dc14f9e0bea152dac7ff8bfc5324386a0de2",
-            "0x41568cb2ac9a2a0efcac704dcaee8a86630d51275950e15b44a00137e1256490",
-            "0x7c4769f38a5c2fc369ca96c6a431eecf342329c938318d34e2689312e9ef3af1",
+            "0xcd8e9ef447fec65823906791dfe61d5661b874eeb8d21b8deaeb43b3d5fd71a3",
+            "0xa355c7e106595b7f3e412a7d50f58a7b7035a7b253c16e8bd8694adfda7c405e",
+            "0xef7e39df6b9b81ec5837546a33e851ea260190ff3020ace83a3e81069b12b1f2",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
         "3": [
             "0x2a35ba588644a8b529cd012c26e6c7ab899b8d5df549229a9d1eecdd62a3d384",
-            "0x258b43e8152128d8be8e0015a7c0abe4d2d1e7cbdb88e9a386306b53f442cadf",
-            "0x60fad99f7fa081dab4613a7d2188d360048df772abba1df1abd2d53072e79ac5",
-            "0x4f7770dd456953c8fd1d8ca8216fd05c78d3f64f557930cf88bcff8849e6f245",
-            "0x263b45ca03d4bbde8f71cde43f5141778bc60167f7e0cbaf6156419d94b0e3c3",
+            "0x5fa4fad47a233bde36da7500d048ae69a2a1ce61a5113c8d3080f665b6a32b1d",
+            "0xcce56a5a5094c53bfd873aa49eee1f0bc2c68a42b5508d7d8679e780612d5135",
+            "0xf8b1e18fc0d20f74ed031e00a619107a9232f99a6bf5c630348e4a76c99a3c8e",
+            "0x596caa6b2b98455a5b8ac3be03b5fe08583de3d42cab24fa9183cadd0e615c42",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
@@ -832,12 +832,12 @@
             "0x624a8dacb2247f937a37612cb55480d85d0749884e4765a01b9ddce0c32a4711",
             "0x09e97adeeceac8b1e607136eccbcd40d5a617851db10b09fc1831bede1b0eb57",
             "0x905deeb8157239bc225c99049b087a39e54f9487180d52c25cfecdf319f74647",
-            "0x48b8fef1f635f2969ffcc630c05451689dc910da55f537634f9179d89efa3f48",
-            "0x3a798df6cdea8ae9f1decb2a0a80fed93270511553492e80ede5df9a40d3ef68",
-            "0x3b043a62bbd88581ec66b44982493e3d296be7161ea90392a5a8119a2be9b65b",
-            "0xe890ccfb8113a2366b6fea13d71c02f44c77ba29f53d5a70bf4f24975e5ba5fa",
-            "0x8cf8c081b07e1940bb3f35955e8d12c7692013dce9b220cb22cecae6b2909f2c",
-            "0x213c9cda7fcc24f6f77e6bc9f0d3e8c6fcc398ff805b235d6a733d999f06ed40",
+            "0xed4872410a6bc14dd70c71a9a9b86441dd3231a43e194ddf378395c80f90731a",
+            "0xa8b6ca8762e9344e44c8482294757813416d961649a5048aba50734cb9d19a8d",
+            "0x40df61835324191dafb09d1e99ab6bd8c00fc77f5e59c8ec50fadcb9ed657f54",
+            "0x7687c4934b2d04df8983b50b152c5764e71d613655e04c5ab119fd593fe41cd8",
+            "0x59bb23cf07d3d8c7eb441fbcc2caba39eeb2d44543fda227dacc347338c0eb24",
+            "0x5786322dab75a0fc8b1a3a031c5dad515aa4cb4411d355589e88f9deaad1870a",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -853,9 +853,10 @@
             "0x25cfc605d708ae6cd5cb82dc3974613fa358441832a0076c25648244ceebf47b",
             "0xdbdbe75c2dc40689ceffd63905beaf12294d0c3779dfe0c13767d66774796f58",
             "0xed1b11a8b2b3f9e6c50f1e5f15e120f919add79000728cbb01302f0db28619f7",
+            "0xd1d25ec1773872bec27211425fa50485cc7949c64f4ed951203a2713abb1a575",
             "0xe5130bb86700b34442748f0b70edcec517fc6d2dd766cd5e5bfb64b80f112e1e",
             "0x4e64225a1be6a11fb44ee62d856726887aedbc75d100fd15280663b0d49eed65",
-            "0x02c547bd224d92295064ba2e621fe3c51a9f1630dd2b03ddbdb5ddca959893f1",
+            "0x9013c015b5ed4de21109ee35044f6ebcda4605c450ea40819f02df413a9f1c96",
             "0x13284b354fd1ee97122044cad9df2f44f0c47c5b68d8a57854fd09bd9ea38d16",
             "0x55ef79c92bcd9059bcccbdd1b29c9bf3311827e89c4fe6b378a15ee43738b088",
             "0x0eea9a02e47217a803fa70a072af18a7febe68020ca80c0e05a153a1aea0308d",
@@ -864,7 +865,6 @@
             "0x1e1fcac93737d7283617b2729f8d8517041e56130a26dda831f721b758acd5e6",
             "0x8470ab8ef17f6d69a9a5123b05524ab229b7ab08c16cf33d0b61aef06125d6f4",
             "0xe5a301b7474f48e10d70dcf6c135b7d3baaa9181a7e403a7b5ff70f8cb3267c5",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -893,12 +893,14 @@
             "0x15f322c2f988db45df8fca37067ce8c3f84c728a736a90483ce97dfe57f5d2cc",
             "0x19579e36dd718352aaa57f5bc2294fe312f22ab056e552d747eea95d5e6e1f6d",
             "0x67b4ddf12b6b93804ed2f175983a3ddbbe1e105e629f4e355df8be40cafb1293",
+            "0xbffe31a45b248b1f8dc403c60e55275d20eeff2f0ec7bee58008e4ac2b51beae",
+            "0x23b451ec3c7fd0b8685bb165873e99df5daea25bfdd3b0bc5afede01ae328298",
             "0x5e4ed732b3ba79e90991f75e56229a630a08af6df5fd8bd371b9d51c62c39b6d",
             "0x06511ed6cc6874dba8acdada52225d31babe28839bbdd75abcd82d3bfd1e56cf",
             "0xd6babbc90075f38900dc27ef3d4dd5baf1e55728f5e98ecfe4eac90c3a5bfe47",
             "0x6a2d184d35f9884da4ee45f897ef8923cd27fa859a2642b566051f315e625fd5",
-            "0xdd6184f995514fc95d23c0335fe649e84422871dcd2023e8a440e8bc1c7d6444",
-            "0x07c2ce4cdaedb9cd980d1eafac1439c74b29d58b5a4fdb6dfb4041a178505ac7",
+            "0xfc038851d61df35234180e8923befc4c560ad0524e6e89aec3294b3c5e19e598",
+            "0xedb466a5c4f0bd0dd9766e2654d7a2611999d3ba9acb2d9379119f8917e87966",
             "0x52be092cc24aa556bdfb855f27efab4c6f178b851d22ad549323058c4e0cd3a3",
             "0xa12cbab03835228745f549608b470797ce058c89c4dc0e2aad5d14f120812ae3",
             "0x2b5f62158a1d206a86fec983045aa30ccb8c64d291e4bd4847104e7c1afae2db",
@@ -915,8 +917,6 @@
             "0xd11b5271a921b24d66d310384f4defb1da3666592b1abb31ab6bc689b7f5790c",
             "0x965d6db9ac146206bb39d4c00a46f7f1c8a4ac7f891807a0d93118911926639c",
             "0x31d7fdd9bc829c10b4689481403f587e279cf708f576fec34827a0f8e096ef14",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/script/MerkleRootCreation/Katana/CreateLiquidKatanaETHMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Katana/CreateLiquidKatanaETHMerkleRoot.s.sol
@@ -16,7 +16,7 @@ contract CreateLiquidKatanaETHMerkleRoot is Script, MerkleTreeHelper {
 
     //standard
     address public boringVault = 0x69d210d3b60E939BFA6E87cCcC4fAb7e8F44C16B;
-    address public rawDataDecoderAndSanitizer = 0x770B3AAA48096b3fB36876b8dD55789372775bf0;
+    address public rawDataDecoderAndSanitizer = 0x3A70bDe90936625208483DDBf88f6E536A1aa4aC;
     address public managerAddress = 0x51CdEcC111c21BED72Ab99f415Bab6d35984BfEB;
     address public accountantAddress = 0xFCb9a6bF02C43f9E38Bb102fd960Cc1e738e787d;
 
@@ -36,8 +36,7 @@ contract CreateLiquidKatanaETHMerkleRoot is Script, MerkleTreeHelper {
         setAddress(false, katana, "accountantAddress", accountantAddress);
         setAddress(false, katana, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](16);
-
+        ManageLeaf[] memory leafs = new ManageLeaf[](64);
 
         // ========================== NativeWrapper ==========================
         _addNativeLeafs(leafs);
@@ -64,6 +63,22 @@ contract CreateLiquidKatanaETHMerkleRoot is Script, MerkleTreeHelper {
         feeAssets[1] = getERC20(sourceChain, "WEETH");
         _addLeafsForFeeClaiming(leafs, getAddress(sourceChain, "accountantAddress"), feeAssets, false);
 
+        // ========================== Sushi ==========================
+        address[] memory token0 = new address[](1);
+        token0[0] = getAddress(sourceChain, "vbETH"); 
+
+        address[] memory token1 = new address[](1);
+        token1[0] = getAddress(sourceChain, "WEETH");
+
+        _addUniswapV3Leafs(leafs, token0, token1, false); 
+
+        // ========================== Morpho Blue ==========================
+        _addMorphoBlueSupplyLeafs(leafs, getBytes32(sourceChain, "WEETH_vbETH_915"));
+
+        _addMorphoBlueCollateralLeafs(leafs, getBytes32(sourceChain, "WEETH_vbETH_915"));
+        
+        // ========================== MetaMorhpo ==========================
+        _addERC4626Leafs(leafs, ERC4626(getAddress(sourceChain, "gauntletWETH"))); 
 
         // ========================== Verify ==========================
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -2724,7 +2724,7 @@ contract ChainValues {
 
         // Sushi
         values[katana]["uniswapV3NonFungiblePositionManager"] = 0x2659C6085D26144117D904C46B48B6d180393d27.toBytes32();
-        values[katana]["uniV3Router"] = 0x2659C6085D26144117D904C46B48B6d180393d27.toBytes32();
+        values[katana]["uniV3Router"] = 0x4e1d81A3E627b9294532e990109e4c21d217376C.toBytes32();
 
     }
 

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -2714,6 +2714,18 @@ contract ChainValues {
         // LayerZero
         values[katana]["LayerZeroEndPoint"] = 0x6F475642a6e85809B1c36Fa62763669b1b48DD5B.toBytes32();
 
+        // Morpho Blue
+        values[katana]["morphoBlue"] = 0xD50F2DffFd62f94Ee4AEd9ca05C61d0753268aBc.toBytes32();
+        values[katana]["LBTC_vbWBTC_915"] = 0x60b54e17d55b765955a20908ed5143192a48df7fd3833f7f7fe86504bf6c4c1a;
+        values[katana]["WEETH_vbETH_915"] = 0x1e74d36ffbda65b8a45d72754b349cdd5ce807c5fa814f91ba8e3cd27881c34b;
+
+        // MetaMorpho
+        values[katana]["gauntletWETH"] = 0xC5e7AB07030305fc925175b25B93b285d40dCdFf.toBytes32();
+
+        // Sushi
+        values[katana]["uniswapV3NonFungiblePositionManager"] = 0x2659C6085D26144117D904C46B48B6d180393d27.toBytes32();
+        values[katana]["uniV3Router"] = 0x2659C6085D26144117D904C46B48B6d180393d27.toBytes32();
+
     }
 
     function _addTACValues() private {


### PR DESCRIPTION
update to new decoder @ `0x3A70bDe90936625208483DDBf88f6E536A1aa4aC`

### Additions
#### SushiSwap
- `WEETH`/`vbWETH` pair 
- Swaps between the above pair

#### Morpho Blue
- `WEETH`/`vbWETH` 91.5% market @ hash `0x1e74d36ffbda65b8a45d72754b349cdd5ce807c5fa814f91ba8e3cd27881c34b`

#### MetaMorpho
- `gauntletWETH` / `gtWETH` 