### PR TITLE
Add Automatic deposits and withdraws to idle strategies

### DIFF
--- a/src/base/Roles/AaveV3BufferHelper.sol
+++ b/src/base/Roles/AaveV3BufferHelper.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
+
+contract AaveV3BufferHelper is IBufferHelper {
+    address[] public depositTargets;
+    uint256[] public depositValues;
+    address[] public withdrawTargets;
+    uint256[] public withdrawValues;
+
+    address public immutable vault;
+
+    constructor(
+        address[] memory _depositTargets,
+        uint256[] memory _depositValues,
+        address[] memory _withdrawTargets,
+        uint256[] memory _withdrawValues,
+        address _vault
+    ) {
+        require(
+            _depositTargets.length == 2 && _depositValues.length == 2 && _withdrawTargets.length == 1
+                && _withdrawValues.length == 1,
+            "Invalid lengths"
+        );
+        depositTargets = _depositTargets;
+        depositValues = _depositValues;
+        withdrawTargets = _withdrawTargets;
+        withdrawValues = _withdrawValues;
+        vault = _vault;
+    }
+
+    function getDepositManageCall(address asset, uint256 amount)
+        public
+        view
+        returns (address[] memory targets, bytes[] memory data, uint256[] memory values)
+    {
+        data = new bytes[](2);
+        data[0] = abi.encodeWithSignature("approve(address,uint256)", depositTargets[1], amount);
+        data[1] = abi.encodeWithSignature("supply(address,uint256,address,uint16)", asset, amount, vault, 0);
+        return (depositTargets, data, depositValues);
+    }
+
+    function getWithdrawManageCall(address asset, uint256 amount)
+        public
+        view
+        returns (address[] memory targets, bytes[] memory data, uint256[] memory values)
+    {
+        data = new bytes[](1);
+        data[0] = abi.encodeWithSignature("withdraw(address,uint256,address)", asset, amount, vault);
+        return (withdrawTargets, data, withdrawValues);
+    }
+}

