### PR TITLE
increase instant withdraw buffer flexibility, add tests

### DIFF
--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -92,11 +92,12 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      * to the deposit management strategy without requiring contract redeployment.
      */
     function setDepositBufferHelper(ERC20 _asset, IBufferHelper _depositBufferHelper) external requiresAuth {
-        if (!allowedBufferHelpers[_asset][_depositBufferHelper]) {
+        if (allowedBufferHelpers[_asset][_depositBufferHelper] || _depositBufferHelper == IBufferHelper(address(0))) {
+            currentBufferHelpers[_asset].depositBufferHelper = _depositBufferHelper;
+            emit DepositBufferHelperSet(_asset, _depositBufferHelper);
+        } else {
             revert TellerWithBuffer__BufferHelperNotAllowed(_asset, _depositBufferHelper);
         }
-        currentBufferHelpers[_asset].depositBufferHelper = _depositBufferHelper;
-        emit DepositBufferHelperSet(_asset, _depositBufferHelper);
     }
 
     /**
@@ -107,11 +108,12 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      * to the withdrawal management strategy without requiring contract redeployment.
      */
     function setWithdrawBufferHelper(ERC20 _asset, IBufferHelper _withdrawBufferHelper) external requiresAuth {
-        if (!allowedBufferHelpers[_asset][_withdrawBufferHelper]) {
+        if (allowedBufferHelpers[_asset][_withdrawBufferHelper] || _withdrawBufferHelper == IBufferHelper(address(0))) {
+            currentBufferHelpers[_asset].withdrawBufferHelper = _withdrawBufferHelper;
+            emit WithdrawBufferHelperSet(_asset, _withdrawBufferHelper);
+        } else {
             revert TellerWithBuffer__BufferHelperNotAllowed(_asset, _withdrawBufferHelper);
         }
-        currentBufferHelpers[_asset].withdrawBufferHelper = _withdrawBufferHelper;
-        emit WithdrawBufferHelperSet(_asset, _withdrawBufferHelper);
     }
 
     /**

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -15,15 +15,26 @@ import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
  * The buffer helpers can trigger additional vault management calls during these operations.
  */
 contract TellerWithBuffer is TellerWithMultiAssetSupport {
-    /// @notice Buffer helper contract for managing deposits
-    IBufferHelper public depositBufferHelper;
 
-    /// @notice Buffer helper contract for managing withdrawals
-    IBufferHelper public withdrawBufferHelper;
+    //============================== STRUCTS ===============================
+    struct BufferHelpers {
+        IBufferHelper depositBufferHelper;
+        IBufferHelper withdrawBufferHelper;
+    }
+
+    //============================== STATE ===============================
+    mapping(ERC20 => BufferHelpers) public currentBufferHelpers;
+
+    mapping(ERC20 => mapping(IBufferHelper => bool)) public allowedBufferHelpers;
+
+    //============================== ERRORS ===============================
+    error TellerWithBuffer__BufferHelperNotAllowed(ERC20 asset, IBufferHelper bufferHelper);
 
     //============================== EVENTS ===============================
-    event DepositBufferHelperSet(address indexed newDepositBufferHelper);
-    event WithdrawBufferHelperSet(address indexed newWithdrawBufferHelper);
+    event DepositBufferHelperSet(ERC20 indexed asset, IBufferHelper indexed newDepositBufferHelper);
+    event WithdrawBufferHelperSet(ERC20 indexed asset, IBufferHelper indexed newWithdrawBufferHelper);
+    event BufferHelperAllowed(ERC20 indexed asset, IBufferHelper indexed bufferHelper);
+    event BufferHelperDisallowed(ERC20 indexed asset, IBufferHelper indexed bufferHelper);
 
     /**
      * @notice Initializes the TellerWithBuffer contract
@@ -31,20 +42,13 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      * @param _vault The vault contract address this teller will interact with
      * @param _accountant The accountant contract address associated with the vault
      * @param _weth The WETH token address for ETH wrapping/unwrapping operations
-     * @param _depositBufferHelper The buffer helper contract for deposit management
-     * @param _withdrawBufferHelper The buffer helper contract for withdrawal management
      */
     constructor(
         address _owner,
         address _vault,
         address _accountant,
-        address _weth,
-        address _depositBufferHelper,
-        address _withdrawBufferHelper
-    ) TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth) {
-        depositBufferHelper = IBufferHelper(_depositBufferHelper);
-        withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
-    }
+        address _weth
+    ) TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth) {}
 
     /**
      * @notice Executes buffer management after a deposit operation
@@ -55,9 +59,10 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      * and execute them through the vault's manage function.
      */
     function _afterDeposit(ERC20 depositAsset, uint256 assetAmount) internal override {
-        if (address(depositBufferHelper) != address(0)) {
-            (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-                depositBufferHelper.getDepositManageCall(address(depositAsset), assetAmount);
+        if (address(currentBufferHelpers[depositAsset].depositBufferHelper) != address(0)) {
+            (address[] memory targets, bytes[] memory data, uint256[] memory values) = currentBufferHelpers[depositAsset]
+                .depositBufferHelper
+                .getDepositManageCall(address(depositAsset), assetAmount);
             vault.manage(targets, data, values);
         }
     }
@@ -71,32 +76,63 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      * and execute them through the vault's manage function.
      */
     function _beforeWithdraw(ERC20 withdrawAsset, uint256 assetAmount) internal override {
-        if (address(withdrawBufferHelper) != address(0)) {
-            (address[] memory targets, bytes[] memory data, uint256[] memory values) =
-                withdrawBufferHelper.getWithdrawManageCall(address(withdrawAsset), assetAmount);
+        if (address(currentBufferHelpers[withdrawAsset].withdrawBufferHelper) != address(0)) {
+            (address[] memory targets, bytes[] memory data, uint256[] memory values) = currentBufferHelpers[withdrawAsset]
+                .withdrawBufferHelper
+                .getWithdrawManageCall(address(withdrawAsset), assetAmount);
             vault.manage(targets, data, values);
         }
     }
 
     /**
      * @notice Updates the deposit buffer helper contract
+     * @param _asset The asset to update the buffer helper for
      * @param _depositBufferHelper The new deposit buffer helper contract address
      * @dev Only callable by authorized accounts. This allows for dynamic updates
      * to the deposit management strategy without requiring contract redeployment.
      */
-    function setDepositBufferHelper(address _depositBufferHelper) external requiresAuth {
-        depositBufferHelper = IBufferHelper(_depositBufferHelper);
-        emit DepositBufferHelperSet(_depositBufferHelper);
+    function setDepositBufferHelper(ERC20 _asset, IBufferHelper _depositBufferHelper) external requiresAuth {
+        if (!allowedBufferHelpers[_asset][_depositBufferHelper]) {
+            revert TellerWithBuffer__BufferHelperNotAllowed(_asset, _depositBufferHelper);
+        }
+        currentBufferHelpers[_asset].depositBufferHelper = _depositBufferHelper;
+        emit DepositBufferHelperSet(_asset, _depositBufferHelper);
     }
 
     /**
      * @notice Updates the withdrawal buffer helper contract
+     * @param _asset The asset to update the buffer helper for
      * @param _withdrawBufferHelper The new withdrawal buffer helper contract address
      * @dev Only callable by authorized accounts. This allows for dynamic updates
      * to the withdrawal management strategy without requiring contract redeployment.
      */
-    function setWithdrawBufferHelper(address _withdrawBufferHelper) external requiresAuth {
-        withdrawBufferHelper = IBufferHelper(_withdrawBufferHelper);
-        emit WithdrawBufferHelperSet(_withdrawBufferHelper);
+    function setWithdrawBufferHelper(ERC20 _asset, IBufferHelper _withdrawBufferHelper) external requiresAuth {
+        if (!allowedBufferHelpers[_asset][_withdrawBufferHelper]) {
+            revert TellerWithBuffer__BufferHelperNotAllowed(_asset, _withdrawBufferHelper);
+        }
+        currentBufferHelpers[_asset].withdrawBufferHelper = _withdrawBufferHelper;
+        emit WithdrawBufferHelperSet(_asset, _withdrawBufferHelper);
+    }
+
+    /**
+     * @notice Allows a buffer helper to be used for a specific asset
+     * @param _asset The asset to allow the buffer helper for
+     * @param _bufferHelper The buffer helper contract address to allow
+     * @dev Only callable by admin to allowlist buffer helpers for a specific asset
+     */
+    function allowBufferHelper(ERC20 _asset, IBufferHelper _bufferHelper) external requiresAuth {
+        allowedBufferHelpers[_asset][_bufferHelper] = true;
+        emit BufferHelperAllowed(_asset, _bufferHelper);
+    }
+
+    /**
+     * @notice Disallows a buffer helper from being used for a specific asset
+     * @param _asset The asset to disallow the buffer helper for
+     * @param _bufferHelper The buffer helper contract address to disallow
+     * @dev Only callable by admin to disallow buffer helpers for a specific asset
+     */
+    function disallowBufferHelper(ERC20 _asset, IBufferHelper _bufferHelper) external requiresAuth {
+        allowedBufferHelpers[_asset][_bufferHelper] = false;
+        emit BufferHelperDisallowed(_asset, _bufferHelper);
     }
 }

--- a/src/base/Roles/TellerWithYieldStreaming.sol
+++ b/src/base/Roles/TellerWithYieldStreaming.sol
@@ -17,10 +17,8 @@ contract TellerWithYieldStreaming is TellerWithBuffer {
         address _owner,
         address _vault,
         address _accountant,
-        address _weth,
-        address _depositBufferHelper,
-        address _withdrawBufferHelper
-    ) TellerWithBuffer(_owner, _vault, _accountant, _weth, _depositBufferHelper, _withdrawBufferHelper) {}
+        address _weth
+    ) TellerWithBuffer(_owner, _vault, _accountant, _weth) {}
 
     /**
      * @notice Allows off ramp role to withdraw from this contract.

--- a/test/AccountantWithYieldStreaming.t.sol
+++ b/test/AccountantWithYieldStreaming.t.sol
@@ -73,7 +73,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
             address(this), address(boringVault), payoutAddress, 1e18, address(WETH), 1.001e4, 0.999e4, 1, 0.1e4, 0.1e4
         );
         teller =
-            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(WETH), address(0), address(0));
+            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(WETH));
 
         rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
         accountant.setAuthority(rolesAuthority);

--- a/test/AccountantWithYieldStreamingExchangeRateGtOne.t.sol
+++ b/test/AccountantWithYieldStreamingExchangeRateGtOne.t.sol
@@ -68,7 +68,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
             address(this), address(boringVault), payoutAddress, 1.2e18, address(WETH), 1.001e4, 0.999e4, 1, 0.1e4, 0.1e4
         );
         teller =
-            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(WETH), address(0), address(0));
+            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(WETH));
 
         rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
         accountant.setAuthority(rolesAuthority);

--- a/test/AccountantWithYieldStreamingNonWadScaledVault.t.sol
+++ b/test/AccountantWithYieldStreamingNonWadScaledVault.t.sol
@@ -63,7 +63,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
             address(this), address(boringVault), payoutAddress, 1e6, address(USDC), 1.001e4, 0.999e4, 1, 0.1e4, 0.1e4
         );
         teller =
-            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(USDC), address(0), address(0));
+            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), getAddress(sourceChain, "WETH"));
 
         rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
         accountant.setAuthority(rolesAuthority);

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -483,9 +483,6 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 5 + amount / 10, 4, "Should have received expected USDT");
     }
 
-    // TODO:
-    // test setting current buffer helper to address(0) deposit/withdraw
-
     function testBufferHelperZeroAddress(uint256 amount) external {
         amount = bound(amount, 0.0001e6, 10_000e6);
         deal(address(USDT), address(this), amount);
@@ -502,10 +499,9 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.withdraw(USDT, amount / 2, 0, address(this));
         assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 2, 4, "Should have received expected USDT");
         assertApproxEqAbs(USDT.balanceOf(address(boringVault)), amount / 2, 4, "half USDT should be in vault");
+        assertEq(aUSDT.balanceOf(address(boringVault)), 0, "0 USDT should be in aave");
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
     }
-
-    // test setting current buffer helper to a different buffer helper deposit/withdraw
 
     function testBufferHelperChange(uint256 amount) external {
         amount = bound(amount, 0.0001e6, 10_000e6);

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -17,6 +17,7 @@ import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthorit
 import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
 import {AaveV3BufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
 import {GenericRateProviderWithDecimalScaling} from "src/helper/GenericRateProviderWithDecimalScaling.sol";
+import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
@@ -77,7 +78,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         address bufferHelper = address(new AaveV3BufferHelper(v3Pool, address(boringVault)));
 
         teller =
-            new TellerWithBuffer(address(this), address(boringVault), address(accountant), address(USDT), bufferHelper, bufferHelper);
+            new TellerWithBuffer(address(this), address(boringVault), address(accountant), getAddress(sourceChain, "WETH"));
 
         rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
 
@@ -149,6 +150,18 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.updateAssetData(sUSDe, true, true, 0);
         accountant.setRateProviderData(USDC, true, address(0));
         accountant.setRateProviderData(sUSDe, false, address(sUSDeRateProvider));
+
+        teller.allowBufferHelper(USDT, IBufferHelper(bufferHelper));
+        teller.allowBufferHelper(USDC, IBufferHelper(bufferHelper));
+        teller.allowBufferHelper(sUSDe, IBufferHelper(bufferHelper));
+
+        teller.setWithdrawBufferHelper(USDT, IBufferHelper(bufferHelper));
+        teller.setWithdrawBufferHelper(USDC, IBufferHelper(bufferHelper));
+        teller.setWithdrawBufferHelper(sUSDe, IBufferHelper(bufferHelper));
+
+        teller.setDepositBufferHelper(USDT, IBufferHelper(bufferHelper));
+        teller.setDepositBufferHelper(USDC, IBufferHelper(bufferHelper));
+        teller.setDepositBufferHelper(sUSDe, IBufferHelper(bufferHelper));
     }
 
     function testUserDepositPeggedAssets(uint256 amount) external {

--- a/test/TellerWithYieldStreamingBuffer.t.sol
+++ b/test/TellerWithYieldStreamingBuffer.t.sol
@@ -18,6 +18,7 @@ import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthorit
 import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
 import {AaveV3BufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
 import {GenericRateProviderWithDecimalScaling} from "src/helper/GenericRateProviderWithDecimalScaling.sol";
+import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
@@ -168,6 +169,18 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         teller.updateAssetData(sUSDe, true, true, 0);
         accountant.setRateProviderData(USDC, true, address(0));
         accountant.setRateProviderData(sUSDe, false, address(sUSDeRateProvider));
+
+        teller.allowBufferHelper(USDT, IBufferHelper(bufferHelper));
+        teller.allowBufferHelper(USDC, IBufferHelper(bufferHelper));
+        teller.allowBufferHelper(sUSDe, IBufferHelper(bufferHelper));
+
+        teller.setWithdrawBufferHelper(USDT, IBufferHelper(bufferHelper));
+        teller.setWithdrawBufferHelper(USDC, IBufferHelper(bufferHelper));
+        teller.setWithdrawBufferHelper(sUSDe, IBufferHelper(bufferHelper));
+
+        teller.setDepositBufferHelper(USDT, IBufferHelper(bufferHelper));
+        teller.setDepositBufferHelper(USDC, IBufferHelper(bufferHelper));
+        teller.setDepositBufferHelper(sUSDe, IBufferHelper(bufferHelper));
     }
 
     function testUserDepositPeggedAssets(uint256 amount) external {
@@ -461,8 +474,9 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         vm.warp(block.timestamp + 10);
         deal(address(USDT), address(boringVault), amount / 100);
         accountant.updateMinimumVestDuration(1);
-        accountant.vestYield(amount / 100, 1);
-        vm.warp(block.timestamp + 2);
+        accountant.updateMaximumDeviationYield(9999);
+        accountant.vestYield(amount / 100, 1000);
+        vm.warp(block.timestamp + 1001);
 
         vm.expectRevert(0x47bc4b2c); // aave withdrawal failure error
         teller.bulkWithdraw(USDT, amount, 0, address(this));

--- a/test/TellerWithYieldStreamingBuffer.t.sol
+++ b/test/TellerWithYieldStreamingBuffer.t.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
-import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+import {TellerWithYieldStreaming, TellerWithBuffer} from "src/base/Roles/TellerWithYieldStreaming.sol";
 import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
 import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -505,9 +505,82 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         vm.warp(block.timestamp + 10);
         teller.withdraw(USDT, amount / 5, 0, address(this));
         assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 5 + amount / 10, 4, "Should have received expected USDT");
+    }
 
+    function testBufferHelperZeroAddress(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        USDT.safeApprove(address(boringVault), amount);
 
+        teller.setWithdrawBufferHelper(USDT, IBufferHelper(address(0)));
+        teller.setDepositBufferHelper(USDT, IBufferHelper(address(0)));
+        
+        teller.deposit(USDT, amount, 0);
 
+        assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
+        assertEq(USDT.balanceOf(address(boringVault)), amount, "USDT should all be in vault");
 
+        teller.withdraw(USDT, amount / 2, 0, address(this));
+        assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 2, 4, "Should have received expected USDT");
+        assertApproxEqAbs(USDT.balanceOf(address(boringVault)), amount / 2, 4, "half USDT should be in vault");
+        assertEq(aUSDT.balanceOf(address(boringVault)), 0, "0 USDT should be in aave");
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
+    }
+
+    function testBufferHelperChange(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+
+        address newBufferHelper = address(new AaveV3BufferHelper(v3Pool, address(boringVault)));
+
+        teller.allowBufferHelper(USDT, IBufferHelper(newBufferHelper));
+
+        teller.setWithdrawBufferHelper(USDT, IBufferHelper(newBufferHelper));
+        teller.setDepositBufferHelper(USDT, IBufferHelper(newBufferHelper));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TellerWithBuffer.TellerWithBuffer__BufferHelperNotAllowed.selector,
+                USDC,
+                IBufferHelper(newBufferHelper)
+            )
+        );
+        teller.setWithdrawBufferHelper(USDC, IBufferHelper(newBufferHelper));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TellerWithBuffer.TellerWithBuffer__BufferHelperNotAllowed.selector,
+                USDC,
+                IBufferHelper(newBufferHelper)
+            )
+        );
+        teller.setDepositBufferHelper(USDC, IBufferHelper(newBufferHelper));
+
+        teller.allowBufferHelper(USDC, IBufferHelper(newBufferHelper));
+        teller.setWithdrawBufferHelper(USDC, IBufferHelper(newBufferHelper));
+        teller.setDepositBufferHelper(USDC, IBufferHelper(newBufferHelper));
+
+        teller.deposit(USDT, amount, 0);
+
+        assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 4, "USDT should all be in aave");
+
+        teller.withdraw(USDT, amount / 2, 0, address(this));
+        assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 2, 4, "Should have received expected USDT");
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount / 2, 4, "half USDT should be in aave");
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
+    
+        uint256 currentShares = boringVault.balanceOf(address(this));
+        teller.deposit(USDC, amount, 0);
+        assertEq(boringVault.balanceOf(address(this)) - currentShares, amount, "Change in shares should be same as deposit amount");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 4, "USDC should all be in aave");
+
+        currentShares = boringVault.balanceOf(address(this));
+        teller.withdraw(USDC, amount / 2, 0, address(this));
+        assertApproxEqAbs(USDC.balanceOf(address(this)), amount / 2, 4, "Should have received expected USDC");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount / 2, 4, "half USDC should be in aave");
+        assertApproxEqAbs(currentShares - boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
     }
 }

--- a/test/TellerWithYieldStreamingBuffer.t.sol
+++ b/test/TellerWithYieldStreamingBuffer.t.sol
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {IRateProvider} from "src/interfaces/IRateProvider.sol";
+import {ILiquidityPool} from "src/interfaces/IStaking.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {AaveV3BufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
+import {GenericRateProviderWithDecimalScaling} from "src/helper/GenericRateProviderWithDecimalScaling.sol";
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+
+contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    BoringVault public boringVault;
+
+    uint8 public constant ADMIN_ROLE = 1;
+    uint8 public constant MINTER_ROLE = 7;
+    uint8 public constant BURNER_ROLE = 8;
+    uint8 public constant SOLVER_ROLE = 9;
+    uint8 public constant QUEUE_ROLE = 10;
+    uint8 public constant CAN_SOLVE_ROLE = 11;
+    uint8 public constant TELLER_MANAGER_ROLE = 62;
+
+    TellerWithYieldStreaming public teller;
+    AccountantWithYieldStreaming public accountant;
+    address public payout_address = vm.addr(7777777);
+    address internal constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    ERC20 internal constant NATIVE_ERC20 = ERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    RolesAuthority public rolesAuthority;
+
+    ERC20 internal USDT;
+    ERC20 internal USDC;
+    ERC20 internal sUSDe;
+    ERC20 internal aUSDT;
+    ERC20 internal aUSDC;
+    ERC20 internal asUSDe;
+
+    GenericRateProviderWithDecimalScaling internal sUSDeRateProvider;
+
+    address internal v3Pool;
+
+    function setUp() public {
+        setSourceChainName("mainnet");
+        // Setup forked environment.
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 23091932;
+        vm.createSelectFork(vm.envString(rpcKey), blockNumber);
+
+        USDT = getERC20(sourceChain, "USDT");
+        USDC = getERC20(sourceChain, "USDC");
+        aUSDT = getERC20(sourceChain, "aV3USDT");
+        aUSDC = getERC20(sourceChain, "aV3USDC");
+        sUSDe = getERC20(sourceChain, "SUSDE");
+        asUSDe = ERC20(0x4579a27aF00A62C0EB156349f31B345c08386419); // aV3sUSDe
+        v3Pool = getAddress(sourceChain, "v3Pool");
+        bytes32 salt = keccak256("boring-vault-salt");
+        boringVault = new BoringVault{salt: salt}(address(this), "Boring Vault", "BV", 6);
+
+        accountant = new AccountantWithYieldStreaming(
+            address(this), address(boringVault), payout_address, 1e6, address(USDT), 1.1e4, 0.9e4, 1, 0, 0
+        );
+
+        address bufferHelper = address(new AaveV3BufferHelper(v3Pool, address(boringVault)));
+
+        teller =
+            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(USDT), bufferHelper, bufferHelper);
+
+        rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
+
+        sUSDeRateProvider = new GenericRateProviderWithDecimalScaling(
+            GenericRateProviderWithDecimalScaling.ConstructorArgs({
+                target: 0xFF3BC18cCBd5999CE63E788A1c250a88626aD099, // sUSDe chainlink
+                selector: bytes4(0x50d25bcd), // latestAnswer()
+                staticArgument0: bytes32(0),
+                staticArgument1: bytes32(0),
+                staticArgument2: bytes32(0),
+                staticArgument3: bytes32(0),
+                staticArgument4: bytes32(0),
+                staticArgument5: bytes32(0),
+                staticArgument6: bytes32(0),
+                staticArgument7: bytes32(0),
+                signed: true,
+                inputDecimals: 8,
+                outputDecimals: 18
+            })
+        );
+
+        boringVault.setAuthority(rolesAuthority);
+        accountant.setAuthority(rolesAuthority);
+        teller.setAuthority(rolesAuthority);
+
+        rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);
+        rolesAuthority.setRoleCapability(BURNER_ROLE, address(boringVault), BoringVault.exit.selector, true);
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.updateAssetData.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.bulkDeposit.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.bulkWithdraw.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.refundDeposit.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(teller), AccountantWithYieldStreaming.updateMinimumVestDuration.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            SOLVER_ROLE, address(teller), TellerWithMultiAssetSupport.bulkWithdraw.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            ADMIN_ROLE, address(accountant), AccountantWithYieldStreaming.vestYield.selector, true
+        );
+        rolesAuthority.setRoleCapability(
+            TELLER_MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address,bytes,uint256)"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            TELLER_MANAGER_ROLE,
+            address(boringVault),
+            bytes4(keccak256(abi.encodePacked("manage(address[],bytes[],uint256[])"))),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            TELLER_MANAGER_ROLE,
+            address(accountant),
+            bytes4(keccak256("updateExchangeRate()")),
+            true
+        );
+        rolesAuthority.setRoleCapability(
+            TELLER_MANAGER_ROLE,
+            address(accountant),
+            bytes4(keccak256("updateCumulative()")),
+            true
+        );
+
+        rolesAuthority.setPublicCapability(address(teller), TellerWithMultiAssetSupport.deposit.selector, true);
+        rolesAuthority.setPublicCapability(
+            address(teller), TellerWithMultiAssetSupport.depositWithPermit.selector, true
+        );
+        rolesAuthority.setPublicCapability(address(teller), TellerWithMultiAssetSupport.withdraw.selector, true);
+
+        rolesAuthority.setUserRole(address(this), ADMIN_ROLE, true);
+        rolesAuthority.setUserRole(address(teller), MINTER_ROLE, true);
+        rolesAuthority.setUserRole(address(teller), BURNER_ROLE, true);
+        rolesAuthority.setUserRole(address(teller), TELLER_MANAGER_ROLE, true);
+
+        teller.updateAssetData(USDT, true, true, 0);
+        teller.updateAssetData(USDC, true, true, 0);
+        teller.updateAssetData(sUSDe, true, true, 0);
+        accountant.setRateProviderData(USDC, true, address(0));
+        accountant.setRateProviderData(sUSDe, false, address(sUSDeRateProvider));
+    }
+
+    function testUserDepositPeggedAssets(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+        uint96 currentNonce = teller.depositNonce();
+
+        teller.deposit(USDT, amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
+
+        teller.deposit(USDC, amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
+        assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+    }
+
+    function testUserDepositWithSufficientOpenApproval(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        // approve >= the amount that will be deposited
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeWithSelector(USDT.approve.selector, v3Pool, amount);
+        data[1] = abi.encodeWithSelector(USDC.approve.selector, v3Pool, amount);
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(USDT);
+        targets[1] = address(USDC);
+
+        uint256[] memory values = new uint256[](2);
+
+        rolesAuthority.setUserRole(address(this), TELLER_MANAGER_ROLE, true);
+
+        boringVault.manage(targets, data, values);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+        uint96 currentNonce = teller.depositNonce();
+
+        teller.deposit(USDT, amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
+
+        teller.deposit(USDC, amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
+        assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+    }
+
+    function testUserDepositWithInsufficientOpenApproval(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        // approve less than the amount that will be deposited
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeWithSelector(USDT.approve.selector, v3Pool, amount - 1);
+        data[1] = abi.encodeWithSelector(USDC.approve.selector, v3Pool, amount - 1);
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(USDT);
+        targets[1] = address(USDC);
+
+        uint256[] memory values = new uint256[](2);
+        
+        rolesAuthority.setUserRole(address(this), TELLER_MANAGER_ROLE, true);
+
+        boringVault.manage(targets, data, values);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+        uint96 currentNonce = teller.depositNonce();
+
+        teller.deposit(USDT, amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
+
+        teller.deposit(USDC, amount, 0);
+        assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
+        assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+    }
+
+    function testBulkDeposit(uint256 amount) external {
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+
+        teller.bulkDeposit(USDT, amount, 0, address(this));
+        teller.bulkDeposit(USDC, amount, 0, address(this));
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+    }
+
+    function testBulkWithdraw(uint256 amount) external {
+        // first do deposits
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+
+        teller.bulkDeposit(USDT, amount, 0, address(this));
+        teller.bulkDeposit(USDC, amount, 0, address(this));
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        
+        // then do withdraws
+        teller.bulkWithdraw(USDT, amount - 2, 0, address(this));
+        teller.bulkWithdraw(USDC, amount - 2, 0, address(this));
+
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), 0, 4, "Should have eliminated expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), 0, 2, "Should have removed entire deposit from aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), 0, 2, "Should have removed entire deposit from aave");
+
+        // check withdrawn balances
+        assertApproxEqAbs(USDT.balanceOf(address(this)), amount - 2, 2, "Should have received expected USDT");
+        assertApproxEqAbs(USDC.balanceOf(address(this)), amount - 2, 2, "Should have received expected USDC");
+    }
+
+    function testWithdraw(uint256 amount) external {
+        // first do deposits
+        amount = bound(amount, 0.0001e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+        deal(address(USDC), address(this), amount);
+
+        USDT.safeApprove(address(boringVault), amount);
+        USDC.safeApprove(address(boringVault), amount);
+
+        teller.bulkDeposit(USDT, amount, 0, address(this));
+        teller.bulkDeposit(USDC, amount, 0, address(this));
+
+        uint256 expected_shares = 2 * amount;
+
+        assertEq(boringVault.balanceOf(address(this)), expected_shares, "Should have received expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 2, "Should have put entire deposit into aave");
+        
+        // then do withdraws
+        teller.withdraw(USDT, amount - 2, 0, address(this));
+        teller.withdraw(USDC, amount - 2, 0, address(this));
+
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), 0, 4, "Should have eliminated expected shares");
+
+        assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), 0, 2, "Should have removed entire deposit from aave");
+        assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), 0, 2, "Should have removed entire deposit from aave");
+
+        // check withdrawn balances
+        assertApproxEqAbs(USDT.balanceOf(address(this)), amount - 2, 2, "Should have received expected USDT");
+        assertApproxEqAbs(USDC.balanceOf(address(this)), amount - 2, 2, "Should have received expected USDC");
+    }
+
+    // function testMultipleDepositWithdraws(uint256 amount) external {
+    //     amount = bound(amount, 0.01e6, 10_000e6);
+    //     deal(address(USDT), address(this), amount);
+    //     deal(address(USDC), address(this), amount);
+
+    //     USDT.safeApprove(address(boringVault), amount);
+    //     USDC.safeApprove(address(boringVault), amount);
+
+    //     teller.bulkDeposit(USDT, amount / 10, 0, address(this));
+    //     teller.deposit(USDC, amount / 10, 0);
+    //     assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 5, 4, "Should have received expected shares");
+    //     uint256 pointOnePercentYield = amount / 5 / 1000; // add 100 to avoid rounding errors
+    //     deal(address(USDC), address(boringVault), pointOnePercentYield + 1000); // 1% of the current total assets
+    //     deal(address(USDT), address(boringVault), pointOnePercentYield + 1000); // 1% of the current total assets
+
+    //     // manage vault to deposit the dealt assets into aave (2% yield, 1% each asset)
+    //     bytes[] memory data = new bytes[](4);
+    //     data[0] = abi.encodeWithSelector(USDC.approve.selector, v3Pool, pointOnePercentYield + 1000);
+    //     data[1] = abi.encodeWithSignature("supply(address,uint256,address,uint16)", address(USDC), pointOnePercentYield + 1000, address(boringVault), 0);
+    //     data[2] = abi.encodeWithSelector(USDT.approve.selector, v3Pool, pointOnePercentYield + 1000);
+    //     data[3] = abi.encodeWithSignature("supply(address,uint256,address,uint16)", address(USDT), pointOnePercentYield + 1000, address(boringVault), 0);
+
+    //     address[] memory targets = new address[](4);
+    //     targets[0] = address(USDC);
+    //     targets[1] = v3Pool;
+    //     targets[2] = address(USDT);
+    //     targets[3] = v3Pool;
+
+    //     uint256[] memory values = new uint256[](4);
+    //     boringVault.manage(targets, data, values);
+
+    //     accountant.updateMinimumVestDuration(1);
+
+    //     accountant.vestYield(2 * pointOnePercentYield, 1);
+
+    //     vm.warp(block.timestamp + 2);
+
+    //     teller.bulkWithdraw(USDC, amount / 10, 0, address(this));
+
+    //     assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 10, 200, "Should have eliminated expected shares");
+
+    //     assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), 0, 2000, "Should have removed entire deposit from aave");
+
+    //     // check that we got back the amount we deposited plus the yield
+    //     assertApproxEqAbs(USDC.balanceOf(address(this)), amount + pointOnePercentYield, 1000, "Should have received expected USDC");
+
+    //     // test regular withdraw
+    //     teller.withdraw(USDT, amount / 100, 0, address(this));
+
+    //     assertApproxEqAbs(boringVault.balanceOf(address(this)), 9 * amount / 100, 200, "Should have eliminated expected shares");
+
+    //     assertApproxEqRel(aUSDT.balanceOf(address(boringVault)), 9 * amount / 100 + 9 * pointOnePercentYield / 10, 1e15, "Should have removed from aave");
+
+    //     assertApproxEqAbs(USDT.balanceOf(address(this)), 91 * amount / 100 + pointOnePercentYield / 10, 1000, "Should have received expected USDT");
+    // }
+
+    function testNonPeggedAsset(uint256 amount) external {
+        amount = bound(amount, 0.0001e18, 10_000e18);
+        deal(address(sUSDe), address(this), amount);
+
+        sUSDe.safeApprove(address(boringVault), amount);
+
+        teller.deposit(sUSDe, amount / 2, 0);
+        teller.bulkDeposit(sUSDe, amount / 2, 0, address(this));
+
+        // 1e6 /1e18 adjusts token decimals, getRate / 1e18 adjusts for rate scaling
+        uint256 expectedShares = amount * 1e6 * sUSDeRateProvider.getRate() / 1e18 / 1e18;
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), expectedShares, 2, "Should have received expected shares");
+
+        assertApproxEqAbs(asUSDe.balanceOf(address(boringVault)), amount, 4, "Should have put entire deposit into aave");
+    
+        teller.bulkWithdraw(sUSDe, expectedShares / 2, 0, address(this));
+
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), expectedShares / 2, 2, "Should have eliminated expected shares");
+
+        assertApproxEqAbs(asUSDe.balanceOf(address(boringVault)),  amount / 2, 1e12, "Should have removed half of the deposit from aave");
+
+        assertApproxEqAbs(sUSDe.balanceOf(address(this)), amount / 2, 1e12, "Should have received expected sUSDe");
+
+        // test regular withdraw
+        teller.withdraw(sUSDe, expectedShares / 2, 0, address(this));
+
+        assertApproxEqAbs(boringVault.balanceOf(address(this)), 0, 2, "Should have eliminated expected shares");
+
+        // increase error to account for 2x rounding errors
+        assertApproxEqAbs(asUSDe.balanceOf(address(boringVault)), 0, 2e12, "Should have removed entire remaining deposit from aave");
+
+        assertApproxEqAbs(sUSDe.balanceOf(address(this)), amount, 2e12, "Should have received expected sUSDe");
+    }
+
+    function testWithdrawFailureWhenBufferIsTooSmall(uint256 amount) external {
+        amount = bound(amount, 0.01e6, 100_000e6);
+        deal(address(USDT), address(this), amount);
+
+        USDT.safeApprove(address(boringVault), amount);
+
+        teller.deposit(USDT, amount, 0);
+
+        // give the vault an additional 1% yield
+        // not in the buffer though
+        vm.warp(block.timestamp + 10);
+        deal(address(USDT), address(boringVault), amount / 100);
+        accountant.updateMinimumVestDuration(1);
+        accountant.vestYield(amount / 100, 1);
+        vm.warp(block.timestamp + 2);
+
+        vm.expectRevert(0x47bc4b2c); // aave withdrawal failure error
+        teller.bulkWithdraw(USDT, amount, 0, address(this));
+
+        vm.expectRevert(0x47bc4b2c); // aave withdrawal failure error
+        teller.withdraw(USDT, amount, 0, address(this));
+    }
+    
+    function testShareLock(uint256 amount) external {
+        amount = bound(amount, 0.01e6, 10_000e6);
+        deal(address(USDT), address(this), amount);
+
+        teller.setShareLockPeriod(10);
+        USDT.safeApprove(address(boringVault), amount);
+        teller.deposit(USDT, amount, 0);
+
+        // should revert because shares are locked
+        vm.expectRevert(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreLocked.selector);
+        teller.withdraw(USDT, amount / 10, 0, address(this));
+
+        // should bypass share lock
+        teller.bulkWithdraw(USDT, amount / 10, 0, address(this));
+        assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 10, 2, "Should have received expected USDT");
+
+        // skip to end of share lock period, regular withdraw should work
+        vm.warp(block.timestamp + 10);
+        teller.withdraw(USDT, amount / 5, 0, address(this));
+        assertApproxEqAbs(USDT.balanceOf(address(this)), amount / 5 + amount / 10, 4, "Should have received expected USDT");
+
+
+
+
+    }
+}

--- a/test/TellerWithYieldStreamingBuffer.t.sol
+++ b/test/TellerWithYieldStreamingBuffer.t.sol
@@ -78,7 +78,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         address bufferHelper = address(new AaveV3BufferHelper(v3Pool, address(boringVault)));
 
         teller =
-            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(USDT), bufferHelper, bufferHelper);
+            new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), getAddress(sourceChain, "WETH"));
 
         rolesAuthority = new RolesAuthority(address(this), Authority(address(0)));
 


### PR DESCRIPTION
move from single deposit and single withdraw buffer to per-asset mappings with allowlist:
- mapping of allowed BufferHelpers per asset
- mapping of current BufferHelpers per asset
- tests for execution after manipulating the mappings
- tests that allowList functions
- replicate TellerWithBuffer tests for child TellerWithYieldStreaming