--- a/src/base/Roles/AaveV3BufferHelper.sol
+++ b/src/base/Roles/AaveV3BufferHelper.sol
@@ -25,7 +25,7 @@ contract AaveV3BufferHelper is IBufferHelper {
         returns (address[] memory targets, bytes[] memory data, uint256[] memory values)
     {
         uint256 currentAllowance = ERC20(asset).allowance(vault, aaveV3Pool);
-        if (currentAllowance > amount) {
+        if (currentAllowance >= amount) {
             targets = new address[](1);
             targets[0] = aaveV3Pool;
             data = new bytes[](1);

--- a/src/base/Roles/AaveV3BufferHelper.sol
+++ b/src/base/Roles/AaveV3BufferHelper.sol
@@ -7,18 +7,43 @@ pragma solidity 0.8.21;
 import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 
+/**
+ * @title AaveV3BufferHelper
+ * @author Veda Tech Labs
+ * @notice A buffer helper contract that integrates with Aave V3 lending pool for automated yield generation
+ * @dev Implements the IBufferHelper interface to provide Aave V3 integration for the TellerWithBuffer contract.
+ * This helper automatically manages token approvals and supply/withdraw operations to maximize yield on deposited assets.
+ */
 contract AaveV3BufferHelper is IBufferHelper {
+    /// @notice The Aave V3 lending pool
     address public immutable aaveV3Pool;
+
+    /// @notice The associated vault
     address public immutable vault;
 
-    constructor(
-        address _aaveV3Pool,
-        address _vault
-    ) {
+    /**
+     * @notice Initializes the AaveV3BufferHelper contract
+     * @param _aaveV3Pool The Aave V3 lending pool
+     * @param _vault The associated vault
+     */
+    constructor(address _aaveV3Pool, address _vault) {
         aaveV3Pool = _aaveV3Pool;
         vault = _vault;
     }
 
+    /**
+     * @notice Generates management calls for depositing assets into Aave V3
+     * @param asset The ERC20 token address to be supplied to Aave V3
+     * @param amount The amount of tokens to supply
+     * @return targets Array of contract addresses to call
+     * @return data Array of encoded function calls
+     * @return values Array of ETH values to send with each call (all 0 for ERC20 operations)
+     * @dev This function manages token approvals to cover all cases:
+     *
+     * - If current allowance >= amount: Only supply to Aave V3 (1 call)
+     * - If current allowance == 0: Approve then supply (2 calls)
+     * - If current allowance < amount: Reset approval to 0, approve new amount, then supply (3 calls)
+     */
     function getDepositManageCall(address asset, uint256 amount)
         public
         view
@@ -53,6 +78,15 @@ contract AaveV3BufferHelper is IBufferHelper {
         }
     }
 
+    /**
+     * @notice Generates management calls for withdrawing assets from Aave V3
+     * @param asset The ERC20 token address to withdraw from Aave V3
+     * @param amount The amount of tokens to withdraw
+     * @return targets Array of contract addresses to call
+     * @return data Array of encoded function calls
+     * @return values Array of ETH values to send with each call (all 0 for ERC20 operations)
+     * @dev Withdraws the specified amount of the asset from Aave V3 and returns it to the vault.
+     */
     function getWithdrawManageCall(address asset, uint256 amount)
         public
         view

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -7,17 +7,49 @@ pragma solidity 0.8.21;
 import {TellerWithMultiAssetSupport, ERC20} from "./TellerWithMultiAssetSupport.sol";
 import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 
+/**
+ * @title TellerWithBuffer
+ * @author Veda Tech Labs
+ * @notice A teller contract that integrates with buffer helpers to manage deposits and withdrawals
+ * @dev Extends TellerWithMultiAssetSupport to add automatic yield and withdrawal buffer capabilities.
+ * The buffer helpers can trigger additional vault management calls during these operations.
+ */
 contract TellerWithBuffer is TellerWithMultiAssetSupport {
+    /// @notice Buffer helper contract for managing deposits
     IBufferHelper public depositBufferHelper;
+
+    /// @notice Buffer helper contract for managing withdrawals
     IBufferHelper public withdrawBufferHelper;
 
-    constructor(address _owner, address _vault, address _accountant, address _weth, address _depositBufferHelper, address _withdrawBufferHelper)
-        TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth)
-    {
+    /**
+     * @notice Initializes the TellerWithBuffer contract
+     * @param _owner The address that will have owner privileges
+     * @param _vault The vault contract address this teller will interact with
+     * @param _accountant The accountant contract address associated with the vault
+     * @param _weth The WETH token address for ETH wrapping/unwrapping operations
+     * @param _depositBufferHelper The buffer helper contract for deposit management
+     * @param _withdrawBufferHelper The buffer helper contract for withdrawal management
+     */
+    constructor(
+        address _owner,
+        address _vault,
+        address _accountant,
+        address _weth,
+        address _depositBufferHelper,
+        address _withdrawBufferHelper
+    ) TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth) {
         depositBufferHelper = IBufferHelper(_depositBufferHelper);
         withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
     }
 
+    /**
+     * @notice Executes buffer management after a deposit operation
+     * @param depositAsset The ERC20 token being deposited
+     * @param assetAmount The amount of the asset being deposited
+     * @dev This function is called internally after a deposit is processed.
+     * If a deposit buffer helper is configured, it will retrieve management calls
+     * and execute them through the vault's manage function.
+     */
     function _afterDeposit(ERC20 depositAsset, uint256 assetAmount) internal override {
         if (address(depositBufferHelper) != address(0)) {
             (address[] memory targets, bytes[] memory data, uint256[] memory values) =
@@ -26,6 +58,14 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
         }
     }
 
+    /**
+     * @notice Executes buffer management before a withdrawal operation
+     * @param withdrawAsset The ERC20 token being withdrawn
+     * @param assetAmount The amount of the asset being withdrawn
+     * @dev This function is called internally before a withdrawal is processed.
+     * If a withdraw buffer helper is configured, it will retrieve management calls
+     * and execute them through the vault's manage function.
+     */
     function _beforeWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal override {
         if (address(withdrawBufferHelper) != address(0)) {
             (address[] memory targets, bytes[] memory data, uint256[] memory values) =
@@ -34,10 +74,22 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
         }
     }
 
+    /**
+     * @notice Updates the deposit buffer helper contract
+     * @param _depositBufferHelper The new deposit buffer helper contract address
+     * @dev Only callable by authorized accounts. This allows for dynamic updates
+     * to the deposit management strategy without requiring contract redeployment.
+     */
     function setDepositBufferHelper(address _depositBufferHelper) external requiresAuth {
         depositBufferHelper = IBufferHelper(_depositBufferHelper);
     }
 
+    /**
+     * @notice Updates the withdrawal buffer helper contract
+     * @param _withdrawBufferHelper The new withdrawal buffer helper contract address
+     * @dev Only callable by authorized accounts. This allows for dynamic updates
+     * to the withdrawal management strategy without requiring contract redeployment.
+     */
     function setWithdrawBufferHelper(address _withdrawBufferHelper) external requiresAuth {
         withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
     }

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -8,31 +8,37 @@ import {TellerWithMultiAssetSupport, ERC20} from "./TellerWithMultiAssetSupport.
 import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 
 contract TellerWithBuffer is TellerWithMultiAssetSupport {
-    IBufferHelper public bufferHelper;
+    IBufferHelper public depositBufferHelper;
+    IBufferHelper public withdrawBufferHelper;
 
-    constructor(address _owner, address _vault, address _accountant, address _weth, address _bufferHelper)
+    constructor(address _owner, address _vault, address _accountant, address _weth, address _depositBufferHelper, address _withdrawBufferHelper)
         TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth)
     {
-        bufferHelper = IBufferHelper(_bufferHelper);
+        depositBufferHelper = IBufferHelper(_depositBufferHelper);
+        withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
     }
 
     function _postDepositHook(ERC20 depositAsset, uint256 depositAmount) internal override {
-        if (address(bufferHelper) != address(0)) {
+        if (address(depositBufferHelper) != address(0)) {
             (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-                bufferHelper.getDepositManageCall(address(depositAsset), depositAmount);
+                depositBufferHelper.getDepositManageCall(address(depositAsset), depositAmount);
             vault.manage(targets, data, values);
         }
     }
 
     function _preWithdrawHook(ERC20 withdrawAsset, uint256 shareAmount) internal override {
-        if (address(bufferHelper) != address(0)) {
+        if (address(withdrawBufferHelper) != address(0)) {
             (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-                bufferHelper.getWithdrawManageCall(address(withdrawAsset), shareAmount);
+                withdrawBufferHelper.getWithdrawManageCall(address(withdrawAsset), shareAmount);
             vault.manage(targets, data, values);
         }
     }
 
-    function setBufferHelper(address _bufferHelper) external requiresAuth {
-        bufferHelper = IBufferHelper(_bufferHelper);
+    function setDepositBufferHelper(address _depositBufferHelper) external requiresAuth {
+        depositBufferHelper = IBufferHelper(_depositBufferHelper);
+    }
+
+    function setWithdrawBufferHelper(address _withdrawBufferHelper) external requiresAuth {
+        withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
     }
 }

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -18,18 +18,18 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
         withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
     }
 
-    function _postDepositHook(ERC20 depositAsset, uint256 depositAmount) internal override {
+    function _afterDeposit(ERC20 depositAsset, uint256 assetAmount) internal override {
         if (address(depositBufferHelper) != address(0)) {
             (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-                depositBufferHelper.getDepositManageCall(address(depositAsset), depositAmount);
+                depositBufferHelper.getDepositManageCall(address(depositAsset), assetAmount);
             vault.manage(targets, data, values);
         }
     }
 
-    function _preWithdrawHook(ERC20 withdrawAsset, uint256 shareAmount) internal override {
+    function _beforeWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal override {
         if (address(withdrawBufferHelper) != address(0)) {
             (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-                withdrawBufferHelper.getWithdrawManageCall(address(withdrawAsset), shareAmount);
+                withdrawBufferHelper.getWithdrawManageCall(address(withdrawAsset), assetAmount);
             vault.manage(targets, data, values);
         }
     }

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -17,14 +17,22 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
     }
 
     function _postDepositHook(ERC20 depositAsset, uint256 depositAmount) internal override {
-        (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-            bufferHelper.getDepositManageCall(address(depositAsset), depositAmount);
-        vault.manage(targets, data, values);
+        if (address(bufferHelper) != address(0)) {
+            (address[] memory targets, bytes[] memory data, uint256[] memory values) =
+                bufferHelper.getDepositManageCall(address(depositAsset), depositAmount);
+            vault.manage(targets, data, values);
+        }
     }
 
     function _preWithdrawHook(ERC20 withdrawAsset, uint256 shareAmount) internal override {
-        (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-            bufferHelper.getWithdrawManageCall(address(withdrawAsset), shareAmount);
-        vault.manage(targets, data, values);
+        if (address(bufferHelper) != address(0)) {
+            (address[] memory targets, bytes[] memory data, uint256[] memory values) =
+                bufferHelper.getWithdrawManageCall(address(withdrawAsset), shareAmount);
+            vault.manage(targets, data, values);
+        }
+    }
+
+    function setBufferHelper(address _bufferHelper) external requiresAuth {
+        bufferHelper = IBufferHelper(_bufferHelper);
     }
 }

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {TellerWithMultiAssetSupport, ERC20} from "./TellerWithMultiAssetSupport.sol";
+import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
+
+contract TellerWithBuffer is TellerWithMultiAssetSupport {
+    IBufferHelper public bufferHelper;
+
+    constructor(address _owner, address _vault, address _accountant, address _weth, address _bufferHelper)
+        TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth)
+    {
+        bufferHelper = IBufferHelper(_bufferHelper);
+    }
+
+    function _postDepositHook(ERC20 depositAsset, uint256 depositAmount) internal override {
+        (address[] memory targets, bytes[] memory data, uint256[] memory values) =
+            bufferHelper.getDepositManageCall(address(depositAsset), depositAmount);
+        vault.manage(targets, data, values);
+    }
+
+    function _preWithdrawHook(ERC20 withdrawAsset, uint256 shareAmount) internal override {
+        (address[] memory targets, bytes[] memory data, uint256[] memory values) =
+            bufferHelper.getWithdrawManageCall(address(withdrawAsset), shareAmount);
+        vault.manage(targets, data, values);
+    }
+}

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -21,6 +21,10 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
     /// @notice Buffer helper contract for managing withdrawals
     IBufferHelper public withdrawBufferHelper;
 
+    //============================== EVENTS ===============================
+    event DepositBufferHelperSet(address indexed newDepositBufferHelper);
+    event WithdrawBufferHelperSet(address indexed newWithdrawBufferHelper);
+
     /**
      * @notice Initializes the TellerWithBuffer contract
      * @param _owner The address that will have owner privileges
@@ -82,6 +86,7 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      */
     function setDepositBufferHelper(address _depositBufferHelper) external requiresAuth {
         depositBufferHelper = IBufferHelper(_depositBufferHelper);
+        emit DepositBufferHelperSet(_depositBufferHelper);
     }
 
     /**
@@ -92,5 +97,6 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      */
     function setWithdrawBufferHelper(address _withdrawBufferHelper) external requiresAuth {
         withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
+        emit WithdrawBufferHelperSet(_withdrawBufferHelper);
     }
 }

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -615,7 +615,19 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
         }
     }
 
+    /**
+     * @notice Hook that is called after a deposit operation.
+     * @dev Can be overridden by child contracts to implement custom post-deposit logic.
+     * @param depositAsset The ERC20 token that was deposited.
+     * @param assetAmount The amount of the asset that was deposited.
+     */
     function _afterDeposit(ERC20 depositAsset, uint256 assetAmount) internal virtual {}
 
+    /**
+     * @notice Hook that is called before a withdrawal operation.
+     * @dev Can be overridden by child contracts to implement custom pre-withdrawal logic.
+     * @param withdrawAsset The ERC20 token that will be withdrawn.
+     * @param assetAmount The amount of the asset that will be withdrawn.
+     */
     function _beforeWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal virtual {}
 }

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -542,7 +542,6 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
         if (assetsOut < minimumAssets) revert TellerWithMultiAssetSupport__MinimumAssetsNotMet();
         _beforeWithdraw(withdrawAsset, assetsOut);
         vault.exit(to, withdrawAsset, assetsOut, msg.sender, shareAmount);
-        _afterWithdraw(withdrawAsset, assetsOut);
         emit BulkWithdraw(address(withdrawAsset), shareAmount);
     }
 
@@ -619,8 +618,4 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
     function _afterDeposit(ERC20 depositAsset, uint256 assetAmount) internal virtual {}
 
     function _beforeWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal virtual {}
-
-    function _afterWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal virtual {}
-
-    // TODO: settle beforeDeposit
 }

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -540,7 +540,9 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
         if (shareAmount == 0) revert TellerWithMultiAssetSupport__ZeroShares();
         assetsOut = shareAmount.mulDivDown(accountant.getRateInQuoteSafe(withdrawAsset), ONE_SHARE);
         if (assetsOut < minimumAssets) revert TellerWithMultiAssetSupport__MinimumAssetsNotMet();
+        _beforeWithdraw(withdrawAsset, assetsOut);
         vault.exit(to, withdrawAsset, assetsOut, msg.sender, shareAmount);
+        _afterWithdraw(withdrawAsset, assetsOut);
         emit BulkWithdraw(address(withdrawAsset), shareAmount);
     }
 
@@ -566,7 +568,7 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
             if (shares + vault.totalSupply() > cap) revert TellerWithMultiAssetSupport__DepositExceedsCap();
         }
         vault.enter(from, depositAsset, depositAmount, to, shares);
-        _postDepositHook(depositAsset, depositAmount);
+        _afterDeposit(depositAsset, depositAmount);
     }
 
     /**
@@ -614,7 +616,11 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
         }
     }
 
-    function _postDepositHook(ERC20 depositAsset, uint256 depositAmount) internal virtual {}
+    function _afterDeposit(ERC20 depositAsset, uint256 assetAmount) internal virtual {}
 
-    function _preWithdrawHook(ERC20 withdrawAsset, uint256 shareAmount) internal virtual {}
+    function _beforeWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal virtual {}
+
+    function _afterWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal virtual {}
+
+    // TODO: settle beforeDeposit
 }

--- a/src/interfaces/IBufferHelper.sol
+++ b/src/interfaces/IBufferHelper.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+interface IBufferHelper {
+    function getDepositManageCall(address asset, uint256 amount)
+        external
+        view
+        returns (address[] memory targets, bytes[] memory data, uint256[] memory values);
+    function getWithdrawManageCall(address asset, uint256 amount)
+        external
+        view
+        returns (address[] memory targets, bytes[] memory data, uint256[] memory values);
+}

--- a/src/interfaces/IBufferHelper.sol
+++ b/src/interfaces/IBufferHelper.sol
@@ -5,10 +5,29 @@
 pragma solidity 0.8.21;
 
 interface IBufferHelper {
+    /**
+     * @notice Generates management calls to be executed after a deposit operation.
+     * @dev Returns arrays of targets, calldata, and values for the vault to execute.
+     * @param asset The address of the ERC20 token being deposited.
+     * @param amount The amount of the asset being deposited.
+     * @return targets Array of contract addresses to call.
+     * @return data Array of encoded function calls.
+     * @return values Array of ETH values to send with each call.
+     */
     function getDepositManageCall(address asset, uint256 amount)
         external
         view
         returns (address[] memory targets, bytes[] memory data, uint256[] memory values);
+
+    /**
+     * @notice Generates management calls to be executed before a withdrawal operation.
+     * @dev Returns arrays of targets, calldata, and values for the vault to execute.
+     * @param asset The address of the ERC20 token being withdrawn.
+     * @param amount The amount of the asset being withdrawn.
+     * @return targets Array of contract addresses to call.
+     * @return data Array of encoded function calls.
+     * @return values Array of ETH values to send with each call.
+     */
     function getWithdrawManageCall(address asset, uint256 amount)
         external
         view

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -152,6 +152,8 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         uint256 expected_shares = amount;
 
         assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(getERC20(sourceChain, "aV3WETH").balanceOf(address(boringVault)), amount, 1, "Should have put entire deposit into aave");
     }
 
 }

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -150,6 +150,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
 
         assertApproxEqAbs(getERC20(sourceChain, "aV3USDT").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(getERC20(sourceChain, "aV3USDC").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
     }
 
     function testUserDepositWithSufficientOpenApproval(uint256 amount) external {
@@ -188,6 +189,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
 
         assertApproxEqAbs(getERC20(sourceChain, "aV3USDT").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(getERC20(sourceChain, "aV3USDC").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
     }
 
     function testUserDepositWithInsufficientOpenApproval(uint256 amount) external {
@@ -226,6 +228,26 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
 
         assertApproxEqAbs(getERC20(sourceChain, "aV3USDT").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(getERC20(sourceChain, "aV3USDC").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+    }
+
+    function testBulkDeposit(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+
+        teller.bulkDeposit(USDT, amount, 0, address(this));
+        teller.bulkDeposit(USDC, amount, 0, address(this));
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(getERC20(sourceChain, "aV3USDT").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(getERC20(sourceChain, "aV3USDC").balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
     }
 
     // TODO NEXT:

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -360,9 +360,18 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.bulkDeposit(sUSDe, amount / 2, 0, address(this));
 
         // 1e6 /1e18 adjusts token decimals, getRate / 1e18 adjusts for rate scaling
-        assertApproxEqAbs(boringVault.balanceOf(address(this)), amount * 1e6 * sUSDeRateProvider.getRate() / 1e18 / 1e18, 2, "Should have received expected shares");
+        uint256 expectedShares = amount * 1e6 * sUSDeRateProvider.getRate() / 1e18 / 1e18;
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), expectedShares, 2, "Should have received expected shares");
 
         assertApproxEqAbs(asUSDe.balanceOf(address(boringVault)), amount, 4, "Should have put entire deposit into aave");
+    
+        teller.bulkWithdraw(sUSDe, expectedShares / 2, 0, address(this));
+
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), expectedShares / 2, 2, "Should have eliminated expected shares");
+
+        assertApproxEqAbs(asUSDe.balanceOf(address(boringVault)),  amount / 2, 1e12, "Should have removed half of the deposit from aave");
+
+        assertApproxEqAbs(sUSDe.balanceOf(address(this)), amount / 2, 1e12, "Should have received expected sUSDe");
     }
 
     function testWithdrawFailureWhenBufferIsTooSmall(uint256 amount) external {

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithBuffer, TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithBuffer.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {IRateProvider} from "src/interfaces/IRateProvider.sol";
+import {ILiquidityPool} from "src/interfaces/IStaking.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {AtomicSolverV3, AtomicQueue} from "src/atomic-queue/AtomicSolverV3.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {AaveV3BufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+contract TellerBufferTest is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    BoringVault public boringVault;
+
+    uint8 public constant ADMIN_ROLE = 1;
+    uint8 public constant MINTER_ROLE = 7;
+    uint8 public constant BURNER_ROLE = 8;
+    uint8 public constant SOLVER_ROLE = 9;
+    uint8 public constant QUEUE_ROLE = 10;
+    uint8 public constant CAN_SOLVE_ROLE = 11;
+    uint8 public constant TELLER_MANAGER_ROLE = 62;
+
+    TellerWithBuffer public teller;
+    AccountantWithRateProviders public accountant;
+    address public payout_address = vm.addr(7777777);
+    address internal constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    ERC20 internal constant NATIVE_ERC20 = ERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    RolesAuthority public rolesAuthority;
+    AtomicQueue public atomicQueue;
+    AtomicSolverV3 public atomicSolverV3;
+
+    ERC20 internal WETH;
+    ERC20 internal EETH;
+    ERC20 internal WEETH;
+    address internal EETH_LIQUIDITY_POOL;
+    address internal WEETH_RATE_PROVIDER;
+
+    function setUp() public {
+        setSourceChainName("mainnet");
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 19363419;
+        vm.createSelectFork(vm.envString(rpcKey), blockNumber);
+
+        WETH = getERC20(sourceChain, "WETH");
+        EETH = getERC20(sourceChain, "EETH");
+        WEETH = getERC20(sourceChain, "WEETH");
+        EETH_LIQUIDITY_POOL = getAddress(sourceChain, "EETH_LIQUIDITY_POOL");
+        WEETH_RATE_PROVIDER = getAddress(sourceChain, "WEETH_RATE_PROVIDER");
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 18);
+
+        accountant = new AccountantWithRateProviders(
+            address(this), address(boringVault), payout_address, 1e18, address(WETH), 1.001e4, 0.999e4, 1, 0, 0
+        );
+
+        address bufferHelper = address(new AaveV3BufferHelper(getAddress(sourceChain, "v3Pool"), address(boringVault)));
+
+        teller =
+            new TellerWithBuffer(address(this), address(boringVault), address(accountant), address(WETH), bufferHelper, bufferHelper);
+
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+
+        atomicQueue = new AtomicQueue(address(this), Authority(address(0)));
+        atomicSolverV3 = new AtomicSolverV3(address(this), rolesAuthority);
+
+        boringVault.setAuthority(rolesAuthority);
+        accountant.setAuthority(rolesAuthority);
+        teller.setAuthority(rolesAuthority);
+        atomicQueue.setAuthority(rolesAuthority);
+
+        rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);
+        rolesAuthority.setRoleCapability(BURNER_ROLE, address(boringVault), BoringVault.exit.selector, true);
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.updateAssetData.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.bulkDeposit.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.bulkWithdraw.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.refundDeposit.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            SOLVER_ROLE, address(teller), TellerWithMultiAssetSupport.bulkWithdraw.selector, true
+        );
+        rolesAuthority.setRoleCapability(QUEUE_ROLE, address(atomicSolverV3), AtomicSolverV3.finishSolve.selector, true);
+        rolesAuthority.setRoleCapability(
+            CAN_SOLVE_ROLE, address(atomicSolverV3), AtomicSolverV3.redeemSolve.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            TELLER_MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address,bytes,uint256)"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            TELLER_MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address[],bytes[],uint256[])"))),
+            true
+        );
+
+        rolesAuthority.setPublicCapability(address(teller), TellerWithMultiAssetSupport.deposit.selector, true);
+        rolesAuthority.setPublicCapability(
+            address(teller), TellerWithMultiAssetSupport.depositWithPermit.selector, true
+        );
+
+        rolesAuthority.setUserRole(address(this), ADMIN_ROLE, true);
+        rolesAuthority.setUserRole(address(teller), MINTER_ROLE, true);
+        rolesAuthority.setUserRole(address(teller), BURNER_ROLE, true);
+        rolesAuthority.setUserRole(address(teller), TELLER_MANAGER_ROLE, true);
+
+        teller.updateAssetData(WETH, true, true, 0);
+        teller.updateAssetData(ERC20(NATIVE), true, true, 0);
+        teller.updateAssetData(EETH, true, true, 0);
+        teller.updateAssetData(WEETH, true, true, 0);
+
+        accountant.setRateProviderData(EETH, true, address(0));
+        accountant.setRateProviderData(WEETH, false, address(WEETH_RATE_PROVIDER));
+    }
+
+    function testUserDepositPeggedAsset(uint256 amount) external {
+        amount = bound(amount, 0.0001e18, 10_000e18);
+
+        uint256 wETH_amount = amount;
+        deal(address(WETH), address(this), wETH_amount);
+
+        WETH.safeApprove(address(boringVault), wETH_amount);
+        uint96 currentNonce = teller.depositNonce();
+
+        teller.deposit(WETH, wETH_amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
+
+        uint256 expected_shares = amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+    }
+
+}


### PR DESCRIPTION
DRAFT:

- Define IBufferHelper to return parameters for TellerWithBuffer to manage call the vault
- Implement AaveV3BufferHelper to return aave deposit/withdrawal parameters
- Implement TellerWithBuffer, using afterDeposit and beforeWithdraw to manage the vault to allocate/deallocate capital from idle strategies
- Change TellerWithMultiAssetSupport to make more functions virtual and include afterDeposit and beforeWithdraw hooks