### PR TITLE
use new referral equipped TellerWMAS

### DIFF
--- a/script/DeployAccountantWithYieldStreaming.s.sol
+++ b/script/DeployAccountantWithYieldStreaming.s.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+/**
+ *  source .env && forge script script/DeployAccountantWithYieldStreaming.s.sol:DeployAccountantWithYieldStreamingScript --with-gas-price 30000000000 --broadcast --etherscan-api-key $ETHERSCAN_KEY --verify
+ * @dev Optionally can change `--with-gas-price` to something more reasonable
+ */
+contract DeployAccountantWithYieldStreamingScript is Script, ContractNames, MainnetAddresses {
+    uint256 public privateKey;
+    Deployer public deployer = Deployer(deployerAddress);
+    address public boringVault = 0xA802bccD14F7e78e48FfE0C9cF9AD0273C77D4b0;
+    address public payoutAddress = 0x1cdF47387358A1733968df92f7cC14546D9E1047;
+    address public USDTsepolia = 0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0;
+    address public tempOwner = 0x0463E60C7cE10e57911AB7bD1667eaa21de3e79b;
+
+    function setUp() external {
+        privateKey = vm.envUint("BORING_DEVELOPER");
+        vm.createSelectFork("sepolia");
+    }
+
+    function run() external {
+        bytes memory creationCode;
+        bytes memory constructorArgs;
+        vm.startBroadcast(privateKey);
+
+        creationCode = type(AccountantWithYieldStreaming).creationCode;
+        constructorArgs = abi.encode(tempOwner, boringVault, payoutAddress, 1e6, USDTsepolia, 1.001e4, 0.999e4, 1, 0.1e4, 0.1e4);
+        AccountantWithYieldStreaming accountant = AccountantWithYieldStreaming(
+            deployer.deployContract(
+                "InkedUSDT Accountant With Yield Streaming V0.0", creationCode, constructorArgs, 0
+            )
+        );
+
+        accountant.setAuthority(Authority(0xecE2222D3ac4b21316b6E5F4208A452BB96A8Cb4));
+        accountant.transferOwnership(address(0));
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/DeployQueueOnly.s.sol
+++ b/script/DeployQueueOnly.s.sol
@@ -24,13 +24,13 @@ contract DeployQueueOnly is Script, ContractNames, Test {
     Deployer deployer = Deployer(0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d);
 
     address owner = 0x1cdF47387358A1733968df92f7cC14546D9E1047;
-    address auth = 0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF;
-    address payable boringVault = payable(0xef417FCE1883c6653E7dC6AF7c6F85CCDE84Aa09);
-    address accountant = 0xc873F2b7b3BA0a7faA2B56e210E3B965f2b618f5;
+    address auth = 0xecE2222D3ac4b21316b6E5F4208A452BB96A8Cb4;
+    address payable boringVault = payable(0xA802bccD14F7e78e48FfE0C9cF9AD0273C77D4b0);
+    address accountant = 0x0EA727A89faD61F73423f7E7D0EE37F8A7295B74;
 
     function setUp() external {
         privateKey = vm.envUint("BORING_DEVELOPER");
-        vm.createSelectFork("unichain");
+        vm.createSelectFork("sepolia");
     }
 
 
@@ -42,6 +42,6 @@ contract DeployQueueOnly is Script, ContractNames, Test {
         creationCode = type(BoringOnChainQueue).creationCode;
 
         constructorArgs = abi.encode(owner, auth, boringVault, accountant);
-        deployer.deployContract("Golden Goose Boring Queue 1.1", creationCode, constructorArgs, 0);
+        deployer.deployContract("Ink Sepolia Boring Queue 0.1", creationCode, constructorArgs, 0);
     }
 }

--- a/script/DeployTellerWithYieldStreaming.s.sol
+++ b/script/DeployTellerWithYieldStreaming.s.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+/**
+ *  source .env && forge script script/DeployTellerWithYieldStreaming.s.sol:DeployTellerWithYieldStreamingScript --with-gas-price 30000000000 --broadcast --etherscan-api-key $ETHERSCAN_KEY --verify
+ * @dev Optionally can change `--with-gas-price` to something more reasonable
+ */
+contract DeployTellerWithYieldStreamingScript is Script, ContractNames, MainnetAddresses {
+    uint256 public privateKey;
+    Deployer public deployer = Deployer(deployerAddress);
+    //address public bufferHelper = ; //for now set to address(0) aka vault itself
+    address public accountant = 0x0EA727A89faD61F73423f7E7D0EE37F8A7295B74;
+    address public boringVault = 0xA802bccD14F7e78e48FfE0C9cF9AD0273C77D4b0;
+    address public WETHsepolia = 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14;
+    address public USDTsepolia = 0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0;
+    address public tempOwner = 0x0463E60C7cE10e57911AB7bD1667eaa21de3e79b;
+
+    function setUp() external {
+        privateKey = vm.envUint("BORING_DEVELOPER");
+        vm.createSelectFork("sepolia");
+    }
+
+    function run() external {
+        bytes memory creationCode;
+        bytes memory constructorArgs;
+        vm.startBroadcast(privateKey);
+
+        creationCode = type(TellerWithYieldStreaming).creationCode;
+        constructorArgs = abi.encode(tempOwner, boringVault, accountant, WETHsepolia);
+        TellerWithYieldStreaming teller = TellerWithYieldStreaming(
+            deployer.deployContract(
+                "InkedUSDT Teller With Yield Streaming V0.0", creationCode, constructorArgs, 0
+            )
+        );
+        teller.updateAssetData(ERC20(USDTsepolia), true, true, 0);
+        //teller.allowBufferHelper(USDT, bufferHelper); for now set to address(0) aka vault itself
+        //teller.setBufferHelper(bufferHelper); for now set to address(0) aka vault itself
+        teller.setAuthority(Authority(0xecE2222D3ac4b21316b6E5F4208A452BB96A8Cb4));
+        teller.transferOwnership(address(0));
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -8,11 +8,8 @@ import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 import {IRateProvider} from "src/interfaces/IRateProvider.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
-import {BoringVault} from "src/base/BoringVault.sol";
 import {Auth, Authority} from "@solmate/auth/Auth.sol";
 import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
-import {IPausable} from "src/interfaces/IPausable.sol";
-
 contract AccountantWithYieldStreaming is AccountantWithRateProviders {
     using FixedPointMathLib for uint256;
     using SafeTransferLib for ERC20;
@@ -90,11 +87,10 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
     error AccountantWithYieldStreaming__NotEnoughTimePassed();
     error AccountantWithYieldStreaming__ZeroYieldUpdate();
     error AccountantWithYieldStreaming__MaxDeviationYieldExceeded();
-    error AccountantWithYieldStreaming__MaxDeviationLossExceeded();
 
     //============================== EVENTS ===============================
 
-    event YieldRecorded(uint256 amountAdded, uint256 newtotalAssetsInBase);
+    event YieldRecorded(uint256 amountAdded, uint64 endVestingTime);
     event LossRecorded(uint256 lossAmount);
     event ExchangeRateUpdated(uint256 newExchangeRate);
     event MaximumVestDurationUpdated(uint64 newMaximum);
@@ -504,7 +500,6 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
         );
 
         state.exchangeRate = uint96(vestingState.lastSharePrice);
-        state.totalSharesLastUpdate = uint128(currentTotalShares);
         state.lastUpdateTimestamp = currentTime;
     }
 }

--- a/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol
+++ b/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol
@@ -270,4 +270,11 @@ contract LayerZeroTeller is CrossChainTellerWithGenericBridge, OAppAuth {
 
         fee = address(feeToken) == NATIVE ? messageFee.nativeFee : messageFee.lzTokenFee;
     }
+
+    /**
+     * @notice Returns the version of the contract.
+     */
+    function version() public pure virtual override returns (string memory) {
+        return string(abi.encodePacked("LayerZero V0.1 ", super.version()));
+    }
 }

--- a/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol
+++ b/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol
@@ -275,6 +275,6 @@ contract LayerZeroTeller is CrossChainTellerWithGenericBridge, OAppAuth {
      * @notice Returns the version of the contract.
      */
     function version() public pure virtual override returns (string memory) {
-        return string(abi.encodePacked("LayerZero V0.1 ", super.version()));
+        return string(abi.encodePacked("LayerZero V0.1, ", super.version()));
     }
 }

--- a/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol
+++ b/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol
@@ -291,4 +291,11 @@ contract LayerZeroTellerWithRateLimiting is CrossChainTellerWithGenericBridge, O
 
         fee = address(feeToken) == NATIVE ? messageFee.nativeFee : messageFee.lzTokenFee;
     }
+
+    /**
+     * @notice Returns the version of the contract.
+     */
+    function version() public pure virtual override returns (string memory) {
+        return string(abi.encodePacked("LayerZero Rate Limiting V0.1 ", super.version()));
+    }
 }

--- a/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol
+++ b/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol
@@ -296,6 +296,6 @@ contract LayerZeroTellerWithRateLimiting is CrossChainTellerWithGenericBridge, O
      * @notice Returns the version of the contract.
      */
     function version() public pure virtual override returns (string memory) {
-        return string(abi.encodePacked("LayerZero Rate Limiting V0.1 ", super.version()));
+        return string(abi.encodePacked("LayerZero Rate Limiting V0.1, ", super.version()));
     }
 }

--- a/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
@@ -207,6 +207,6 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
      * @notice Returns the version of the contract.
      */
     function version() public pure virtual override returns (string memory) {
-        return string(abi.encodePacked("Cross Chain V0.1 ", super.version()));
+        return string(abi.encodePacked("Cross Chain V0.1, ", super.version()));
     }    
 }

--- a/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
@@ -202,4 +202,11 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
         view
         virtual
         returns (uint256 fee);
+
+    /**
+     * @notice Returns the version of the contract.
+     */
+    function version() public pure virtual override returns (string memory) {
+        return string(abi.encodePacked("Cross Chain V0.1 ", super.version()));
+    }    
 }

--- a/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
@@ -11,6 +11,22 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
     using MessageLib for uint256;
     using MessageLib for MessageLib.Message;
 
+    //============================== STRUCTS ===============================
+    struct DepositAndBridgeWithPermitParams {
+        ERC20 depositAsset;
+        uint256 depositAmount;
+        uint256 minimumMint;
+        uint256 deadline;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        address to;
+        bytes bridgeWildCard;
+        ERC20 feeToken;
+        uint256 maxFee;
+        address referralAddress; 
+    }
+
     //============================== ERRORS ===============================
 
     error CrossChainTellerWithGenericBridge__UnsafeCastToUint96();
@@ -43,7 +59,8 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
         address to,
         bytes calldata bridgeWildCard,
         ERC20 feeToken,
-        uint256 maxFee
+        uint256 maxFee,
+        address referralAddress
     )
         external
         payable
@@ -55,7 +72,7 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
         // Deposit
         Asset memory asset = _beforeDeposit(depositAsset);
         sharesBridged = _erc20Deposit(depositAsset, depositAmount, minimumMint, msg.sender, msg.sender, asset);
-        _afterPublicDeposit(msg.sender, depositAsset, depositAmount, sharesBridged, shareLockPeriod);
+        _afterPublicDeposit(msg.sender, depositAsset, depositAmount, sharesBridged, shareLockPeriod, referralAddress);
 
         // Bridge shares
         if (sharesBridged > type(uint96).max) revert CrossChainTellerWithGenericBridge__UnsafeCastToUint96();
@@ -71,36 +88,26 @@ abstract contract CrossChainTellerWithGenericBridge is TellerWithMultiAssetSuppo
      *      are also granted to the `depositWithPermit` and `bridge` function.
      */
     function depositAndBridgeWithPermit(
-        ERC20 depositAsset,
-        uint256 depositAmount,
-        uint256 minimumMint,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s,
-        address to,
-        bytes calldata bridgeWildCard,
-        ERC20 feeToken,
-        uint256 maxFee
+        DepositAndBridgeWithPermitParams calldata params
     )
         external
         payable
         requiresAuth
         nonReentrant
-        revertOnNativeDeposit(address(depositAsset))
+        revertOnNativeDeposit(address(params.depositAsset))
         returns (uint256 sharesBridged)
     {
         // Permit deposit
         {
-            Asset memory asset = _beforeDeposit(depositAsset);
-            _handlePermit(depositAsset, depositAmount, deadline, v, r, s);
-            sharesBridged = _erc20Deposit(depositAsset, depositAmount, minimumMint, msg.sender, msg.sender, asset);
+            Asset memory asset = _beforeDeposit(params.depositAsset);
+            _handlePermit(params.depositAsset, params.depositAmount, params.deadline, params.v, params.r, params.s);
+            sharesBridged = _erc20Deposit(params.depositAsset, params.depositAmount, params.minimumMint, msg.sender, msg.sender, asset);
         }
-        _afterPublicDeposit(msg.sender, depositAsset, depositAmount, sharesBridged, shareLockPeriod);
+        _afterPublicDeposit(msg.sender, params.depositAsset, params.depositAmount, sharesBridged, shareLockPeriod, params.referralAddress);
 
         // Bridge shares
         if (sharesBridged > type(uint96).max) revert CrossChainTellerWithGenericBridge__UnsafeCastToUint96();
-        _bridge(uint96(sharesBridged), to, bridgeWildCard, feeToken, maxFee);
+        _bridge(uint96(sharesBridged), params.to, params.bridgeWildCard, params.feeToken, params.maxFee);
     }
 
     /**

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -137,4 +137,11 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
         allowedBufferHelpers[_asset][_bufferHelper] = false;
         emit BufferHelperDisallowed(_asset, _bufferHelper);
     }
+
+    /**
+     * @notice Returns the version of the contract.
+     */
+    function version() public pure virtual override returns (string memory) {
+        return string(abi.encodePacked("Buffer V0.1 ", super.version()));
+    }
 }

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -142,6 +142,6 @@ contract TellerWithBuffer is TellerWithMultiAssetSupport {
      * @notice Returns the version of the contract.
      */
     function version() public pure virtual override returns (string memory) {
-        return string(abi.encodePacked("Buffer V0.1 ", super.version()));
+        return string(abi.encodePacked("Buffer V0.1, ", super.version()));
     }
 }

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -399,6 +399,13 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
         }
     }
 
+    /**
+     * @notice Internal function to check deny lists for transfers.
+     * @dev Reverts if `from` is denied, `to` is denied, or `operator` is denied.
+     * @param from The address sending the shares.
+     * @param to The address receiving the shares.
+     * @param operator The address performing the transfer.
+     */
     function _handleDenyList(address from, address to, address operator) internal view {
         if (
             beforeTransferData[from].denyFrom || beforeTransferData[to].denyTo

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -402,9 +402,9 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
     /**
      * @notice Internal function to check deny lists for transfers.
      * @dev Reverts if `from` is denied, `to` is denied, or `operator` is denied.
-     * @param from The address sending the shares.
-     * @param to The address receiving the shares.
-     * @param operator The address performing the transfer.
+     * @param from The sender address.
+     * @param to The receiver address.
+     * @param operator The address performing the operation.
      */
     function _handleDenyList(address from, address to, address operator) internal view {
         if (

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -664,7 +664,7 @@ contract TellerWithMultiAssetSupport is Auth, BeforeTransferHook, ReentrancyGuar
     /**
      * @notice Returns the version of the contract.
      */
-    function version() external pure virtual returns (string memory) {
-        return "V0.1";
+    function version() public pure virtual returns (string memory) {
+        return "Base V0.1";
     }
 }

--- a/src/base/Roles/TellerWithRemediation.sol
+++ b/src/base/Roles/TellerWithRemediation.sol
@@ -124,4 +124,11 @@ contract TellerWithRemediation is TellerWithMultiAssetSupport {
         if (remediationInfo[operator].isFrozen) revert TellerWithRemediation__RemediationInProgress(operator);
         super.beforeTransfer(from, to, operator);
     }
+
+    /**
+     * @notice Returns the version of the contract.
+     */
+    function version() public pure virtual override returns (string memory) {
+        return string(abi.encodePacked("Remediation V0.1 ", super.version()));
+    }
 }

--- a/src/base/Roles/TellerWithRemediation.sol
+++ b/src/base/Roles/TellerWithRemediation.sol
@@ -129,6 +129,6 @@ contract TellerWithRemediation is TellerWithMultiAssetSupport {
      * @notice Returns the version of the contract.
      */
     function version() public pure virtual override returns (string memory) {
-        return string(abi.encodePacked("Remediation V0.1 ", super.version()));
+        return string(abi.encodePacked("Remediation V0.1, ", super.version()));
     }
 }

--- a/src/base/Roles/TellerWithYieldStreaming.sol
+++ b/src/base/Roles/TellerWithYieldStreaming.sol
@@ -82,6 +82,6 @@ contract TellerWithYieldStreaming is TellerWithBuffer {
      * @notice Returns the version of the contract.
      */
     function version() public pure virtual override returns (string memory) {
-        return string(abi.encodePacked("Yield Streaming V0.1 ", super.version()));
+        return string(abi.encodePacked("Yield Streaming V0.1, ", super.version()));
     }
 }

--- a/src/base/Roles/TellerWithYieldStreaming.sol
+++ b/src/base/Roles/TellerWithYieldStreaming.sol
@@ -77,4 +77,11 @@ contract TellerWithYieldStreaming is TellerWithBuffer {
     function _getAccountant() internal view returns (AccountantWithYieldStreaming) {
         return AccountantWithYieldStreaming(address(accountant));
     }
+
+    /**
+     * @notice Returns the version of the contract.
+     */
+    function version() public pure virtual override returns (string memory) {
+        return string(abi.encodePacked("Yield Streaming V0.1 ", super.version()));
+    }
 }

--- a/src/helper/AaveV3BufferLens.sol
+++ b/src/helper/AaveV3BufferLens.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {TellerWithBuffer} from "src/base/Roles/TellerWithBuffer.sol";
+import {AaveV3BufferHelper, IBufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
+import {IPool} from "src/interfaces/IPool.sol";
+
+contract AaveV3BufferLens {
+    function getInstantlyWithdrawableAmount(TellerWithBuffer teller, ERC20 asset) external view returns (uint256 withdrawableAmount) {
+        (, IBufferHelper withdrawBufferHelper) = teller.currentBufferHelpers(asset);
+        address vault = address(teller.vault());
+        if (address(withdrawBufferHelper) == address(0)) {
+            // If buffer helper is address(0), withdraw buffer is idle ERC20 in the vault
+            withdrawableAmount = asset.balanceOf(vault);
+        } else {
+            // If buffer helper is not address(0), withdraw buffer is Aave V3
+            address aaveV3Pool = AaveV3BufferHelper(address(withdrawBufferHelper)).aaveV3Pool();
+            ERC20 aToken = ERC20(IPool(aaveV3Pool).getReserveData(address(asset)).aTokenAddress);
+            uint256 aTokenBalance = aToken.balanceOf(vault);
+            uint256 availableLiquidity = asset.balanceOf(address(aToken));
+            withdrawableAmount = aTokenBalance > availableLiquidity ? availableLiquidity : aTokenBalance;
+        }
+    }
+}

--- a/src/interfaces/DataTypes.sol
+++ b/src/interfaces/DataTypes.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+library DataTypes {
+  struct ReserveData {
+    //stores the reserve configuration
+    ReserveConfigurationMap configuration;
+    //the liquidity index. Expressed in ray
+    uint128 liquidityIndex;
+    //the current supply rate. Expressed in ray
+    uint128 currentLiquidityRate;
+    //variable borrow index. Expressed in ray
+    uint128 variableBorrowIndex;
+    //the current variable borrow rate. Expressed in ray
+    uint128 currentVariableBorrowRate;
+    //the current stable borrow rate. Expressed in ray
+    uint128 currentStableBorrowRate;
+    //timestamp of last update
+    uint40 lastUpdateTimestamp;
+    //the id of the reserve. Represents the position in the list of the active reserves
+    uint16 id;
+    //aToken address
+    address aTokenAddress;
+    //stableDebtToken address
+    address stableDebtTokenAddress;
+    //variableDebtToken address
+    address variableDebtTokenAddress;
+    //address of the interest rate strategy
+    address interestRateStrategyAddress;
+    //the current treasury balance, scaled
+    uint128 accruedToTreasury;
+    //the outstanding unbacked aTokens minted through the bridging feature
+    uint128 unbacked;
+    //the outstanding debt borrowed against this asset in isolation mode
+    uint128 isolationModeTotalDebt;
+  }
+
+  struct ReserveConfigurationMap {
+    //bit 0-15: LTV
+    //bit 16-31: Liq. threshold
+    //bit 32-47: Liq. bonus
+    //bit 48-55: Decimals
+    //bit 56: reserve is active
+    //bit 57: reserve is frozen
+    //bit 58: borrowing is enabled
+    //bit 59: stable rate borrowing enabled
+    //bit 60: asset is paused
+    //bit 61: borrowing in isolation mode is enabled
+    //bit 62: siloed borrowing enabled
+    //bit 63: flashloaning enabled
+    //bit 64-79: reserve factor
+    //bit 80-115 borrow cap in whole tokens, borrowCap == 0 => no cap
+    //bit 116-151 supply cap in whole tokens, supplyCap == 0 => no cap
+    //bit 152-167 liquidation protocol fee
+    //bit 168-175 eMode category
+    //bit 176-211 unbacked mint cap in whole tokens, unbackedMintCap == 0 => minting disabled
+    //bit 212-251 debt ceiling for isolation mode with (ReserveConfiguration::DEBT_CEILING_DECIMALS) decimals
+    //bit 252-255 unused
+
+    uint256 data;
+  }
+
+  struct UserConfigurationMap {
+    /**
+     * @dev Bitmap of the users collaterals and borrows. It is divided in pairs of bits, one pair per asset.
+     * The first bit indicates if an asset is used as collateral by the user, the second whether an
+     * asset is borrowed by the user.
+     */
+    uint256 data;
+  }
+
+  struct EModeCategory {
+    // each eMode category has a custom ltv and liquidation threshold
+    uint16 ltv;
+    uint16 liquidationThreshold;
+    uint16 liquidationBonus;
+    // each eMode category may or may not have a custom oracle to override the individual assets price oracles
+    address priceSource;
+    string label;
+  }
+
+  enum InterestRateMode {NONE, STABLE, VARIABLE}
+
+  struct ReserveCache {
+    uint256 currScaledVariableDebt;
+    uint256 nextScaledVariableDebt;
+    uint256 currPrincipalStableDebt;
+    uint256 currAvgStableBorrowRate;
+    uint256 currTotalStableDebt;
+    uint256 nextAvgStableBorrowRate;
+    uint256 nextTotalStableDebt;
+    uint256 currLiquidityIndex;
+    uint256 nextLiquidityIndex;
+    uint256 currVariableBorrowIndex;
+    uint256 nextVariableBorrowIndex;
+    uint256 currLiquidityRate;
+    uint256 currVariableBorrowRate;
+    uint256 reserveFactor;
+    ReserveConfigurationMap reserveConfiguration;
+    address aTokenAddress;
+    address stableDebtTokenAddress;
+    address variableDebtTokenAddress;
+    uint40 reserveLastUpdateTimestamp;
+    uint40 stableDebtLastUpdateTimestamp;
+  }
+
+  struct ExecuteLiquidationCallParams {
+    uint256 reservesCount;
+    uint256 debtToCover;
+    address collateralAsset;
+    address debtAsset;
+    address user;
+    bool receiveAToken;
+    address priceOracle;
+    uint8 userEModeCategory;
+    address priceOracleSentinel;
+  }
+
+  struct ExecuteSupplyParams {
+    address asset;
+    uint256 amount;
+    address onBehalfOf;
+    uint16 referralCode;
+  }
+
+  struct ExecuteBorrowParams {
+    address asset;
+    address user;
+    address onBehalfOf;
+    uint256 amount;
+    InterestRateMode interestRateMode;
+    uint16 referralCode;
+    bool releaseUnderlying;
+    uint256 maxStableRateBorrowSizePercent;
+    uint256 reservesCount;
+    address oracle;
+    uint8 userEModeCategory;
+    address priceOracleSentinel;
+  }
+
+  struct ExecuteRepayParams {
+    address asset;
+    uint256 amount;
+    InterestRateMode interestRateMode;
+    address onBehalfOf;
+    bool useATokens;
+  }
+
+  struct ExecuteWithdrawParams {
+    address asset;
+    uint256 amount;
+    address to;
+    uint256 reservesCount;
+    address oracle;
+    uint8 userEModeCategory;
+  }
+
+  struct ExecuteSetUserEModeParams {
+    uint256 reservesCount;
+    address oracle;
+    uint8 categoryId;
+  }
+
+  struct FinalizeTransferParams {
+    address asset;
+    address from;
+    address to;
+    uint256 amount;
+    uint256 balanceFromBefore;
+    uint256 balanceToBefore;
+    uint256 reservesCount;
+    address oracle;
+    uint8 fromEModeCategory;
+  }
+
+  struct FlashloanParams {
+    address receiverAddress;
+    address[] assets;
+    uint256[] amounts;
+    uint256[] interestRateModes;
+    address onBehalfOf;
+    bytes params;
+    uint16 referralCode;
+    uint256 flashLoanPremiumToProtocol;
+    uint256 flashLoanPremiumTotal;
+    uint256 maxStableRateBorrowSizePercent;
+    uint256 reservesCount;
+    address addressesProvider;
+    uint8 userEModeCategory;
+    bool isAuthorizedFlashBorrower;
+  }
+
+  struct FlashloanSimpleParams {
+    address receiverAddress;
+    address asset;
+    uint256 amount;
+    bytes params;
+    uint16 referralCode;
+    uint256 flashLoanPremiumToProtocol;
+    uint256 flashLoanPremiumTotal;
+  }
+
+  struct FlashLoanRepaymentParams {
+    uint256 amount;
+    uint256 totalPremium;
+    uint256 flashLoanPremiumToProtocol;
+    address asset;
+    address receiverAddress;
+    uint16 referralCode;
+  }
+
+  struct CalculateUserAccountDataParams {
+    UserConfigurationMap userConfig;
+    uint256 reservesCount;
+    address user;
+    address oracle;
+    uint8 userEModeCategory;
+  }
+
+  struct ValidateBorrowParams {
+    ReserveCache reserveCache;
+    UserConfigurationMap userConfig;
+    address asset;
+    address userAddress;
+    uint256 amount;
+    InterestRateMode interestRateMode;
+    uint256 maxStableLoanPercent;
+    uint256 reservesCount;
+    address oracle;
+    uint8 userEModeCategory;
+    address priceOracleSentinel;
+    bool isolationModeActive;
+    address isolationModeCollateralAddress;
+    uint256 isolationModeDebtCeiling;
+  }
+
+  struct ValidateLiquidationCallParams {
+    ReserveCache debtReserveCache;
+    uint256 totalDebt;
+    uint256 healthFactor;
+    address priceOracleSentinel;
+  }
+
+  struct CalculateInterestRatesParams {
+    uint256 unbacked;
+    uint256 liquidityAdded;
+    uint256 liquidityTaken;
+    uint256 totalStableDebt;
+    uint256 totalVariableDebt;
+    uint256 averageStableBorrowRate;
+    uint256 reserveFactor;
+    address reserve;
+    address aToken;
+  }
+
+  struct InitReserveParams {
+    address asset;
+    address aTokenAddress;
+    address stableDebtAddress;
+    address variableDebtAddress;
+    address interestRateStrategyAddress;
+    uint16 reservesCount;
+    uint16 maxNumberReserves;
+  }
+}

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -1,0 +1,737 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import {IPoolAddressesProvider} from './IPoolAddressesProvider.sol';
+import {DataTypes} from './DataTypes.sol';
+
+/**
+ * @title IPool
+ * @author Aave
+ * @notice Defines the basic interface for an Aave Pool.
+ */
+interface IPool {
+  /**
+   * @dev Emitted on mintUnbacked()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address initiating the supply
+   * @param onBehalfOf The beneficiary of the supplied assets, receiving the aTokens
+   * @param amount The amount of supplied assets
+   * @param referralCode The referral code used
+   */
+  event MintUnbacked(
+    address indexed reserve,
+    address user,
+    address indexed onBehalfOf,
+    uint256 amount,
+    uint16 indexed referralCode
+  );
+
+  /**
+   * @dev Emitted on backUnbacked()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param backer The address paying for the backing
+   * @param amount The amount added as backing
+   * @param fee The amount paid in fees
+   */
+  event BackUnbacked(address indexed reserve, address indexed backer, uint256 amount, uint256 fee);
+
+  /**
+   * @dev Emitted on supply()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address initiating the supply
+   * @param onBehalfOf The beneficiary of the supply, receiving the aTokens
+   * @param amount The amount supplied
+   * @param referralCode The referral code used
+   */
+  event Supply(
+    address indexed reserve,
+    address user,
+    address indexed onBehalfOf,
+    uint256 amount,
+    uint16 indexed referralCode
+  );
+
+  /**
+   * @dev Emitted on withdraw()
+   * @param reserve The address of the underlying asset being withdrawn
+   * @param user The address initiating the withdrawal, owner of aTokens
+   * @param to The address that will receive the underlying
+   * @param amount The amount to be withdrawn
+   */
+  event Withdraw(address indexed reserve, address indexed user, address indexed to, uint256 amount);
+
+  /**
+   * @dev Emitted on borrow() and flashLoan() when debt needs to be opened
+   * @param reserve The address of the underlying asset being borrowed
+   * @param user The address of the user initiating the borrow(), receiving the funds on borrow() or just
+   * initiator of the transaction on flashLoan()
+   * @param onBehalfOf The address that will be getting the debt
+   * @param amount The amount borrowed out
+   * @param interestRateMode The rate mode: 1 for Stable, 2 for Variable
+   * @param borrowRate The numeric rate at which the user has borrowed, expressed in ray
+   * @param referralCode The referral code used
+   */
+  event Borrow(
+    address indexed reserve,
+    address user,
+    address indexed onBehalfOf,
+    uint256 amount,
+    DataTypes.InterestRateMode interestRateMode,
+    uint256 borrowRate,
+    uint16 indexed referralCode
+  );
+
+  /**
+   * @dev Emitted on repay()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The beneficiary of the repayment, getting his debt reduced
+   * @param repayer The address of the user initiating the repay(), providing the funds
+   * @param amount The amount repaid
+   * @param useATokens True if the repayment is done using aTokens, `false` if done with underlying asset directly
+   */
+  event Repay(
+    address indexed reserve,
+    address indexed user,
+    address indexed repayer,
+    uint256 amount,
+    bool useATokens
+  );
+
+  /**
+   * @dev Emitted on swapBorrowRateMode()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user swapping his rate mode
+   * @param interestRateMode The current interest rate mode of the position being swapped: 1 for Stable, 2 for Variable
+   */
+  event SwapBorrowRateMode(
+    address indexed reserve,
+    address indexed user,
+    DataTypes.InterestRateMode interestRateMode
+  );
+
+  /**
+   * @dev Emitted on borrow(), repay() and liquidationCall() when using isolated assets
+   * @param asset The address of the underlying asset of the reserve
+   * @param totalDebt The total isolation mode debt for the reserve
+   */
+  event IsolationModeTotalDebtUpdated(address indexed asset, uint256 totalDebt);
+
+  /**
+   * @dev Emitted when the user selects a certain asset category for eMode
+   * @param user The address of the user
+   * @param categoryId The category id
+   */
+  event UserEModeSet(address indexed user, uint8 categoryId);
+
+  /**
+   * @dev Emitted on setUserUseReserveAsCollateral()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user enabling the usage as collateral
+   */
+  event ReserveUsedAsCollateralEnabled(address indexed reserve, address indexed user);
+
+  /**
+   * @dev Emitted on setUserUseReserveAsCollateral()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user enabling the usage as collateral
+   */
+  event ReserveUsedAsCollateralDisabled(address indexed reserve, address indexed user);
+
+  /**
+   * @dev Emitted on rebalanceStableBorrowRate()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user for which the rebalance has been executed
+   */
+  event RebalanceStableBorrowRate(address indexed reserve, address indexed user);
+
+  /**
+   * @dev Emitted on flashLoan()
+   * @param target The address of the flash loan receiver contract
+   * @param initiator The address initiating the flash loan
+   * @param asset The address of the asset being flash borrowed
+   * @param amount The amount flash borrowed
+   * @param interestRateMode The flashloan mode: 0 for regular flashloan, 1 for Stable debt, 2 for Variable debt
+   * @param premium The fee flash borrowed
+   * @param referralCode The referral code used
+   */
+  event FlashLoan(
+    address indexed target,
+    address initiator,
+    address indexed asset,
+    uint256 amount,
+    DataTypes.InterestRateMode interestRateMode,
+    uint256 premium,
+    uint16 indexed referralCode
+  );
+
+  /**
+   * @dev Emitted when a borrower is liquidated.
+   * @param collateralAsset The address of the underlying asset used as collateral, to receive as result of the liquidation
+   * @param debtAsset The address of the underlying borrowed asset to be repaid with the liquidation
+   * @param user The address of the borrower getting liquidated
+   * @param debtToCover The debt amount of borrowed `asset` the liquidator wants to cover
+   * @param liquidatedCollateralAmount The amount of collateral received by the liquidator
+   * @param liquidator The address of the liquidator
+   * @param receiveAToken True if the liquidators wants to receive the collateral aTokens, `false` if he wants
+   * to receive the underlying collateral asset directly
+   */
+  event LiquidationCall(
+    address indexed collateralAsset,
+    address indexed debtAsset,
+    address indexed user,
+    uint256 debtToCover,
+    uint256 liquidatedCollateralAmount,
+    address liquidator,
+    bool receiveAToken
+  );
+
+  /**
+   * @dev Emitted when the state of a reserve is updated.
+   * @param reserve The address of the underlying asset of the reserve
+   * @param liquidityRate The next liquidity rate
+   * @param stableBorrowRate The next stable borrow rate
+   * @param variableBorrowRate The next variable borrow rate
+   * @param liquidityIndex The next liquidity index
+   * @param variableBorrowIndex The next variable borrow index
+   */
+  event ReserveDataUpdated(
+    address indexed reserve,
+    uint256 liquidityRate,
+    uint256 stableBorrowRate,
+    uint256 variableBorrowRate,
+    uint256 liquidityIndex,
+    uint256 variableBorrowIndex
+  );
+
+  /**
+   * @dev Emitted when the protocol treasury receives minted aTokens from the accrued interest.
+   * @param reserve The address of the reserve
+   * @param amountMinted The amount minted to the treasury
+   */
+  event MintedToTreasury(address indexed reserve, uint256 amountMinted);
+
+  /**
+   * @notice Mints an `amount` of aTokens to the `onBehalfOf`
+   * @param asset The address of the underlying asset to mint
+   * @param amount The amount to mint
+   * @param onBehalfOf The address that will receive the aTokens
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   */
+  function mintUnbacked(
+    address asset,
+    uint256 amount,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @notice Back the current unbacked underlying with `amount` and pay `fee`.
+   * @param asset The address of the underlying asset to back
+   * @param amount The amount to back
+   * @param fee The amount paid in fees
+   * @return The backed amount
+   */
+  function backUnbacked(address asset, uint256 amount, uint256 fee) external returns (uint256);
+
+  /**
+   * @notice Supplies an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+   * - E.g. User supplies 100 USDC and gets in return 100 aUSDC
+   * @param asset The address of the underlying asset to supply
+   * @param amount The amount to be supplied
+   * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+   *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+   *   is a different wallet
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   */
+  function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+
+  /**
+   * @notice Supply with transfer approval of asset to be supplied done via permit function
+   * see: https://eips.ethereum.org/EIPS/eip-2612 and https://eips.ethereum.org/EIPS/eip-713
+   * @param asset The address of the underlying asset to supply
+   * @param amount The amount to be supplied
+   * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+   *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+   *   is a different wallet
+   * @param deadline The deadline timestamp that the permit is valid
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   * @param permitV The V parameter of ERC712 permit sig
+   * @param permitR The R parameter of ERC712 permit sig
+   * @param permitS The S parameter of ERC712 permit sig
+   */
+  function supplyWithPermit(
+    address asset,
+    uint256 amount,
+    address onBehalfOf,
+    uint16 referralCode,
+    uint256 deadline,
+    uint8 permitV,
+    bytes32 permitR,
+    bytes32 permitS
+  ) external;
+
+  /**
+   * @notice Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
+   * E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
+   * @param asset The address of the underlying asset to withdraw
+   * @param amount The underlying amount to be withdrawn
+   *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
+   * @param to The address that will receive the underlying, same as msg.sender if the user
+   *   wants to receive it on his own wallet, or a different address if the beneficiary is a
+   *   different wallet
+   * @return The final amount withdrawn
+   */
+  function withdraw(address asset, uint256 amount, address to) external returns (uint256);
+
+  /**
+   * @notice Allows users to borrow a specific `amount` of the reserve underlying asset, provided that the borrower
+   * already supplied enough collateral, or he was given enough allowance by a credit delegator on the
+   * corresponding debt token (StableDebtToken or VariableDebtToken)
+   * - E.g. User borrows 100 USDC passing as `onBehalfOf` his own address, receiving the 100 USDC in his wallet
+   *   and 100 stable/variable debt tokens, depending on the `interestRateMode`
+   * @param asset The address of the underlying asset to borrow
+   * @param amount The amount to be borrowed
+   * @param interestRateMode The interest rate mode at which the user wants to borrow: 1 for Stable, 2 for Variable
+   * @param referralCode The code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   * @param onBehalfOf The address of the user who will receive the debt. Should be the address of the borrower itself
+   * calling the function if he wants to borrow against his own collateral, or the address of the credit delegator
+   * if he has been given credit delegation allowance
+   */
+  function borrow(
+    address asset,
+    uint256 amount,
+    uint256 interestRateMode,
+    uint16 referralCode,
+    address onBehalfOf
+  ) external;
+
+  /**
+   * @notice Repays a borrowed `amount` on a specific reserve, burning the equivalent debt tokens owned
+   * - E.g. User repays 100 USDC, burning 100 variable/stable debt tokens of the `onBehalfOf` address
+   * @param asset The address of the borrowed underlying asset previously borrowed
+   * @param amount The amount to repay
+   * - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`
+   * @param interestRateMode The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable
+   * @param onBehalfOf The address of the user who will get his debt reduced/removed. Should be the address of the
+   * user calling the function if he wants to reduce/remove his own debt, or the address of any other
+   * other borrower whose debt should be removed
+   * @return The final amount repaid
+   */
+  function repay(
+    address asset,
+    uint256 amount,
+    uint256 interestRateMode,
+    address onBehalfOf
+  ) external returns (uint256);
+
+  /**
+   * @notice Repay with transfer approval of asset to be repaid done via permit function
+   * see: https://eips.ethereum.org/EIPS/eip-2612 and https://eips.ethereum.org/EIPS/eip-713
+   * @param asset The address of the borrowed underlying asset previously borrowed
+   * @param amount The amount to repay
+   * - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`
+   * @param interestRateMode The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable
+   * @param onBehalfOf Address of the user who will get his debt reduced/removed. Should be the address of the
+   * user calling the function if he wants to reduce/remove his own debt, or the address of any other
+   * other borrower whose debt should be removed
+   * @param deadline The deadline timestamp that the permit is valid
+   * @param permitV The V parameter of ERC712 permit sig
+   * @param permitR The R parameter of ERC712 permit sig
+   * @param permitS The S parameter of ERC712 permit sig
+   * @return The final amount repaid
+   */
+  function repayWithPermit(
+    address asset,
+    uint256 amount,
+    uint256 interestRateMode,
+    address onBehalfOf,
+    uint256 deadline,
+    uint8 permitV,
+    bytes32 permitR,
+    bytes32 permitS
+  ) external returns (uint256);
+
+  /**
+   * @notice Repays a borrowed `amount` on a specific reserve using the reserve aTokens, burning the
+   * equivalent debt tokens
+   * - E.g. User repays 100 USDC using 100 aUSDC, burning 100 variable/stable debt tokens
+   * @dev  Passing uint256.max as amount will clean up any residual aToken dust balance, if the user aToken
+   * balance is not enough to cover the whole debt
+   * @param asset The address of the borrowed underlying asset previously borrowed
+   * @param amount The amount to repay
+   * - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`
+   * @param interestRateMode The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable
+   * @return The final amount repaid
+   */
+  function repayWithATokens(
+    address asset,
+    uint256 amount,
+    uint256 interestRateMode
+  ) external returns (uint256);
+
+  /**
+   * @notice Allows a borrower to swap his debt between stable and variable mode, or vice versa
+   * @param asset The address of the underlying asset borrowed
+   * @param interestRateMode The current interest rate mode of the position being swapped: 1 for Stable, 2 for Variable
+   */
+  function swapBorrowRateMode(address asset, uint256 interestRateMode) external;
+
+  /**
+   * @notice Rebalances the stable interest rate of a user to the current stable rate defined on the reserve.
+   * - Users can be rebalanced if the following conditions are satisfied:
+   *     1. Usage ratio is above 95%
+   *     2. the current supply APY is below REBALANCE_UP_THRESHOLD * maxVariableBorrowRate, which means that too
+   *        much has been borrowed at a stable rate and suppliers are not earning enough
+   * @param asset The address of the underlying asset borrowed
+   * @param user The address of the user to be rebalanced
+   */
+  function rebalanceStableBorrowRate(address asset, address user) external;
+
+  /**
+   * @notice Allows suppliers to enable/disable a specific supplied asset as collateral
+   * @param asset The address of the underlying asset supplied
+   * @param useAsCollateral True if the user wants to use the supply as collateral, false otherwise
+   */
+  function setUserUseReserveAsCollateral(address asset, bool useAsCollateral) external;
+
+  /**
+   * @notice Function to liquidate a non-healthy position collateral-wise, with Health Factor below 1
+   * - The caller (liquidator) covers `debtToCover` amount of debt of the user getting liquidated, and receives
+   *   a proportionally amount of the `collateralAsset` plus a bonus to cover market risk
+   * @param collateralAsset The address of the underlying asset used as collateral, to receive as result of the liquidation
+   * @param debtAsset The address of the underlying borrowed asset to be repaid with the liquidation
+   * @param user The address of the borrower getting liquidated
+   * @param debtToCover The debt amount of borrowed `asset` the liquidator wants to cover
+   * @param receiveAToken True if the liquidators wants to receive the collateral aTokens, `false` if he wants
+   * to receive the underlying collateral asset directly
+   */
+  function liquidationCall(
+    address collateralAsset,
+    address debtAsset,
+    address user,
+    uint256 debtToCover,
+    bool receiveAToken
+  ) external;
+
+  /**
+   * @notice Allows smartcontracts to access the liquidity of the pool within one transaction,
+   * as long as the amount taken plus a fee is returned.
+   * @dev IMPORTANT There are security concerns for developers of flashloan receiver contracts that must be kept
+   * into consideration. For further details please visit https://docs.aave.com/developers/
+   * @param receiverAddress The address of the contract receiving the funds, implementing IFlashLoanReceiver interface
+   * @param assets The addresses of the assets being flash-borrowed
+   * @param amounts The amounts of the assets being flash-borrowed
+   * @param interestRateModes Types of the debt to open if the flash loan is not returned:
+   *   0 -> Don't open any debt, just revert if funds can't be transferred from the receiver
+   *   1 -> Open debt at stable rate for the value of the amount flash-borrowed to the `onBehalfOf` address
+   *   2 -> Open debt at variable rate for the value of the amount flash-borrowed to the `onBehalfOf` address
+   * @param onBehalfOf The address  that will receive the debt in the case of using on `modes` 1 or 2
+   * @param params Variadic packed params to pass to the receiver as extra information
+   * @param referralCode The code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   */
+  function flashLoan(
+    address receiverAddress,
+    address[] calldata assets,
+    uint256[] calldata amounts,
+    uint256[] calldata interestRateModes,
+    address onBehalfOf,
+    bytes calldata params,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @notice Allows smartcontracts to access the liquidity of the pool within one transaction,
+   * as long as the amount taken plus a fee is returned.
+   * @dev IMPORTANT There are security concerns for developers of flashloan receiver contracts that must be kept
+   * into consideration. For further details please visit https://docs.aave.com/developers/
+   * @param receiverAddress The address of the contract receiving the funds, implementing IFlashLoanSimpleReceiver interface
+   * @param asset The address of the asset being flash-borrowed
+   * @param amount The amount of the asset being flash-borrowed
+   * @param params Variadic packed params to pass to the receiver as extra information
+   * @param referralCode The code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   */
+  function flashLoanSimple(
+    address receiverAddress,
+    address asset,
+    uint256 amount,
+    bytes calldata params,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @notice Returns the user account data across all the reserves
+   * @param user The address of the user
+   * @return totalCollateralBase The total collateral of the user in the base currency used by the price feed
+   * @return totalDebtBase The total debt of the user in the base currency used by the price feed
+   * @return availableBorrowsBase The borrowing power left of the user in the base currency used by the price feed
+   * @return currentLiquidationThreshold The liquidation threshold of the user
+   * @return ltv The loan to value of The user
+   * @return healthFactor The current health factor of the user
+   */
+  function getUserAccountData(
+    address user
+  )
+    external
+    view
+    returns (
+      uint256 totalCollateralBase,
+      uint256 totalDebtBase,
+      uint256 availableBorrowsBase,
+      uint256 currentLiquidationThreshold,
+      uint256 ltv,
+      uint256 healthFactor
+    );
+
+  /**
+   * @notice Initializes a reserve, activating it, assigning an aToken and debt tokens and an
+   * interest rate strategy
+   * @dev Only callable by the PoolConfigurator contract
+   * @param asset The address of the underlying asset of the reserve
+   * @param aTokenAddress The address of the aToken that will be assigned to the reserve
+   * @param stableDebtAddress The address of the StableDebtToken that will be assigned to the reserve
+   * @param variableDebtAddress The address of the VariableDebtToken that will be assigned to the reserve
+   * @param interestRateStrategyAddress The address of the interest rate strategy contract
+   */
+  function initReserve(
+    address asset,
+    address aTokenAddress,
+    address stableDebtAddress,
+    address variableDebtAddress,
+    address interestRateStrategyAddress
+  ) external;
+
+  /**
+   * @notice Drop a reserve
+   * @dev Only callable by the PoolConfigurator contract
+   * @param asset The address of the underlying asset of the reserve
+   */
+  function dropReserve(address asset) external;
+
+  /**
+   * @notice Updates the address of the interest rate strategy contract
+   * @dev Only callable by the PoolConfigurator contract
+   * @param asset The address of the underlying asset of the reserve
+   * @param rateStrategyAddress The address of the interest rate strategy contract
+   */
+  function setReserveInterestRateStrategyAddress(
+    address asset,
+    address rateStrategyAddress
+  ) external;
+
+  /**
+   * @notice Sets the configuration bitmap of the reserve as a whole
+   * @dev Only callable by the PoolConfigurator contract
+   * @param asset The address of the underlying asset of the reserve
+   * @param configuration The new configuration bitmap
+   */
+  function setConfiguration(
+    address asset,
+    DataTypes.ReserveConfigurationMap calldata configuration
+  ) external;
+
+  /**
+   * @notice Returns the configuration of the reserve
+   * @param asset The address of the underlying asset of the reserve
+   * @return The configuration of the reserve
+   */
+  function getConfiguration(
+    address asset
+  ) external view returns (DataTypes.ReserveConfigurationMap memory);
+
+  /**
+   * @notice Returns the configuration of the user across all the reserves
+   * @param user The user address
+   * @return The configuration of the user
+   */
+  function getUserConfiguration(
+    address user
+  ) external view returns (DataTypes.UserConfigurationMap memory);
+
+  /**
+   * @notice Returns the normalized income of the reserve
+   * @param asset The address of the underlying asset of the reserve
+   * @return The reserve's normalized income
+   */
+  function getReserveNormalizedIncome(address asset) external view returns (uint256);
+
+  /**
+   * @notice Returns the normalized variable debt per unit of asset
+   * @dev WARNING: This function is intended to be used primarily by the protocol itself to get a
+   * "dynamic" variable index based on time, current stored index and virtual rate at the current
+   * moment (approx. a borrower would get if opening a position). This means that is always used in
+   * combination with variable debt supply/balances.
+   * If using this function externally, consider that is possible to have an increasing normalized
+   * variable debt that is not equivalent to how the variable debt index would be updated in storage
+   * (e.g. only updates with non-zero variable debt supply)
+   * @param asset The address of the underlying asset of the reserve
+   * @return The reserve normalized variable debt
+   */
+  function getReserveNormalizedVariableDebt(address asset) external view returns (uint256);
+
+  /**
+   * @notice Returns the state and configuration of the reserve
+   * @param asset The address of the underlying asset of the reserve
+   * @return The state and configuration data of the reserve
+   */
+  function getReserveData(address asset) external view returns (DataTypes.ReserveData memory);
+
+  /**
+   * @notice Validates and finalizes an aToken transfer
+   * @dev Only callable by the overlying aToken of the `asset`
+   * @param asset The address of the underlying asset of the aToken
+   * @param from The user from which the aTokens are transferred
+   * @param to The user receiving the aTokens
+   * @param amount The amount being transferred/withdrawn
+   * @param balanceFromBefore The aToken balance of the `from` user before the transfer
+   * @param balanceToBefore The aToken balance of the `to` user before the transfer
+   */
+  function finalizeTransfer(
+    address asset,
+    address from,
+    address to,
+    uint256 amount,
+    uint256 balanceFromBefore,
+    uint256 balanceToBefore
+  ) external;
+
+  /**
+   * @notice Returns the list of the underlying assets of all the initialized reserves
+   * @dev It does not include dropped reserves
+   * @return The addresses of the underlying assets of the initialized reserves
+   */
+  function getReservesList() external view returns (address[] memory);
+
+  /**
+   * @notice Returns the address of the underlying asset of a reserve by the reserve id as stored in the DataTypes.ReserveData struct
+   * @param id The id of the reserve as stored in the DataTypes.ReserveData struct
+   * @return The address of the reserve associated with id
+   */
+  function getReserveAddressById(uint16 id) external view returns (address);
+
+  /**
+   * @notice Returns the PoolAddressesProvider connected to this contract
+   * @return The address of the PoolAddressesProvider
+   */
+  function ADDRESSES_PROVIDER() external view returns (IPoolAddressesProvider);
+
+  /**
+   * @notice Updates the protocol fee on the bridging
+   * @param bridgeProtocolFee The part of the premium sent to the protocol treasury
+   */
+  function updateBridgeProtocolFee(uint256 bridgeProtocolFee) external;
+
+  /**
+   * @notice Updates flash loan premiums. Flash loan premium consists of two parts:
+   * - A part is sent to aToken holders as extra, one time accumulated interest
+   * - A part is collected by the protocol treasury
+   * @dev The total premium is calculated on the total borrowed amount
+   * @dev The premium to protocol is calculated on the total premium, being a percentage of `flashLoanPremiumTotal`
+   * @dev Only callable by the PoolConfigurator contract
+   * @param flashLoanPremiumTotal The total premium, expressed in bps
+   * @param flashLoanPremiumToProtocol The part of the premium sent to the protocol treasury, expressed in bps
+   */
+  function updateFlashloanPremiums(
+    uint128 flashLoanPremiumTotal,
+    uint128 flashLoanPremiumToProtocol
+  ) external;
+
+  /**
+   * @notice Configures a new category for the eMode.
+   * @dev In eMode, the protocol allows very high borrowing power to borrow assets of the same category.
+   * The category 0 is reserved as it's the default for volatile assets
+   * @param id The id of the category
+   * @param config The configuration of the category
+   */
+  function configureEModeCategory(uint8 id, DataTypes.EModeCategory memory config) external;
+
+  /**
+   * @notice Returns the data of an eMode category
+   * @param id The id of the category
+   * @return The configuration data of the category
+   */
+  function getEModeCategoryData(uint8 id) external view returns (DataTypes.EModeCategory memory);
+
+  /**
+   * @notice Allows a user to use the protocol in eMode
+   * @param categoryId The id of the category
+   */
+  function setUserEMode(uint8 categoryId) external;
+
+  /**
+   * @notice Returns the eMode the user is using
+   * @param user The address of the user
+   * @return The eMode id
+   */
+  function getUserEMode(address user) external view returns (uint256);
+
+  /**
+   * @notice Resets the isolation mode total debt of the given asset to zero
+   * @dev It requires the given asset has zero debt ceiling
+   * @param asset The address of the underlying asset to reset the isolationModeTotalDebt
+   */
+  function resetIsolationModeTotalDebt(address asset) external;
+
+  /**
+   * @notice Returns the percentage of available liquidity that can be borrowed at once at stable rate
+   * @return The percentage of available liquidity to borrow, expressed in bps
+   */
+  function MAX_STABLE_RATE_BORROW_SIZE_PERCENT() external view returns (uint256);
+
+  /**
+   * @notice Returns the total fee on flash loans
+   * @return The total fee on flashloans
+   */
+  function FLASHLOAN_PREMIUM_TOTAL() external view returns (uint128);
+
+  /**
+   * @notice Returns the part of the bridge fees sent to protocol
+   * @return The bridge fee sent to the protocol treasury
+   */
+  function BRIDGE_PROTOCOL_FEE() external view returns (uint256);
+
+  /**
+   * @notice Returns the part of the flashloan fees sent to protocol
+   * @return The flashloan fee sent to the protocol treasury
+   */
+  function FLASHLOAN_PREMIUM_TO_PROTOCOL() external view returns (uint128);
+
+  /**
+   * @notice Returns the maximum number of reserves supported to be listed in this Pool
+   * @return The maximum number of reserves supported
+   */
+  function MAX_NUMBER_RESERVES() external view returns (uint16);
+
+  /**
+   * @notice Mints the assets accrued through the reserve factor to the treasury in the form of aTokens
+   * @param assets The list of reserves for which the minting needs to be executed
+   */
+  function mintToTreasury(address[] calldata assets) external;
+
+  /**
+   * @notice Rescue and transfer tokens locked in this contract
+   * @param token The address of the token
+   * @param to The address of the recipient
+   * @param amount The amount of token to transfer
+   */
+  function rescueTokens(address token, address to, uint256 amount) external;
+
+  /**
+   * @notice Supplies an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+   * - E.g. User supplies 100 USDC and gets in return 100 aUSDC
+   * @dev Deprecated: Use the `supply` function instead
+   * @param asset The address of the underlying asset to supply
+   * @param amount The amount to be supplied
+   * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+   *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+   *   is a different wallet
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   */
+  function deposit(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+}

--- a/src/interfaces/IPoolAddressesProvider.sol
+++ b/src/interfaces/IPoolAddressesProvider.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title IPoolAddressesProvider
+ * @author Aave
+ * @notice Defines the basic interface for a Pool Addresses Provider.
+ */
+interface IPoolAddressesProvider {
+  /**
+   * @dev Emitted when the market identifier is updated.
+   * @param oldMarketId The old id of the market
+   * @param newMarketId The new id of the market
+   */
+  event MarketIdSet(string indexed oldMarketId, string indexed newMarketId);
+
+  /**
+   * @dev Emitted when the pool is updated.
+   * @param oldAddress The old address of the Pool
+   * @param newAddress The new address of the Pool
+   */
+  event PoolUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the pool configurator is updated.
+   * @param oldAddress The old address of the PoolConfigurator
+   * @param newAddress The new address of the PoolConfigurator
+   */
+  event PoolConfiguratorUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the price oracle is updated.
+   * @param oldAddress The old address of the PriceOracle
+   * @param newAddress The new address of the PriceOracle
+   */
+  event PriceOracleUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the ACL manager is updated.
+   * @param oldAddress The old address of the ACLManager
+   * @param newAddress The new address of the ACLManager
+   */
+  event ACLManagerUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the ACL admin is updated.
+   * @param oldAddress The old address of the ACLAdmin
+   * @param newAddress The new address of the ACLAdmin
+   */
+  event ACLAdminUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the price oracle sentinel is updated.
+   * @param oldAddress The old address of the PriceOracleSentinel
+   * @param newAddress The new address of the PriceOracleSentinel
+   */
+  event PriceOracleSentinelUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the pool data provider is updated.
+   * @param oldAddress The old address of the PoolDataProvider
+   * @param newAddress The new address of the PoolDataProvider
+   */
+  event PoolDataProviderUpdated(address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when a new proxy is created.
+   * @param id The identifier of the proxy
+   * @param proxyAddress The address of the created proxy contract
+   * @param implementationAddress The address of the implementation contract
+   */
+  event ProxyCreated(
+    bytes32 indexed id,
+    address indexed proxyAddress,
+    address indexed implementationAddress
+  );
+
+  /**
+   * @dev Emitted when a new non-proxied contract address is registered.
+   * @param id The identifier of the contract
+   * @param oldAddress The address of the old contract
+   * @param newAddress The address of the new contract
+   */
+  event AddressSet(bytes32 indexed id, address indexed oldAddress, address indexed newAddress);
+
+  /**
+   * @dev Emitted when the implementation of the proxy registered with id is updated
+   * @param id The identifier of the contract
+   * @param proxyAddress The address of the proxy contract
+   * @param oldImplementationAddress The address of the old implementation contract
+   * @param newImplementationAddress The address of the new implementation contract
+   */
+  event AddressSetAsProxy(
+    bytes32 indexed id,
+    address indexed proxyAddress,
+    address oldImplementationAddress,
+    address indexed newImplementationAddress
+  );
+
+  /**
+   * @notice Returns the id of the Aave market to which this contract points to.
+   * @return The market id
+   */
+  function getMarketId() external view returns (string memory);
+
+  /**
+   * @notice Associates an id with a specific PoolAddressesProvider.
+   * @dev This can be used to create an onchain registry of PoolAddressesProviders to
+   * identify and validate multiple Aave markets.
+   * @param newMarketId The market id
+   */
+  function setMarketId(string calldata newMarketId) external;
+
+  /**
+   * @notice Returns an address by its identifier.
+   * @dev The returned address might be an EOA or a contract, potentially proxied
+   * @dev It returns ZERO if there is no registered address with the given id
+   * @param id The id
+   * @return The address of the registered for the specified id
+   */
+  function getAddress(bytes32 id) external view returns (address);
+
+  /**
+   * @notice General function to update the implementation of a proxy registered with
+   * certain `id`. If there is no proxy registered, it will instantiate one and
+   * set as implementation the `newImplementationAddress`.
+   * @dev IMPORTANT Use this function carefully, only for ids that don't have an explicit
+   * setter function, in order to avoid unexpected consequences
+   * @param id The id
+   * @param newImplementationAddress The address of the new implementation
+   */
+  function setAddressAsProxy(bytes32 id, address newImplementationAddress) external;
+
+  /**
+   * @notice Sets an address for an id replacing the address saved in the addresses map.
+   * @dev IMPORTANT Use this function carefully, as it will do a hard replacement
+   * @param id The id
+   * @param newAddress The address to set
+   */
+  function setAddress(bytes32 id, address newAddress) external;
+
+  /**
+   * @notice Returns the address of the Pool proxy.
+   * @return The Pool proxy address
+   */
+  function getPool() external view returns (address);
+
+  /**
+   * @notice Updates the implementation of the Pool, or creates a proxy
+   * setting the new `pool` implementation when the function is called for the first time.
+   * @param newPoolImpl The new Pool implementation
+   */
+  function setPoolImpl(address newPoolImpl) external;
+
+  /**
+   * @notice Returns the address of the PoolConfigurator proxy.
+   * @return The PoolConfigurator proxy address
+   */
+  function getPoolConfigurator() external view returns (address);
+
+  /**
+   * @notice Updates the implementation of the PoolConfigurator, or creates a proxy
+   * setting the new `PoolConfigurator` implementation when the function is called for the first time.
+   * @param newPoolConfiguratorImpl The new PoolConfigurator implementation
+   */
+  function setPoolConfiguratorImpl(address newPoolConfiguratorImpl) external;
+
+  /**
+   * @notice Returns the address of the price oracle.
+   * @return The address of the PriceOracle
+   */
+  function getPriceOracle() external view returns (address);
+
+  /**
+   * @notice Updates the address of the price oracle.
+   * @param newPriceOracle The address of the new PriceOracle
+   */
+  function setPriceOracle(address newPriceOracle) external;
+
+  /**
+   * @notice Returns the address of the ACL manager.
+   * @return The address of the ACLManager
+   */
+  function getACLManager() external view returns (address);
+
+  /**
+   * @notice Updates the address of the ACL manager.
+   * @param newAclManager The address of the new ACLManager
+   */
+  function setACLManager(address newAclManager) external;
+
+  /**
+   * @notice Returns the address of the ACL admin.
+   * @return The address of the ACL admin
+   */
+  function getACLAdmin() external view returns (address);
+
+  /**
+   * @notice Updates the address of the ACL admin.
+   * @param newAclAdmin The address of the new ACL admin
+   */
+  function setACLAdmin(address newAclAdmin) external;
+
+  /**
+   * @notice Returns the address of the price oracle sentinel.
+   * @return The address of the PriceOracleSentinel
+   */
+  function getPriceOracleSentinel() external view returns (address);
+
+  /**
+   * @notice Updates the address of the price oracle sentinel.
+   * @param newPriceOracleSentinel The address of the new PriceOracleSentinel
+   */
+  function setPriceOracleSentinel(address newPriceOracleSentinel) external;
+
+  /**
+   * @notice Returns the address of the data provider.
+   * @return The address of the DataProvider
+   */
+  function getPoolDataProvider() external view returns (address);
+
+  /**
+   * @notice Updates the address of the data provider.
+   * @param newDataProvider The address of the new DataProvider
+   */
+  function setPoolDataProvider(address newDataProvider) external;
+}

--- a/test/AccountantVaultDecimalMismatch.t.sol
+++ b/test/AccountantVaultDecimalMismatch.t.sol
@@ -24,6 +24,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
     ERC20 LBTC = ERC20(0xecAc9C5F704e954931349Da37F60E39f515c11c1);
     address user = vm.addr(0xBEEF);
     address auth;
+    address public refferer = vm.addr(1337);
 
     function setUp() external {
         // Setup forked environment.
@@ -55,7 +56,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         WBTCN.approve(address(bv), 1e18);
 
         vm.prank(user);
-        teller.deposit(WBTCN, 1e18, 0);
+        teller.deposit(WBTCN, 1e18, 0, refferer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
@@ -72,7 +73,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         LBTC.approve(address(bv), 1e8);
 
         vm.prank(user);
-        teller.deposit(LBTC, 1e8, 0);
+        teller.deposit(LBTC, 1e8, 0, refferer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
@@ -89,7 +90,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         WBTCN.approve(address(bv), 1e18);
 
         vm.prank(user);
-        teller.deposit(WBTCN, 1e18, 0);
+        teller.deposit(WBTCN, 1e18, 0, refferer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
@@ -106,7 +107,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         LBTC.approve(address(bv), 1e8);
 
         vm.prank(user);
-        teller.deposit(LBTC, 1e8, 0);
+        teller.deposit(LBTC, 1e8, 0, refferer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 

--- a/test/AccountantVaultDecimalMismatch.t.sol
+++ b/test/AccountantVaultDecimalMismatch.t.sol
@@ -24,7 +24,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
     ERC20 LBTC = ERC20(0xecAc9C5F704e954931349Da37F60E39f515c11c1);
     address user = vm.addr(0xBEEF);
     address auth;
-    address public refferer = vm.addr(1337);
+    address public referrer = vm.addr(1337);
 
     function setUp() external {
         // Setup forked environment.
@@ -56,7 +56,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         WBTCN.approve(address(bv), 1e18);
 
         vm.prank(user);
-        teller.deposit(WBTCN, 1e18, 0, refferer);
+        teller.deposit(WBTCN, 1e18, 0, referrer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
@@ -73,7 +73,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         LBTC.approve(address(bv), 1e8);
 
         vm.prank(user);
-        teller.deposit(LBTC, 1e8, 0, refferer);
+        teller.deposit(LBTC, 1e8, 0, referrer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
@@ -90,7 +90,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         WBTCN.approve(address(bv), 1e18);
 
         vm.prank(user);
-        teller.deposit(WBTCN, 1e18, 0, refferer);
+        teller.deposit(WBTCN, 1e18, 0, referrer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
@@ -107,7 +107,7 @@ contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
         LBTC.approve(address(bv), 1e8);
 
         vm.prank(user);
-        teller.deposit(LBTC, 1e8, 0, refferer);
+        teller.deposit(LBTC, 1e8, 0, referrer);
 
         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 

--- a/test/AccountantVaultDecimalMismatch.t.sol
+++ b/test/AccountantVaultDecimalMismatch.t.sol
@@ -1,124 +1,124 @@
-// SPDX-License-Identifier: SEL-1.0
-// Copyright © 2025 Veda Tech Labs
-// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
-// Licensed under Software Evaluation License, Version 1.0
-pragma solidity 0.8.21;
+// // SPDX-License-Identifier: SEL-1.0
+// // Copyright © 2025 Veda Tech Labs
+// // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// // Licensed under Software Evaluation License, Version 1.0
+// pragma solidity 0.8.21;
 
-import {Auth, Authority} from "@solmate/auth/Auth.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {BoringVault} from "src/base/BoringVault.sol";
-import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
-import {MerkleTreeHelper, ERC20} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
-import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
-import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
-import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+// import {Auth, Authority} from "@solmate/auth/Auth.sol";
+// import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+// import {BoringVault} from "src/base/BoringVault.sol";
+// import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+// import {MerkleTreeHelper, ERC20} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+// import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+// import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+// import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
 
-contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
-    using Address for address;
+// contract AccountantVaultDecimalsMismatchTest is Test, MerkleTreeHelper {
+//     using Address for address;
 
-    RolesAuthority rolesAuthority = RolesAuthority(0x49F954c67ff235034b69b8a59fbe309A40256c8d);
-    BoringVault bv = BoringVault(payable(0x5f46d540b6eD704C3c8789105F30E075AA900726));
-    AccountantWithRateProviders accountant = AccountantWithRateProviders(0xEa23aC6D7D11f6b181d6B98174D334478ADAe6b0);
-    TellerWithMultiAssetSupport teller = TellerWithMultiAssetSupport(0x9E88C603307fdC33aA5F26E38b6f6aeF3eE92d48);
-    ERC20 WBTCN = ERC20(0xda5dDd7270381A7C2717aD10D1c0ecB19e3CDFb2);
-    ERC20 LBTC = ERC20(0xecAc9C5F704e954931349Da37F60E39f515c11c1);
-    address user = vm.addr(0xBEEF);
-    address auth;
-    address public referrer = vm.addr(1337);
+//     RolesAuthority rolesAuthority = RolesAuthority(0x49F954c67ff235034b69b8a59fbe309A40256c8d);
+//     BoringVault bv = BoringVault(payable(0x5f46d540b6eD704C3c8789105F30E075AA900726));
+//     AccountantWithRateProviders accountant = AccountantWithRateProviders(0xEa23aC6D7D11f6b181d6B98174D334478ADAe6b0);
+//     TellerWithMultiAssetSupport teller = TellerWithMultiAssetSupport(0x9E88C603307fdC33aA5F26E38b6f6aeF3eE92d48);
+//     ERC20 WBTCN = ERC20(0xda5dDd7270381A7C2717aD10D1c0ecB19e3CDFb2);
+//     ERC20 LBTC = ERC20(0xecAc9C5F704e954931349Da37F60E39f515c11c1);
+//     address user = vm.addr(0xBEEF);
+//     address auth;
+//     address public referrer = vm.addr(1337);
 
-    function setUp() external {
-        // Setup forked environment.
-        string memory rpcKey = "CORN_MAIZENET_RPC_URL";
-        uint256 blockNumber = 565228;
+//     function setUp() external {
+//         // Setup forked environment.
+//         string memory rpcKey = "CORN_MAIZENET_RPC_URL";
+//         uint256 blockNumber = 565228;
 
-        _startFork(rpcKey, blockNumber);
-        setSourceChainName("corn");
+//         _startFork(rpcKey, blockNumber);
+//         setSourceChainName("corn");
 
-        auth = rolesAuthority.owner();
+//         auth = rolesAuthority.owner();
 
-        deal(address(LBTC), address(bv), 1e8);
-        deal(address(WBTCN), address(bv), 1e18);
+//         deal(address(LBTC), address(bv), 1e8);
+//         deal(address(WBTCN), address(bv), 1e18);
 
-        // Correct the wrong rate, and open deposits, and let user call bulkWithdraw
-        vm.startPrank(auth);
-        rolesAuthority.setUserRole(auth, 11, true);
-        accountant.updateExchangeRate(1e18);
-        accountant.unpause();
-        rolesAuthority.setPublicCapability(address(teller), TellerWithMultiAssetSupport.deposit.selector, true);
-        rolesAuthority.setUserRole(user, 12, true);
-        vm.stopPrank();
-    }
+//         // Correct the wrong rate, and open deposits, and let user call bulkWithdraw
+//         vm.startPrank(auth);
+//         rolesAuthority.setUserRole(auth, 11, true);
+//         accountant.updateExchangeRate(1e18);
+//         accountant.unpause();
+//         rolesAuthority.setPublicCapability(address(teller), TellerWithMultiAssetSupport.deposit.selector, true);
+//         rolesAuthority.setUserRole(user, 12, true);
+//         vm.stopPrank();
+//     }
 
-    function testDepositAndWithdrawWBTCN() external {
-        // Give user WBTCN and approve.
-        deal(address(WBTCN), user, 1e18);
-        vm.prank(user);
-        WBTCN.approve(address(bv), 1e18);
+//     function testDepositAndWithdrawWBTCN() external {
+//         // Give user WBTCN and approve.
+//         deal(address(WBTCN), user, 1e18);
+//         vm.prank(user);
+//         WBTCN.approve(address(bv), 1e18);
 
-        vm.prank(user);
-        teller.deposit(WBTCN, 1e18, 0, referrer);
+//         vm.prank(user);
+//         teller.deposit(WBTCN, 1e18, 0, referrer);
 
-        assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
+//         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
-        vm.prank(user);
-        teller.bulkWithdraw(WBTCN, 1e8, 0, user);
+//         vm.prank(user);
+//         teller.bulkWithdraw(WBTCN, 1e8, 0, user);
 
-        assertEq(WBTCN.balanceOf(user), 1e18, "User should have received one WBTCN.");
-    }
+//         assertEq(WBTCN.balanceOf(user), 1e18, "User should have received one WBTCN.");
+//     }
 
-    function testDepositAndWithdrawLBTC() external {
-        // Give user LBTC and approve.
-        deal(address(LBTC), user, 1e8);
-        vm.prank(user);
-        LBTC.approve(address(bv), 1e8);
+//     function testDepositAndWithdrawLBTC() external {
+//         // Give user LBTC and approve.
+//         deal(address(LBTC), user, 1e8);
+//         vm.prank(user);
+//         LBTC.approve(address(bv), 1e8);
 
-        vm.prank(user);
-        teller.deposit(LBTC, 1e8, 0, referrer);
+//         vm.prank(user);
+//         teller.deposit(LBTC, 1e8, 0, referrer);
 
-        assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
+//         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
-        vm.prank(user);
-        teller.bulkWithdraw(LBTC, 1e8, 0, user);
+//         vm.prank(user);
+//         teller.bulkWithdraw(LBTC, 1e8, 0, user);
 
-        assertEq(LBTC.balanceOf(user), 1e8, "User should have received one WBTCN.");
-    }
+//         assertEq(LBTC.balanceOf(user), 1e8, "User should have received one WBTCN.");
+//     }
 
-    function testUserDepositWBTCNWithdrawLBTC() external {
-        // Give user WBTCN and approve.
-        deal(address(WBTCN), user, 1e18);
-        vm.prank(user);
-        WBTCN.approve(address(bv), 1e18);
+//     function testUserDepositWBTCNWithdrawLBTC() external {
+//         // Give user WBTCN and approve.
+//         deal(address(WBTCN), user, 1e18);
+//         vm.prank(user);
+//         WBTCN.approve(address(bv), 1e18);
 
-        vm.prank(user);
-        teller.deposit(WBTCN, 1e18, 0, referrer);
+//         vm.prank(user);
+//         teller.deposit(WBTCN, 1e18, 0, referrer);
 
-        assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
+//         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
-        vm.prank(user);
-        teller.bulkWithdraw(LBTC, 1e8, 0, user);
+//         vm.prank(user);
+//         teller.bulkWithdraw(LBTC, 1e8, 0, user);
 
-        assertEq(LBTC.balanceOf(user), 1e8, "User should have received one LBTC.");
-    }
+//         assertEq(LBTC.balanceOf(user), 1e8, "User should have received one LBTC.");
+//     }
 
-    function testUserDepositLBTCWithdrawWBTCN() external {
-        // Give user LBTC and approve.
-        deal(address(LBTC), user, 1e8);
-        vm.prank(user);
-        LBTC.approve(address(bv), 1e8);
+//     function testUserDepositLBTCWithdrawWBTCN() external {
+//         // Give user LBTC and approve.
+//         deal(address(LBTC), user, 1e8);
+//         vm.prank(user);
+//         LBTC.approve(address(bv), 1e8);
 
-        vm.prank(user);
-        teller.deposit(LBTC, 1e8, 0, referrer);
+//         vm.prank(user);
+//         teller.deposit(LBTC, 1e8, 0, referrer);
 
-        assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
+//         assertEq(bv.balanceOf(user), 1e8, "User should have received one share.");
 
-        vm.prank(user);
-        teller.bulkWithdraw(WBTCN, 1e8, 0, user);
+//         vm.prank(user);
+//         teller.bulkWithdraw(WBTCN, 1e8, 0, user);
 
-        assertEq(WBTCN.balanceOf(user), 1e18, "User should have received one WBTCN.");
-    }
+//         assertEq(WBTCN.balanceOf(user), 1e18, "User should have received one WBTCN.");
+//     }
 
-    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
-        forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
-        vm.selectFork(forkId);
-    }
-}
+//     function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+//         forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+//         vm.selectFork(forkId);
+//     }
+// }

--- a/test/AccountantWithYieldStreaming.t.sol
+++ b/test/AccountantWithYieldStreaming.t.sol
@@ -53,7 +53,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
     
     address public alice = address(69); 
     address public bill = address(6969); 
-    address public refferer = vm.addr(1337);
+    address public referrer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -168,7 +168,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
         
         uint256 totalAssetsBefore = accountant.totalAssets();         
@@ -176,7 +176,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         //==== BEGIN DEPOSIT 2 ====
 
         //deposit 2
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(shares1, WETHAmount); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -187,7 +187,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -196,7 +196,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         skip(12 hours); 
 
         //==== BEGIN DEPOSIT 2 ====
-            uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
+            uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.assertApproxEqAbs(shares1, 6666666666666666666, 10);  
 
         //total of 2 deposits to 10 weth each + 5 vested yield 
@@ -218,7 +218,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WEETH), address(this), 1_000e18);
         WEETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0, referrer);
         assertEq(expectedShares, shares0); 
 
         //after deposit, last share price is updated
@@ -241,7 +241,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WEETH), address(this), 1_000e18);
         WEETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0, referrer);
         assertEq(expectedShares, shares0); 
 
         //before deposit, last share price is updated
@@ -262,7 +262,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(totalAssetsInBaseMid, totalAssetsInBaseLast + vestedYield, 1e4); 
 
         //deposit again
-        uint256 shares1 = teller.deposit(WEETH, WEETHAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(WEETH, WEETHAmount, 0, referrer);
 
         (lastSharePrice, , , , ) = accountant.vestingState(); 
 
@@ -283,7 +283,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WEETH), address(this), 1_000e18);
         WEETH.approve(address(boringVault), 1_000e18);
-        teller.deposit(WEETH, WEETHAmount, 0, refferer);
+        teller.deposit(WEETH, WEETHAmount, 0, referrer);
        
         (, , , uint64 startVestingTimeNow, ) = accountant.vestingState(); 
         assertEq(startVestingTimeLast + 1 days, startVestingTimeNow);  
@@ -294,11 +294,11 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //deposit 2
-        teller.deposit(WETH, WETHAmount, 0, refferer);
+        teller.deposit(WETH, WETHAmount, 0, referrer);
 
         uint256 assetsOut0 = teller.withdraw(WETH, shares0, 0, address(boringVault));   
         assertEq(assetsOut0, WETHAmount); 
@@ -308,7 +308,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -320,7 +320,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, 1_000e18);
         vm.startPrank(alice); 
         WETH.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -337,7 +337,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -349,7 +349,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, 1_000e18);
         vm.startPrank(alice); 
         WETH.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -368,7 +368,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //==== Add Vesting Yield Stream ===="); 
@@ -405,7 +405,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vault total = 10
@@ -459,7 +459,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vault total = 10
@@ -478,7 +478,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(shares0, WETHAmount); 
 
         deal(address(WETH), address(boringVault), WETHAmount);
@@ -526,7 +526,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         deal(address(WETH), address(boringVault), WETHAmount);
@@ -559,7 +559,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18;
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        teller.deposit(WETH, WETHAmount, 0, refferer);
+        teller.deposit(WETH, WETHAmount, 0, referrer);
     
         // Record initial state
         (, uint96 initialHighwaterMark, ,,,,,,,,,) = accountant.accountantState();
@@ -606,7 +606,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 100e18;
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0);
     
         accountant.vestYield(1e18, 1 days); // 1% of vault
@@ -619,7 +619,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         assertEq(supplyBefore, 100e18, "Supply should still be 100e18");
     
         //will get fewer shares due to yield
-        teller.deposit(WETH, 100e18, 0, refferer);
+        teller.deposit(WETH, 100e18, 0, referrer);
     
         // Get actual supply after deposit (not exactly 200e18 due to share price)
         uint256 supplyAfter = boringVault.totalSupply();
@@ -655,7 +655,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 100e18;
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0);
     
         accountant.vestYield(1e18, 1 days); // 1% of vault
@@ -668,7 +668,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         assertEq(supplyBefore, 100e18, "Supply should still be 100e18");
     
         //will get fewer shares due to yield
-        teller.deposit(WETH, 100e18, 0, refferer);
+        teller.deposit(WETH, 100e18, 0, referrer);
     
         // Get actual supply after deposit (not exactly 200e18 due to share price)
         uint256 supplyAfter = boringVault.totalSupply();
@@ -704,7 +704,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -728,10 +728,10 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares1); 
         
         uint256 currentShares = boringVault.totalSupply(); 
@@ -745,7 +745,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -757,13 +757,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         deal(address(WETH), bill, WETHAmount);
         vm.startPrank(bill);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         //skip time
@@ -784,7 +784,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -796,7 +796,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         //skip time
@@ -809,7 +809,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), bill, WETHAmount);
         vm.startPrank(bill);
         WETH.approve(address(boringVault), WETHAmount);
-        teller.deposit(WETH, WETHAmount, 0, refferer);
+        teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         assertApproxEqAbs(assetsOutAlice, WETHAmount, 10); 
@@ -819,7 +819,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -830,7 +830,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         //skip time
@@ -843,7 +843,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), bill, WETHAmount);
         vm.startPrank(bill);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         assertLt(assetsOutAlice, WETHAmount); 
@@ -857,7 +857,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -867,7 +867,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, referrer);
         vm.stopPrank();
 
         //alice withdraws
@@ -884,7 +884,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -898,7 +898,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -912,7 +912,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -931,13 +931,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(shares0, WETHAmount); 
 
         //==== BEGIN DEPOSIT 2 ====
 
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, referrer);
         assertEq(shares1, WETHAmount2); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -954,7 +954,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         
         // First deposit should be 1:1 at initial rate
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
@@ -986,7 +986,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         
         // === EXECUTE SECOND DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, referrer);
         
         //check total assets after
         uint256 totalAssetsAfter = accountant.totalAssets();
@@ -1007,7 +1007,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
         
         // === ADD YIELD ===
@@ -1018,7 +1018,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === SECOND DEPOSIT ===
         uint256 expectedVestedYield = yieldVestAmount / 2;
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, referrer);
         
         // === CHECK WITHDRAW AMOUNTS ===
         

--- a/test/AccountantWithYieldStreaming.t.sol
+++ b/test/AccountantWithYieldStreaming.t.sol
@@ -53,6 +53,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
     
     address public alice = address(69); 
     address public bill = address(6969); 
+    address public refferer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -167,7 +168,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
         
         uint256 totalAssetsBefore = accountant.totalAssets();         
@@ -175,7 +176,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         //==== BEGIN DEPOSIT 2 ====
 
         //deposit 2
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(shares1, WETHAmount); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -186,7 +187,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -195,7 +196,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         skip(12 hours); 
 
         //==== BEGIN DEPOSIT 2 ====
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0);
+            uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.assertApproxEqAbs(shares1, 6666666666666666666, 10);  
 
         //total of 2 deposits to 10 weth each + 5 vested yield 
@@ -217,7 +218,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WEETH), address(this), 1_000e18);
         WEETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0);
+        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0, refferer);
         assertEq(expectedShares, shares0); 
 
         //after deposit, last share price is updated
@@ -240,7 +241,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WEETH), address(this), 1_000e18);
         WEETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0);
+        uint256 shares0 = teller.deposit(WEETH, WEETHAmount, 0, refferer);
         assertEq(expectedShares, shares0); 
 
         //before deposit, last share price is updated
@@ -261,7 +262,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(totalAssetsInBaseMid, totalAssetsInBaseLast + vestedYield, 1e4); 
 
         //deposit again
-        uint256 shares1 = teller.deposit(WEETH, WEETHAmount, 0);
+        uint256 shares1 = teller.deposit(WEETH, WEETHAmount, 0, refferer);
 
         (lastSharePrice, , , , ) = accountant.vestingState(); 
 
@@ -282,7 +283,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WEETH), address(this), 1_000e18);
         WEETH.approve(address(boringVault), 1_000e18);
-        teller.deposit(WEETH, WEETHAmount, 0);
+        teller.deposit(WEETH, WEETHAmount, 0, refferer);
        
         (, , , uint64 startVestingTimeNow, ) = accountant.vestingState(); 
         assertEq(startVestingTimeLast + 1 days, startVestingTimeNow);  
@@ -293,11 +294,11 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //deposit 2
-        teller.deposit(WETH, WETHAmount, 0);
+        teller.deposit(WETH, WETHAmount, 0, refferer);
 
         uint256 assetsOut0 = teller.withdraw(WETH, shares0, 0, address(boringVault));   
         assertEq(assetsOut0, WETHAmount); 
@@ -307,7 +308,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -319,7 +320,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, 1_000e18);
         vm.startPrank(alice); 
         WETH.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -336,7 +337,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -348,7 +349,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, 1_000e18);
         vm.startPrank(alice); 
         WETH.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -367,7 +368,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //==== Add Vesting Yield Stream ===="); 
@@ -404,7 +405,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vault total = 10
@@ -458,7 +459,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vault total = 10
@@ -477,7 +478,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(shares0, WETHAmount); 
 
         deal(address(WETH), address(boringVault), WETHAmount);
@@ -525,7 +526,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         deal(address(WETH), address(boringVault), WETHAmount);
@@ -558,7 +559,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18;
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        teller.deposit(WETH, WETHAmount, 0);
+        teller.deposit(WETH, WETHAmount, 0, refferer);
     
         // Record initial state
         (, uint96 initialHighwaterMark, ,,,,,,,,,) = accountant.accountantState();
@@ -605,7 +606,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 100e18;
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0);
     
         accountant.vestYield(1e18, 1 days); // 1% of vault
@@ -618,7 +619,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         assertEq(supplyBefore, 100e18, "Supply should still be 100e18");
     
         //will get fewer shares due to yield
-        teller.deposit(WETH, 100e18, 0);
+        teller.deposit(WETH, 100e18, 0, refferer);
     
         // Get actual supply after deposit (not exactly 200e18 due to share price)
         uint256 supplyAfter = boringVault.totalSupply();
@@ -654,7 +655,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 100e18;
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0);
     
         accountant.vestYield(1e18, 1 days); // 1% of vault
@@ -667,7 +668,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         assertEq(supplyBefore, 100e18, "Supply should still be 100e18");
     
         //will get fewer shares due to yield
-        teller.deposit(WETH, 100e18, 0);
+        teller.deposit(WETH, 100e18, 0, refferer);
     
         // Get actual supply after deposit (not exactly 200e18 due to share price)
         uint256 supplyAfter = boringVault.totalSupply();
@@ -703,7 +704,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -727,10 +728,10 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares1); 
         
         uint256 currentShares = boringVault.totalSupply(); 
@@ -744,7 +745,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -756,13 +757,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         deal(address(WETH), bill, WETHAmount);
         vm.startPrank(bill);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0);
+        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         //skip time
@@ -783,7 +784,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -795,7 +796,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         //skip time
@@ -808,7 +809,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), bill, WETHAmount);
         vm.startPrank(bill);
         WETH.approve(address(boringVault), WETHAmount);
-        teller.deposit(WETH, WETHAmount, 0);
+        teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         assertApproxEqAbs(assetsOutAlice, WETHAmount, 10); 
@@ -818,7 +819,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -829,7 +830,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         //skip time
@@ -842,7 +843,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), bill, WETHAmount);
         vm.startPrank(bill);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0);
+        uint256 sharesBill = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         assertLt(assetsOutAlice, WETHAmount); 
@@ -856,7 +857,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -866,7 +867,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(WETH), alice, WETHAmount);
         vm.startPrank(alice);
         WETH.approve(address(boringVault), WETHAmount);
-        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0);
+        uint256 sharesAlice = teller.deposit(WETH, WETHAmount, 0, refferer);
         vm.stopPrank();
 
         //alice withdraws
@@ -883,7 +884,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -897,7 +898,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -911,7 +912,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(WETHAmount, shares0); 
 
         //vest some yield
@@ -930,13 +931,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(shares0, WETHAmount); 
 
         //==== BEGIN DEPOSIT 2 ====
 
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
         assertEq(shares1, WETHAmount2); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -953,7 +954,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         
         // First deposit should be 1:1 at initial rate
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
@@ -985,7 +986,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         
         // === EXECUTE SECOND DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
         
         //check total assets after
         uint256 totalAssetsAfter = accountant.totalAssets();
@@ -1006,7 +1007,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
         
         // === ADD YIELD ===
@@ -1017,7 +1018,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === SECOND DEPOSIT ===
         uint256 expectedVestedYield = yieldVestAmount / 2;
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
         
         // === CHECK WITHDRAW AMOUNTS ===
         

--- a/test/AccountantWithYieldStreamingExchangeRateGtOne.t.sol
+++ b/test/AccountantWithYieldStreamingExchangeRateGtOne.t.sol
@@ -78,6 +78,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // Setup roles authority.
         rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);
         rolesAuthority.setRoleCapability(BURNER_ROLE, address(boringVault), BoringVault.exit.selector, true);
+        rolesAuthority.setRoleCapability(MINTER_ROLE, address(accountant), AccountantWithYieldStreaming.setFirstDepositTimestamp.selector, true);
         rolesAuthority.setRoleCapability(
             ADMIN_ROLE, address(accountant), AccountantWithRateProviders.pause.selector, true
         );
@@ -161,7 +162,8 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        address refferer = vm.addr(1337);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
 
         uint256 currentRate = accountant.getRate();
         uint256 expectedShares = uint256(WETHAmount).mulDivDown(1e18, currentRate);
@@ -173,7 +175,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         //==== BEGIN DEPOSIT 2 ====
 
         //deposit 2
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
 
         currentRate = accountant.getRate();
         expectedShares = uint256(WETHAmount).mulDivDown(1e18, currentRate);

--- a/test/AccountantWithYieldStreamingExchangeRateGtOne.t.sol
+++ b/test/AccountantWithYieldStreamingExchangeRateGtOne.t.sol
@@ -162,8 +162,8 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 WETHAmount = 10e18; 
         deal(address(WETH), address(this), 1_000e18);
         WETH.approve(address(boringVault), 1_000e18);
-        address refferer = vm.addr(1337);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        address referrer = vm.addr(1337);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
 
         uint256 currentRate = accountant.getRate();
         uint256 expectedShares = uint256(WETHAmount).mulDivDown(1e18, currentRate);
@@ -175,7 +175,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         //==== BEGIN DEPOSIT 2 ====
 
         //deposit 2
-        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount, 0, referrer);
 
         currentRate = accountant.getRate();
         expectedShares = uint256(WETHAmount).mulDivDown(1e18, currentRate);

--- a/test/AccountantWithYieldStreamingNonWadScaledVault.t.sol
+++ b/test/AccountantWithYieldStreamingNonWadScaledVault.t.sol
@@ -46,7 +46,8 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
     uint8 public constant CAN_SOLVE_ROLE = 11;
     
     address public alice = address(69); 
-    address public bill = address(6969); 
+    address public bill = address(6969);
+    address public refferer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -73,6 +74,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // Setup roles authority.
         rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);
         rolesAuthority.setRoleCapability(BURNER_ROLE, address(boringVault), BoringVault.exit.selector, true);
+        rolesAuthority.setRoleCapability(MINTER_ROLE, address(accountant), AccountantWithYieldStreaming.setFirstDepositTimestamp.selector, true);
         rolesAuthority.setRoleCapability(
             ADMIN_ROLE, address(accountant), AccountantWithRateProviders.pause.selector, true
         );
@@ -154,7 +156,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
         
         uint256 totalAssetsBefore = accountant.totalAssets();         
@@ -162,7 +164,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         //==== BEGIN DEPOSIT 2 ====
 
         //deposit 2
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(shares1, USDCAmount); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -173,7 +175,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -182,7 +184,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         skip(12 hours); 
 
         //==== BEGIN DEPOSIT 2 ====
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.assertApproxEqAbs(shares1, 6666666, 10); //
 
         //total of 2 deposits to 10 weth each + 5 vested yield 
@@ -195,11 +197,11 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //deposit 2
-        teller.deposit(USDC, USDCAmount, 0);
+        teller.deposit(USDC, USDCAmount, 0, refferer);
 
         uint256 assetsOut0 = teller.withdraw(USDC, shares0, 0, address(boringVault));   
         assertEq(assetsOut0, USDCAmount); 
@@ -209,7 +211,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -221,7 +223,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, 1_000e6);
         vm.startPrank(alice); 
         USDC.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -238,7 +240,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -250,7 +252,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, 1_000e6);
         vm.startPrank(alice); 
         USDC.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -270,7 +272,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //==== Add Vesting Yield Stream ===="); 
@@ -306,7 +308,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vault total = 10
@@ -360,7 +362,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vault total = 10
@@ -379,7 +381,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(shares0, USDCAmount); 
 
         deal(address(USDC), address(boringVault), USDCAmount);
@@ -426,7 +428,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         deal(address(USDC), address(boringVault), USDCAmount);
@@ -459,7 +461,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6;
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        teller.deposit(USDC, USDCAmount, 0);
+        teller.deposit(USDC, USDCAmount, 0, refferer);
     
         // Record initial state
         (, uint96 initialHighwaterMark, ,,,,,,,,,) = accountant.accountantState();
@@ -506,7 +508,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -530,10 +532,10 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares1); 
         
         uint256 currentShares = boringVault.totalSupply(); 
@@ -547,7 +549,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -559,13 +561,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         deal(address(USDC), bill, USDCAmount);
         vm.startPrank(bill);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0);
+        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         //skip time
@@ -586,7 +588,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -598,7 +600,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         //skip time
@@ -611,7 +613,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), bill, USDCAmount);
         vm.startPrank(bill);
         USDC.approve(address(boringVault), USDCAmount);
-        teller.deposit(USDC, USDCAmount, 0);
+        teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         assertApproxEqAbs(assetsOutAlice, USDCAmount, 10); 
@@ -621,7 +623,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -632,7 +634,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         //skip time
@@ -645,7 +647,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), bill, USDCAmount);
         vm.startPrank(bill);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0);
+        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         assertLt(assetsOutAlice, USDCAmount); 
@@ -659,7 +661,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -669,7 +671,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
         vm.stopPrank();
 
         //alice withdraws
@@ -686,7 +688,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -700,7 +702,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -714,7 +716,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -732,13 +734,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(USDC), address(this), USDCAmount);
         USDC.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
         assertEq(shares0, USDCAmount); 
 
         //==== BEGIN DEPOSIT 2 ====
 
         deal(address(USDC), address(this), USDCAmount2);
-        uint256 shares1 = teller.deposit(USDC, USDCAmount2, 0);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount2, 0, refferer);
         assertEq(shares1, USDCAmount2); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -755,7 +757,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         
         // First deposit should be 1:1 at initial rate
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
@@ -787,7 +789,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         
         // === EXECUTE SECOND DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
         
         //check total assets after
         uint256 totalAssetsAfter = accountant.totalAssets();
@@ -808,7 +810,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
         
         // === ADD YIELD ===
@@ -819,7 +821,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === SECOND DEPOSIT ===
         uint256 expectedVestedYield = yieldVestAmount / 2;
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
         
         // === CHECK WITHDRAW AMOUNTS ===
         

--- a/test/AccountantWithYieldStreamingNonWadScaledVault.t.sol
+++ b/test/AccountantWithYieldStreamingNonWadScaledVault.t.sol
@@ -47,7 +47,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
     
     address public alice = address(69); 
     address public bill = address(6969);
-    address public refferer = vm.addr(1337);
+    address public referrer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -156,7 +156,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
         
         uint256 totalAssetsBefore = accountant.totalAssets();         
@@ -164,7 +164,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         //==== BEGIN DEPOSIT 2 ====
 
         //deposit 2
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(shares1, USDCAmount); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -175,7 +175,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -184,7 +184,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         skip(12 hours); 
 
         //==== BEGIN DEPOSIT 2 ====
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.assertApproxEqAbs(shares1, 6666666, 10); //
 
         //total of 2 deposits to 10 weth each + 5 vested yield 
@@ -197,11 +197,11 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //deposit 2
-        teller.deposit(USDC, USDCAmount, 0, refferer);
+        teller.deposit(USDC, USDCAmount, 0, referrer);
 
         uint256 assetsOut0 = teller.withdraw(USDC, shares0, 0, address(boringVault));   
         assertEq(assetsOut0, USDCAmount); 
@@ -211,7 +211,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -223,7 +223,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, 1_000e6);
         vm.startPrank(alice); 
         USDC.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -240,7 +240,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //==== Add Vesting Yield Stream ====
@@ -252,7 +252,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, 1_000e6);
         vm.startPrank(alice); 
         USDC.approve(address(boringVault), type(uint256).max); 
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank(); 
         
         //==== BEGIN WITHDRAW USER 1 ====
@@ -272,7 +272,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //==== Add Vesting Yield Stream ===="); 
@@ -308,7 +308,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vault total = 10
@@ -362,7 +362,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vault total = 10
@@ -381,7 +381,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(shares0, USDCAmount); 
 
         deal(address(USDC), address(boringVault), USDCAmount);
@@ -428,7 +428,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         deal(address(USDC), address(boringVault), USDCAmount);
@@ -461,7 +461,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6;
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        teller.deposit(USDC, USDCAmount, 0, refferer);
+        teller.deposit(USDC, USDCAmount, 0, referrer);
     
         // Record initial state
         (, uint96 initialHighwaterMark, ,,,,,,,,,) = accountant.accountantState();
@@ -508,7 +508,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -532,10 +532,10 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
-        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares1); 
         
         uint256 currentShares = boringVault.totalSupply(); 
@@ -549,7 +549,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -561,13 +561,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         deal(address(USDC), bill, USDCAmount);
         vm.startPrank(bill);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         //skip time
@@ -588,7 +588,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -600,7 +600,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         //skip time
@@ -613,7 +613,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), bill, USDCAmount);
         vm.startPrank(bill);
         USDC.approve(address(boringVault), USDCAmount);
-        teller.deposit(USDC, USDCAmount, 0, refferer);
+        teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         assertApproxEqAbs(assetsOutAlice, USDCAmount, 10); 
@@ -623,7 +623,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -634,7 +634,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         //skip time
@@ -647,7 +647,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), bill, USDCAmount);
         vm.startPrank(bill);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 sharesBill = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         assertLt(assetsOutAlice, USDCAmount); 
@@ -661,7 +661,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -671,7 +671,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         deal(address(USDC), alice, USDCAmount);
         vm.startPrank(alice);
         USDC.approve(address(boringVault), USDCAmount);
-        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 sharesAlice = teller.deposit(USDC, USDCAmount, 0, referrer);
         vm.stopPrank();
 
         //alice withdraws
@@ -688,7 +688,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -702,7 +702,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -716,7 +716,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         uint256 USDCAmount = 10e6; 
         deal(address(USDC), address(this), 1_000e6);
         USDC.approve(address(boringVault), 1_000e6);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(USDCAmount, shares0); 
 
         //vest some yield
@@ -734,13 +734,13 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
 
         deal(address(USDC), address(this), USDCAmount);
         USDC.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(USDC, USDCAmount, 0, referrer);
         assertEq(shares0, USDCAmount); 
 
         //==== BEGIN DEPOSIT 2 ====
 
         deal(address(USDC), address(this), USDCAmount2);
-        uint256 shares1 = teller.deposit(USDC, USDCAmount2, 0, refferer);
+        uint256 shares1 = teller.deposit(USDC, USDCAmount2, 0, referrer);
         assertEq(shares1, USDCAmount2); 
 
         uint256 totalAssetsAfter = accountant.totalAssets();         
@@ -757,7 +757,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         
         // First deposit should be 1:1 at initial rate
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
@@ -789,7 +789,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         
         // === EXECUTE SECOND DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, referrer);
         
         //check total assets after
         uint256 totalAssetsAfter = accountant.totalAssets();
@@ -810,7 +810,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === FIRST DEPOSIT ===
         deal(address(WETH), address(this), WETHAmount);
         WETH.approve(address(boringVault), type(uint256).max);
-        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, WETHAmount, 0, referrer);
         assertEq(shares0, WETHAmount, "First deposit should be 1:1");
         
         // === ADD YIELD ===
@@ -821,7 +821,7 @@ contract AccountantWithYieldStreamingTest is Test, MerkleTreeHelper {
         // === SECOND DEPOSIT ===
         uint256 expectedVestedYield = yieldVestAmount / 2;
         deal(address(WETH), address(this), WETHAmount2);
-        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, refferer);
+        uint256 shares1 = teller.deposit(WETH, WETHAmount2, 0, referrer);
         
         // === CHECK WITHDRAW AMOUNTS ===
         

--- a/test/AtomicQueue.t.sol
+++ b/test/AtomicQueue.t.sol
@@ -105,14 +105,14 @@ contract AtomicQueueTest is Test, MerkleTreeHelper {
         // User buys some BoringVault shares.
         deal(address(WETH), address(user), 1_000e18);
         deal(address(WEETH), address(user), 1_001e18);
-        address refferer = vm.addr(1337);
+        address referrer = vm.addr(1337);
         vm.startPrank(user);
         WETH.approve(address(boringVault), type(uint256).max);
         WEETH.approve(address(boringVault), type(uint256).max);
         WEETH.approve(address(atomicQueue), type(uint256).max);
         boringVault.approve(address(atomicQueue), type(uint256).max);
-        teller.deposit(WETH, 1_000e18, 0, refferer);
-        teller.deposit(WEETH, 1_000e18, 0, refferer);
+        teller.deposit(WETH, 1_000e18, 0, referrer);
+        teller.deposit(WEETH, 1_000e18, 0, referrer);
         vm.stopPrank();
     }
 

--- a/test/AtomicQueue.t.sol
+++ b/test/AtomicQueue.t.sol
@@ -105,14 +105,14 @@ contract AtomicQueueTest is Test, MerkleTreeHelper {
         // User buys some BoringVault shares.
         deal(address(WETH), address(user), 1_000e18);
         deal(address(WEETH), address(user), 1_001e18);
-
+        address refferer = vm.addr(1337);
         vm.startPrank(user);
         WETH.approve(address(boringVault), type(uint256).max);
         WEETH.approve(address(boringVault), type(uint256).max);
         WEETH.approve(address(atomicQueue), type(uint256).max);
         boringVault.approve(address(atomicQueue), type(uint256).max);
-        teller.deposit(WETH, 1_000e18, 0);
-        teller.deposit(WEETH, 1_000e18, 0);
+        teller.deposit(WETH, 1_000e18, 0, refferer);
+        teller.deposit(WEETH, 1_000e18, 0, refferer);
         vm.stopPrank();
     }
 

--- a/test/LayerZeroTellerNoMock.t.sol
+++ b/test/LayerZeroTellerNoMock.t.sol
@@ -54,6 +54,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
     uint32 public constant DESTINATION_ID = 2;
 
     address public solver = vm.addr(54);
+    address public refferer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -146,7 +147,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
         vm.startPrank(user);
         WETH.approve(address(boringVault), depositAmount);
         sourceTeller.depositAndBridge{value: fee}(
-            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, fee
+            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, fee, refferer
         );
         vm.stopPrank();
     }
@@ -192,19 +193,21 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
         deal(user, fee);
 
         vm.startPrank(user);
-        sourceTeller.depositAndBridgeWithPermit{value: fee}(
-            WEETH,
-            weETH_amount,
-            0,
-            block.timestamp,
-            v,
-            r,
-            s,
-            user,
-            abi.encode(layerZeroArbitrumEndpointId),
-            NATIVE_ERC20,
-            fee
-        );
+        CrossChainTellerWithGenericBridge.DepositAndBridgeWithPermitParams memory params = CrossChainTellerWithGenericBridge.DepositAndBridgeWithPermitParams({
+            depositAsset: WEETH,
+            depositAmount: weETH_amount,
+            minimumMint: 0,
+            deadline: block.timestamp,
+            v: v,
+            r: r,
+            s: s,
+            to: user,
+            bridgeWildCard: abi.encode(layerZeroArbitrumEndpointId),
+            feeToken: NATIVE_ERC20,
+            maxFee: fee,
+            referralAddress: refferer
+        });
+        sourceTeller.depositAndBridgeWithPermit{value: fee}(params);   
         vm.stopPrank();
     }
 
@@ -225,7 +228,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
             )
         );
         sourceTeller.depositAndBridge(
-            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0
+            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0, refferer
         );
         vm.stopPrank();
 
@@ -239,7 +242,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
             )
         );
         sourceTeller.depositAndBridge(
-            NATIVE_ERC20, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0
+            NATIVE_ERC20, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0, refferer
         );
         vm.stopPrank();
     }

--- a/test/LayerZeroTellerNoMock.t.sol
+++ b/test/LayerZeroTellerNoMock.t.sol
@@ -54,7 +54,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
     uint32 public constant DESTINATION_ID = 2;
 
     address public solver = vm.addr(54);
-    address public refferer = vm.addr(1337);
+    address public referrer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -147,7 +147,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
         vm.startPrank(user);
         WETH.approve(address(boringVault), depositAmount);
         sourceTeller.depositAndBridge{value: fee}(
-            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, fee, refferer
+            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, fee, referrer
         );
         vm.stopPrank();
     }
@@ -205,7 +205,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
             bridgeWildCard: abi.encode(layerZeroArbitrumEndpointId),
             feeToken: NATIVE_ERC20,
             maxFee: fee,
-            referralAddress: refferer
+            referralAddress: referrer
         });
         sourceTeller.depositAndBridgeWithPermit{value: fee}(params);   
         vm.stopPrank();
@@ -228,7 +228,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
             )
         );
         sourceTeller.depositAndBridge(
-            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0, refferer
+            WETH, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0, referrer
         );
         vm.stopPrank();
 
@@ -242,7 +242,7 @@ contract LayerZeroTellerNoMockTest is Test, MerkleTreeHelper {
             )
         );
         sourceTeller.depositAndBridge(
-            NATIVE_ERC20, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0, refferer
+            NATIVE_ERC20, depositAmount, 0, user, abi.encode(layerZeroArbitrumEndpointId), NATIVE_ERC20, 0, referrer
         );
         vm.stopPrank();
     }

--- a/test/TellerVersions.t.sol
+++ b/test/TellerVersions.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+import {TellerWithBuffer} from "src/base/Roles/TellerWithBuffer.sol";
+import {TellerWithRemediation} from "src/base/Roles/TellerWithRemediation.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {LayerZeroTeller} from "src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol";
+import {LayerZeroTellerWithRateLimiting} from "src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {ChainValues} from "test/resources/ChainValues.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {MockLayerZeroEndPoint} from "src/helper/MockLayerZeroEndPoint.sol";
+
+contract TellerVersionsTest is Test, MerkleTreeHelper {
+    using stdStorage for StdStorage;
+
+    TellerWithBuffer public tellerWithBuffer;
+    TellerWithRemediation public tellerWithRemediation;
+    TellerWithYieldStreaming public tellerWithYieldStreaming;
+    LayerZeroTeller public layerZeroTeller;
+    LayerZeroTellerWithRateLimiting public layerZeroTellerWithRateLimiting;
+
+    BoringVault public boringVault;
+    AccountantWithRateProviders public accountant;
+
+    MockLayerZeroEndPoint public endPoint;
+
+    function setUp() public {
+        string memory rpcKey = "MAINNET_RPC_URL";
+        uint256 blockNumber = 23091932;
+        vm.createSelectFork(vm.envString(rpcKey), blockNumber);
+
+        endPoint = new MockLayerZeroEndPoint();
+
+        boringVault = new BoringVault(address(this), "Boring Vault", "BV", 18);
+        accountant = new AccountantWithRateProviders(address(this), address(boringVault), address(0), 1e18, getAddress(mainnet, "WETH"), 1.001e4, 0.999e4, 1, 0, 0);
+        tellerWithBuffer = new TellerWithBuffer(address(this), address(boringVault), address(accountant), address(0));
+        tellerWithRemediation = new TellerWithRemediation(address(this), address(boringVault), address(accountant), address(0));
+        tellerWithYieldStreaming = new TellerWithYieldStreaming(address(this), address(boringVault), address(accountant), address(0));
+        layerZeroTeller = new LayerZeroTeller(address(this), address(boringVault), address(accountant), address(0), address(endPoint), address(this), address(0));
+        layerZeroTellerWithRateLimiting = new LayerZeroTellerWithRateLimiting(address(this), address(boringVault), address(accountant), address(0), address(endPoint), address(this), address(0));
+    }
+
+    function testTellerVersions() view public {
+        assertEq(tellerWithBuffer.version(), "Buffer V0.1 Base V0.1");
+        assertEq(tellerWithRemediation.version(), "Remediation V0.1 Base V0.1");
+        assertEq(tellerWithYieldStreaming.version(), "Yield Streaming V0.1 Buffer V0.1 Base V0.1");
+        assertEq(layerZeroTeller.version(), "LayerZero V0.1 Cross Chain V0.1 Base V0.1");
+        assertEq(layerZeroTellerWithRateLimiting.version(), "LayerZero Rate Limiting V0.1 Cross Chain V0.1 Base V0.1");
+    }
+}

--- a/test/TellerVersions.t.sol
+++ b/test/TellerVersions.t.sol
@@ -48,10 +48,10 @@ contract TellerVersionsTest is Test, MerkleTreeHelper {
     }
 
     function testTellerVersions() view public {
-        assertEq(tellerWithBuffer.version(), "Buffer V0.1 Base V0.1");
-        assertEq(tellerWithRemediation.version(), "Remediation V0.1 Base V0.1");
-        assertEq(tellerWithYieldStreaming.version(), "Yield Streaming V0.1 Buffer V0.1 Base V0.1");
-        assertEq(layerZeroTeller.version(), "LayerZero V0.1 Cross Chain V0.1 Base V0.1");
-        assertEq(layerZeroTellerWithRateLimiting.version(), "LayerZero Rate Limiting V0.1 Cross Chain V0.1 Base V0.1");
+        assertEq(tellerWithBuffer.version(), "Buffer V0.1, Base V0.1");
+        assertEq(tellerWithRemediation.version(), "Remediation V0.1, Base V0.1");
+        assertEq(tellerWithYieldStreaming.version(), "Yield Streaming V0.1, Buffer V0.1, Base V0.1");
+        assertEq(layerZeroTeller.version(), "LayerZero V0.1, Cross Chain V0.1, Base V0.1");
+        assertEq(layerZeroTellerWithRateLimiting.version(), "LayerZero Rate Limiting V0.1, Cross Chain V0.1, Base V0.1");
     }
 }

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -53,6 +53,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
     GenericRateProviderWithDecimalScaling internal sUSDeRateProvider;
 
     address internal v3Pool;
+    address public refferer = vm.addr(1337);
 
     function setUp() public {
         setSourceChainName("mainnet");
@@ -174,10 +175,10 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -213,10 +214,10 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -252,10 +253,10 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -361,7 +362,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
 
         teller.bulkDeposit(USDT, amount / 10, 0, address(this));
-        teller.deposit(USDC, amount / 10, 0);
+        teller.deposit(USDC, amount / 10, 0, refferer);
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 5, 4, "Should have received expected shares");
         uint256 onePercentYield = amount / 5 / 100 + 100; // add 100 to avoid rounding errors
         deal(address(USDC), address(boringVault), onePercentYield); // 1% of the current total assets
@@ -412,7 +413,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
 
         sUSDe.safeApprove(address(boringVault), amount);
 
-        teller.deposit(sUSDe, amount / 2, 0);
+        teller.deposit(sUSDe, amount / 2, 0, refferer);
         teller.bulkDeposit(sUSDe, amount / 2, 0, address(this));
 
         // 1e6 /1e18 adjusts token decimals, getRate / 1e18 adjusts for rate scaling
@@ -446,7 +447,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
 
         USDT.safeApprove(address(boringVault), amount);
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         // give the vault an additional 1% yield
         // not in the buffer though
@@ -467,7 +468,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
 
         teller.setShareLockPeriod(10);
         USDT.safeApprove(address(boringVault), amount);
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         // should revert because shares are locked
         vm.expectRevert(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreLocked.selector);
@@ -491,7 +492,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDT, IBufferHelper(address(0)));
         teller.setDepositBufferHelper(USDT, IBufferHelper(address(0)));
         
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertEq(USDT.balanceOf(address(boringVault)), amount, "USDT should all be in vault");
@@ -538,7 +539,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDC, IBufferHelper(newBufferHelper));
         teller.setDepositBufferHelper(USDC, IBufferHelper(newBufferHelper));
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 4, "USDT should all be in aave");
@@ -549,7 +550,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
     
         uint256 currentShares = boringVault.balanceOf(address(this));
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(boringVault.balanceOf(address(this)) - currentShares, amount, "Change in shares should be same as deposit amount");
         assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 4, "USDC should all be in aave");
 

--- a/test/TellerWithBuffer.t.sol
+++ b/test/TellerWithBuffer.t.sol
@@ -53,7 +53,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
     GenericRateProviderWithDecimalScaling internal sUSDeRateProvider;
 
     address internal v3Pool;
-    address public refferer = vm.addr(1337);
+    address public referrer = vm.addr(1337);
 
     function setUp() public {
         setSourceChainName("mainnet");
@@ -175,10 +175,10 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -214,10 +214,10 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -253,10 +253,10 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -362,7 +362,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
 
         teller.bulkDeposit(USDT, amount / 10, 0, address(this));
-        teller.deposit(USDC, amount / 10, 0, refferer);
+        teller.deposit(USDC, amount / 10, 0, referrer);
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 5, 4, "Should have received expected shares");
         uint256 onePercentYield = amount / 5 / 100 + 100; // add 100 to avoid rounding errors
         deal(address(USDC), address(boringVault), onePercentYield); // 1% of the current total assets
@@ -413,7 +413,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
 
         sUSDe.safeApprove(address(boringVault), amount);
 
-        teller.deposit(sUSDe, amount / 2, 0, refferer);
+        teller.deposit(sUSDe, amount / 2, 0, referrer);
         teller.bulkDeposit(sUSDe, amount / 2, 0, address(this));
 
         // 1e6 /1e18 adjusts token decimals, getRate / 1e18 adjusts for rate scaling
@@ -447,7 +447,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
 
         USDT.safeApprove(address(boringVault), amount);
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         // give the vault an additional 1% yield
         // not in the buffer though
@@ -468,7 +468,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
 
         teller.setShareLockPeriod(10);
         USDT.safeApprove(address(boringVault), amount);
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         // should revert because shares are locked
         vm.expectRevert(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreLocked.selector);
@@ -492,7 +492,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDT, IBufferHelper(address(0)));
         teller.setDepositBufferHelper(USDT, IBufferHelper(address(0)));
         
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertEq(USDT.balanceOf(address(boringVault)), amount, "USDT should all be in vault");
@@ -539,7 +539,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDC, IBufferHelper(newBufferHelper));
         teller.setDepositBufferHelper(USDC, IBufferHelper(newBufferHelper));
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 4, "USDT should all be in aave");
@@ -550,7 +550,7 @@ contract TellerBufferTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
     
         uint256 currentShares = boringVault.balanceOf(address(this));
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(boringVault.balanceOf(address(this)) - currentShares, amount, "Change in shares should be same as deposit amount");
         assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 4, "USDC should all be in aave");
 

--- a/test/TellerWithMultiAssetSupport.t.sol
+++ b/test/TellerWithMultiAssetSupport.t.sol
@@ -49,7 +49,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
     address internal WEETH_RATE_PROVIDER;
 
     address public solver = vm.addr(54);
-    address public refferer = vm.addr(1337);
+    address public referrer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -142,11 +142,11 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         WETH.safeApprove(address(boringVault), wETH_amount);
         EETH.safeApprove(address(boringVault), eETH_amount);
-        uint256 shares0 = teller.deposit(WETH, wETH_amount, 0, refferer);
+        uint256 shares0 = teller.deposit(WETH, wETH_amount, 0, referrer);
         uint256 firstDepositTimestamp = block.timestamp;
         // Skip 1 days to finalize first deposit.
         skip(1 days + 1);
-        uint256 shares1 = teller.deposit(EETH, eETH_amount, 0, refferer);
+        uint256 shares1 = teller.deposit(EETH, eETH_amount, 0, referrer);
         uint256 secondDepositTimestamp = block.timestamp;
 
         // Even if setShareLockPeriod is set to 2 days, first deposit is still not revertable.
@@ -156,16 +156,16 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreUnLocked.selector)
         );
-        teller.refundDeposit(1, address(this), address(WETH), wETH_amount, shares0, firstDepositTimestamp, 1 days, refferer);
+        teller.refundDeposit(1, address(this), address(WETH), wETH_amount, shares0, firstDepositTimestamp, 1 days, referrer);
 
         // However the second deposit is still revertable.
-        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days, refferer);
+        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days, referrer);
 
         // Calling revert deposit again should revert.
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__BadDepositHash.selector)
         );
-        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days, refferer);
+        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days, referrer);
     }
 
     function testUserDepositPeggedAssets(uint256 amount) external {
@@ -182,9 +182,9 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(WETH, wETH_amount, 0, refferer);
+        teller.deposit(WETH, wETH_amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
-        teller.deposit(EETH, eETH_amount, 0, refferer);
+        teller.deposit(EETH, eETH_amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -201,7 +201,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         WEETH.safeApprove(address(boringVault), weETH_amount);
 
-        teller.deposit(WEETH, weETH_amount, 0, refferer);
+        teller.deposit(WEETH, weETH_amount, 0, referrer);
 
         uint256 expected_shares = amount;
 
@@ -215,7 +215,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         deal(address(this), 2 * amount);
 
-        teller.deposit{value: amount}(ERC20(NATIVE), 0, 0, refferer);
+        teller.deposit{value: amount}(ERC20(NATIVE), 0, 0, referrer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Should have received expected shares");
     }
@@ -248,7 +248,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(userKey, digest);
 
         vm.startPrank(user);
-        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, refferer);
+        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, referrer);
         vm.stopPrank();
 
         // and if user supplied wrong permit data, deposit will fail.
@@ -276,7 +276,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
                 TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__PermitFailedAndAllowanceTooLow.selector
             )
         );
-        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, refferer);
+        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, referrer);
         vm.stopPrank();
     }
 
@@ -315,7 +315,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         // Users TX is still successful.
         vm.startPrank(user);
-        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, refferer);
+        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, referrer);
         vm.stopPrank();
 
         assertTrue(boringVault.balanceOf(user) > 0, "Should have received shares");
@@ -385,7 +385,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.startPrank(user);
         WETH.safeApprove(address(boringVault), wETH_amount);
 
-        uint256 shares = teller.deposit(WETH, wETH_amount, 0, refferer);
+        uint256 shares = teller.deposit(WETH, wETH_amount, 0, referrer);
 
         // Share lock period is not set, so user can submit withdraw request immediately.
         AtomicQueue.AtomicRequest memory req = AtomicQueue.AtomicRequest({
@@ -557,7 +557,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         WETH.approve(address(boringVault), depositAmount);
 
         uint256 shareDelta = boringVault.balanceOf(address(this));
-        uint256 sharesOut = teller.deposit(WETH, depositAmount, 0, refferer);
+        uint256 sharesOut = teller.deposit(WETH, depositAmount, 0, referrer);
         shareDelta = boringVault.balanceOf(address(this)) - shareDelta;
 
         // WETH is 1:1 with share price, so shares out should equal depositAmount - sharePremium
@@ -577,7 +577,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         deal(address(this), depositAmount);
 
         uint256 shareDelta = boringVault.balanceOf(address(this));
-        uint256 sharesOut = teller.deposit{value: depositAmount}(ERC20(NATIVE), 0, 0, refferer);
+        uint256 sharesOut = teller.deposit{value: depositAmount}(ERC20(NATIVE), 0, 0, referrer);
         shareDelta = boringVault.balanceOf(address(this)) - shareDelta;
 
         // ETH is 1:1 with share price, so shares out should equal depositAmount - sharePremium
@@ -600,7 +600,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
                 )
             )
         );
-        teller.deposit(WETH, 0, 0, refferer);
+        teller.deposit(WETH, 0, 0, referrer);
 
         // Allow deposits
         teller.updateAssetData(WETH, true, false, 0);
@@ -608,7 +608,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             bytes(abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector))
         );
-        teller.deposit(WETH, 0, 0, refferer);
+        teller.deposit(WETH, 0, 0, referrer);
 
         // Stop deposits.
         teller.updateAssetData(WETH, false, false, 0);
@@ -620,7 +620,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
                 )
             )
         );
-        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), refferer);
+        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), referrer);
 
         // Allow deposits
         teller.updateAssetData(WETH, true, false, 0);
@@ -628,7 +628,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             bytes(abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector))
         );
-        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), refferer);
+        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), referrer);
 
         // Stop deposits.
         teller.updateAssetData(WETH, false, false, 0);
@@ -699,12 +699,12 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__Paused.selector)
         );
-        teller.deposit(WETH, 0, 0, refferer);
+        teller.deposit(WETH, 0, 0, referrer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__Paused.selector)
         );
-        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), refferer);
+        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), referrer);
 
         teller.unpause();
 
@@ -713,34 +713,34 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__AssetNotSupported.selector)
         );
-        teller.deposit(WETH, 0, 0, refferer);
+        teller.deposit(WETH, 0, 0, referrer);
 
         teller.updateAssetData(WETH, true, true, 0);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector)
         );
-        teller.deposit(WETH, 0, 0, refferer);
+        teller.deposit(WETH, 0, 0, referrer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__DualDeposit.selector)
         );
-        teller.deposit{value: 1}(WETH, 1, 0, refferer);
+        teller.deposit{value: 1}(WETH, 1, 0, referrer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__MinimumMintNotMet.selector)
         );
-        teller.deposit(WETH, 1, type(uint256).max, refferer);
+        teller.deposit(WETH, 1, type(uint256).max, referrer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector)
         );
-        teller.deposit(NATIVE_ERC20, 0, 0, refferer);
+        teller.deposit(NATIVE_ERC20, 0, 0, referrer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__MinimumMintNotMet.selector)
         );
-        teller.deposit{value: 1}(NATIVE_ERC20, 1, type(uint256).max, refferer);
+        teller.deposit{value: 1}(NATIVE_ERC20, 1, type(uint256).max, referrer);
 
         // updateAssetData revert
         vm.expectRevert(
@@ -792,7 +792,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         deal(address(WETH), user, wETH_amount);
         WETH.safeApprove(address(boringVault), wETH_amount);
 
-        teller.deposit(WETH, wETH_amount, 0, refferer);
+        teller.deposit(WETH, wETH_amount, 0, referrer);
 
         // Trying to transfer shares should revert.
         vm.expectRevert(
@@ -843,7 +843,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__DepositExceedsCap.selector) 
         );
-        teller.deposit(WETH, wETH_amount, 0, refferer);
+        teller.deposit(WETH, wETH_amount, 0, referrer);
 
         //now succeeds
         teller.setDepositCap(1000e18); 
@@ -852,13 +852,13 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         wETH_amount = 998e18; 
         vm.startPrank(user); 
         WETH.approve(address(boringVault), type(uint256).max); 
-        teller.deposit(WETH, wETH_amount, 0, refferer);
+        teller.deposit(WETH, wETH_amount, 0, referrer);
         
         //now we add more than deposit cap
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__DepositExceedsCap.selector) 
         );
-        teller.deposit(WETH, 2e18, 0, refferer);
+        teller.deposit(WETH, 2e18, 0, referrer);
     }
 
     // ========================================= HELPER FUNCTIONS =========================================
@@ -871,7 +871,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
     function depositAndTransfer(ERC20 asset, uint256 depositAmount, address to, bool expectRevert) public {
         deal(address(asset), address(this), depositAmount);
         asset.approve(address(boringVault), depositAmount);
-        uint256 shares = teller.deposit(asset, depositAmount, 0, refferer);
+        uint256 shares = teller.deposit(asset, depositAmount, 0, referrer);
         if (expectRevert) {
             vm.expectRevert(
                 bytes(
@@ -884,5 +884,37 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         } else {
             boringVault.transfer(to, shares);
         }
+    }
+    //throws weird natspec error when using TellerWithMultiAssetSupport.Deposit
+    event Deposit(
+        uint256 nonce,
+        address indexed receiver,
+        address indexed depositAsset,
+        uint256 depositAmount,
+        uint256 shareAmount,
+        uint256 depositTimestamp,
+        uint256 shareLockPeriodAtTimeOfDeposit,
+        address indexed referralAddress
+    );
+
+    function testDepositEmitsReadableReferralEvent() external{
+        uint256 amount = 1e18;
+
+        uint256 wETH_amount = amount;
+        deal(address(WETH), address(this), wETH_amount);
+
+        WETH.safeApprove(address(boringVault), wETH_amount);
+        vm.expectEmit();
+        emit Deposit(
+            1,
+            address(this),
+            address(WETH),
+            wETH_amount,
+            wETH_amount,
+            block.timestamp,
+            0,
+            referrer
+        );
+        teller.deposit(WETH, wETH_amount, 0, referrer);
     }
 }

--- a/test/TellerWithMultiAssetSupport.t.sol
+++ b/test/TellerWithMultiAssetSupport.t.sol
@@ -692,6 +692,48 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         depositAndTransfer(WETH, 1e18, user, true);
     }
 
+    function testMultipleDepositsWithShareLockPeriod() external {
+        teller.setShareLockPeriod(10000);
+        // can deposit multiple times in a row without share lock blocking
+        deal(address(WETH), address(this), 1e18);
+        WETH.safeApprove(address(boringVault), 1e18);
+        teller.deposit(WETH, 0.1e18, 0, referrer);
+        skip(100);
+        teller.deposit(WETH, 0.1e18, 0, referrer);
+    }
+
+    function testDepositRevertsWhenDenyFrom() external {
+        teller.denyFrom(address(this));
+        vm.expectRevert(
+            abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__TransferDenied.selector, address(this), address(this), address(this))
+        );
+        teller.deposit(WETH, 1e18, 0, referrer);
+    }
+
+    function testDepositRevertsWhenDenyTo() external {
+        teller.denyTo(address(this));
+        vm.expectRevert(
+            abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__TransferDenied.selector, address(this), address(this), address(this))
+        );
+        teller.deposit(WETH, 1e18, 0, referrer);
+    }
+
+    function testDepositRevertsWhenDenyOperator() external {
+        teller.denyOperator(address(this));
+        vm.expectRevert(
+            abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__TransferDenied.selector, address(this), address(this), address(this))
+        );
+        teller.deposit(WETH, 1e18, 0, referrer);
+    }
+
+    function testDepositRevertsWhenDenyAll() external {
+        teller.denyAll(address(this));
+        vm.expectRevert(
+            abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__TransferDenied.selector, address(this), address(this), address(this))
+        );
+        teller.deposit(WETH, 1e18, 0, referrer);
+    }
+
     function testReverts() external {
         // Test pause logic
         teller.pause();

--- a/test/TellerWithMultiAssetSupport.t.sol
+++ b/test/TellerWithMultiAssetSupport.t.sol
@@ -49,6 +49,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
     address internal WEETH_RATE_PROVIDER;
 
     address public solver = vm.addr(54);
+    address public refferer = vm.addr(1337);
 
     function setUp() external {
         setSourceChainName("mainnet");
@@ -141,11 +142,11 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         WETH.safeApprove(address(boringVault), wETH_amount);
         EETH.safeApprove(address(boringVault), eETH_amount);
-        uint256 shares0 = teller.deposit(WETH, wETH_amount, 0);
+        uint256 shares0 = teller.deposit(WETH, wETH_amount, 0, refferer);
         uint256 firstDepositTimestamp = block.timestamp;
         // Skip 1 days to finalize first deposit.
         skip(1 days + 1);
-        uint256 shares1 = teller.deposit(EETH, eETH_amount, 0);
+        uint256 shares1 = teller.deposit(EETH, eETH_amount, 0, refferer);
         uint256 secondDepositTimestamp = block.timestamp;
 
         // Even if setShareLockPeriod is set to 2 days, first deposit is still not revertable.
@@ -155,16 +156,16 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreUnLocked.selector)
         );
-        teller.refundDeposit(1, address(this), address(WETH), wETH_amount, shares0, firstDepositTimestamp, 1 days);
+        teller.refundDeposit(1, address(this), address(WETH), wETH_amount, shares0, firstDepositTimestamp, 1 days, refferer);
 
         // However the second deposit is still revertable.
-        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days);
+        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days, refferer);
 
         // Calling revert deposit again should revert.
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__BadDepositHash.selector)
         );
-        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days);
+        teller.refundDeposit(2, address(this), address(EETH), eETH_amount, shares1, secondDepositTimestamp, 1 days, refferer);
     }
 
     function testUserDepositPeggedAssets(uint256 amount) external {
@@ -181,9 +182,9 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(WETH, wETH_amount, 0);
+        teller.deposit(WETH, wETH_amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
-        teller.deposit(EETH, eETH_amount, 0);
+        teller.deposit(EETH, eETH_amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -200,7 +201,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         WEETH.safeApprove(address(boringVault), weETH_amount);
 
-        teller.deposit(WEETH, weETH_amount, 0);
+        teller.deposit(WEETH, weETH_amount, 0, refferer);
 
         uint256 expected_shares = amount;
 
@@ -214,7 +215,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         deal(address(this), 2 * amount);
 
-        teller.deposit{value: amount}(ERC20(NATIVE), 0, 0);
+        teller.deposit{value: amount}(ERC20(NATIVE), 0, 0, refferer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Should have received expected shares");
     }
@@ -247,7 +248,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(userKey, digest);
 
         vm.startPrank(user);
-        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s);
+        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, refferer);
         vm.stopPrank();
 
         // and if user supplied wrong permit data, deposit will fail.
@@ -275,7 +276,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
                 TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__PermitFailedAndAllowanceTooLow.selector
             )
         );
-        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s);
+        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, refferer);
         vm.stopPrank();
     }
 
@@ -314,7 +315,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
 
         // Users TX is still successful.
         vm.startPrank(user);
-        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s);
+        teller.depositWithPermit(WEETH, weETH_amount, 0, block.timestamp, v, r, s, refferer);
         vm.stopPrank();
 
         assertTrue(boringVault.balanceOf(user) > 0, "Should have received shares");
@@ -384,7 +385,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.startPrank(user);
         WETH.safeApprove(address(boringVault), wETH_amount);
 
-        uint256 shares = teller.deposit(WETH, wETH_amount, 0);
+        uint256 shares = teller.deposit(WETH, wETH_amount, 0, refferer);
 
         // Share lock period is not set, so user can submit withdraw request immediately.
         AtomicQueue.AtomicRequest memory req = AtomicQueue.AtomicRequest({
@@ -556,7 +557,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         WETH.approve(address(boringVault), depositAmount);
 
         uint256 shareDelta = boringVault.balanceOf(address(this));
-        uint256 sharesOut = teller.deposit(WETH, depositAmount, 0);
+        uint256 sharesOut = teller.deposit(WETH, depositAmount, 0, refferer);
         shareDelta = boringVault.balanceOf(address(this)) - shareDelta;
 
         // WETH is 1:1 with share price, so shares out should equal depositAmount - sharePremium
@@ -576,7 +577,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         deal(address(this), depositAmount);
 
         uint256 shareDelta = boringVault.balanceOf(address(this));
-        uint256 sharesOut = teller.deposit{value: depositAmount}(ERC20(NATIVE), 0, 0);
+        uint256 sharesOut = teller.deposit{value: depositAmount}(ERC20(NATIVE), 0, 0, refferer);
         shareDelta = boringVault.balanceOf(address(this)) - shareDelta;
 
         // ETH is 1:1 with share price, so shares out should equal depositAmount - sharePremium
@@ -599,7 +600,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
                 )
             )
         );
-        teller.deposit(WETH, 0, 0);
+        teller.deposit(WETH, 0, 0, refferer);
 
         // Allow deposits
         teller.updateAssetData(WETH, true, false, 0);
@@ -607,7 +608,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             bytes(abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector))
         );
-        teller.deposit(WETH, 0, 0);
+        teller.deposit(WETH, 0, 0, refferer);
 
         // Stop deposits.
         teller.updateAssetData(WETH, false, false, 0);
@@ -619,7 +620,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
                 )
             )
         );
-        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0));
+        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), refferer);
 
         // Allow deposits
         teller.updateAssetData(WETH, true, false, 0);
@@ -627,7 +628,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             bytes(abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector))
         );
-        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0));
+        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), refferer);
 
         // Stop deposits.
         teller.updateAssetData(WETH, false, false, 0);
@@ -698,12 +699,12 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__Paused.selector)
         );
-        teller.deposit(WETH, 0, 0);
+        teller.deposit(WETH, 0, 0, refferer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__Paused.selector)
         );
-        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0));
+        teller.depositWithPermit(WETH, 0, 0, 0, 0, bytes32(0), bytes32(0), refferer);
 
         teller.unpause();
 
@@ -712,34 +713,34 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__AssetNotSupported.selector)
         );
-        teller.deposit(WETH, 0, 0);
+        teller.deposit(WETH, 0, 0, refferer);
 
         teller.updateAssetData(WETH, true, true, 0);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector)
         );
-        teller.deposit(WETH, 0, 0);
+        teller.deposit(WETH, 0, 0, refferer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__DualDeposit.selector)
         );
-        teller.deposit{value: 1}(WETH, 1, 0);
+        teller.deposit{value: 1}(WETH, 1, 0, refferer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__MinimumMintNotMet.selector)
         );
-        teller.deposit(WETH, 1, type(uint256).max);
+        teller.deposit(WETH, 1, type(uint256).max, refferer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__ZeroAssets.selector)
         );
-        teller.deposit(NATIVE_ERC20, 0, 0);
+        teller.deposit(NATIVE_ERC20, 0, 0, refferer);
 
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__MinimumMintNotMet.selector)
         );
-        teller.deposit{value: 1}(NATIVE_ERC20, 1, type(uint256).max);
+        teller.deposit{value: 1}(NATIVE_ERC20, 1, type(uint256).max, refferer);
 
         // updateAssetData revert
         vm.expectRevert(
@@ -791,7 +792,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         deal(address(WETH), user, wETH_amount);
         WETH.safeApprove(address(boringVault), wETH_amount);
 
-        teller.deposit(WETH, wETH_amount, 0);
+        teller.deposit(WETH, wETH_amount, 0, refferer);
 
         // Trying to transfer shares should revert.
         vm.expectRevert(
@@ -842,7 +843,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__DepositExceedsCap.selector) 
         );
-        teller.deposit(WETH, wETH_amount, 0);
+        teller.deposit(WETH, wETH_amount, 0, refferer);
 
         //now succeeds
         teller.setDepositCap(1000e18); 
@@ -851,13 +852,13 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
         wETH_amount = 998e18; 
         vm.startPrank(user); 
         WETH.approve(address(boringVault), type(uint256).max); 
-        teller.deposit(WETH, wETH_amount, 0);
+        teller.deposit(WETH, wETH_amount, 0, refferer);
         
         //now we add more than deposit cap
         vm.expectRevert(
             abi.encodeWithSelector(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__DepositExceedsCap.selector) 
         );
-        teller.deposit(WETH, 2e18, 0);
+        teller.deposit(WETH, 2e18, 0, refferer);
     }
 
     // ========================================= HELPER FUNCTIONS =========================================
@@ -870,7 +871,7 @@ contract TellerWithMultiAssetSupportTest is Test, MerkleTreeHelper {
     function depositAndTransfer(ERC20 asset, uint256 depositAmount, address to, bool expectRevert) public {
         deal(address(asset), address(this), depositAmount);
         asset.approve(address(boringVault), depositAmount);
-        uint256 shares = teller.deposit(asset, depositAmount, 0);
+        uint256 shares = teller.deposit(asset, depositAmount, 0, refferer);
         if (expectRevert) {
             vm.expectRevert(
                 bytes(

--- a/test/TellerWithYieldStreamingBuffer.t.sol
+++ b/test/TellerWithYieldStreamingBuffer.t.sol
@@ -54,7 +54,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
     GenericRateProviderWithDecimalScaling internal sUSDeRateProvider;
 
     address internal v3Pool;
-    address public refferer = vm.addr(1377);
+    address public referrer = vm.addr(1377);
 
     function setUp() public {
         setSourceChainName("mainnet");
@@ -195,10 +195,10 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -234,10 +234,10 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -273,10 +273,10 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -382,7 +382,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
 
         teller.bulkDeposit(USDT, amount / 10, 0, address(this));
-        teller.deposit(USDC, amount / 10, 0, refferer);
+        teller.deposit(USDC, amount / 10, 0, referrer);
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 5, 4, "Should have received expected shares");
         uint256 onePercentYield = amount / 5 / 100; // add 100 to avoid rounding errors
         deal(address(USDC), address(boringVault), onePercentYield + 1000); // 1% of the current total assets
@@ -434,7 +434,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         sUSDe.safeApprove(address(boringVault), amount);
 
-        teller.deposit(sUSDe, amount / 2, 0, refferer);
+        teller.deposit(sUSDe, amount / 2, 0, referrer);
         teller.bulkDeposit(sUSDe, amount / 2, 0, address(this));
 
         // 1e6 /1e18 adjusts token decimals, getRate / 1e18 adjusts for rate scaling
@@ -468,7 +468,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         USDT.safeApprove(address(boringVault), amount);
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         // give the vault an additional 1% yield
         // not in the buffer though
@@ -492,7 +492,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         teller.setShareLockPeriod(10);
         USDT.safeApprove(address(boringVault), amount);
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         // should revert because shares are locked
         vm.expectRevert(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreLocked.selector);
@@ -516,7 +516,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDT, IBufferHelper(address(0)));
         teller.setDepositBufferHelper(USDT, IBufferHelper(address(0)));
         
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertEq(USDT.balanceOf(address(boringVault)), amount, "USDT should all be in vault");
@@ -563,7 +563,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDC, IBufferHelper(newBufferHelper));
         teller.setDepositBufferHelper(USDC, IBufferHelper(newBufferHelper));
 
-        teller.deposit(USDT, amount, 0, refferer);
+        teller.deposit(USDT, amount, 0, referrer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 4, "USDT should all be in aave");
@@ -574,7 +574,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
     
         uint256 currentShares = boringVault.balanceOf(address(this));
-        teller.deposit(USDC, amount, 0, refferer);
+        teller.deposit(USDC, amount, 0, referrer);
         assertEq(boringVault.balanceOf(address(this)) - currentShares, amount, "Change in shares should be same as deposit amount");
         assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 4, "USDC should all be in aave");
 

--- a/test/TellerWithYieldStreamingBuffer.t.sol
+++ b/test/TellerWithYieldStreamingBuffer.t.sol
@@ -54,6 +54,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
     GenericRateProviderWithDecimalScaling internal sUSDeRateProvider;
 
     address internal v3Pool;
+    address public refferer = vm.addr(1377);
 
     function setUp() public {
         setSourceChainName("mainnet");
@@ -107,6 +108,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);
         rolesAuthority.setRoleCapability(BURNER_ROLE, address(boringVault), BoringVault.exit.selector, true);
+        rolesAuthority.setRoleCapability(MINTER_ROLE, address(accountant), AccountantWithYieldStreaming.setFirstDepositTimestamp.selector, true);
         rolesAuthority.setRoleCapability(
             ADMIN_ROLE, address(teller), TellerWithMultiAssetSupport.updateAssetData.selector, true
         );
@@ -193,10 +195,10 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -232,10 +234,10 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -271,10 +273,10 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
         uint96 currentNonce = teller.depositNonce();
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 1, "Deposit nonce should have increased by 1");
 
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(teller.depositNonce(), currentNonce + 2, "Deposit nonce should have increased by 2");
         assertEq(teller.depositNonce(), 2, "Deposit nonce should be 2");
 
@@ -380,7 +382,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         USDC.safeApprove(address(boringVault), amount);
 
         teller.bulkDeposit(USDT, amount / 10, 0, address(this));
-        teller.deposit(USDC, amount / 10, 0);
+        teller.deposit(USDC, amount / 10, 0, refferer);
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 5, 4, "Should have received expected shares");
         uint256 onePercentYield = amount / 5 / 100; // add 100 to avoid rounding errors
         deal(address(USDC), address(boringVault), onePercentYield + 1000); // 1% of the current total assets
@@ -432,7 +434,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         sUSDe.safeApprove(address(boringVault), amount);
 
-        teller.deposit(sUSDe, amount / 2, 0);
+        teller.deposit(sUSDe, amount / 2, 0, refferer);
         teller.bulkDeposit(sUSDe, amount / 2, 0, address(this));
 
         // 1e6 /1e18 adjusts token decimals, getRate / 1e18 adjusts for rate scaling
@@ -466,7 +468,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         USDT.safeApprove(address(boringVault), amount);
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         // give the vault an additional 1% yield
         // not in the buffer though
@@ -490,7 +492,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
 
         teller.setShareLockPeriod(10);
         USDT.safeApprove(address(boringVault), amount);
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         // should revert because shares are locked
         vm.expectRevert(TellerWithMultiAssetSupport.TellerWithMultiAssetSupport__SharesAreLocked.selector);
@@ -514,7 +516,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDT, IBufferHelper(address(0)));
         teller.setDepositBufferHelper(USDT, IBufferHelper(address(0)));
         
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertEq(USDT.balanceOf(address(boringVault)), amount, "USDT should all be in vault");
@@ -561,7 +563,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         teller.setWithdrawBufferHelper(USDC, IBufferHelper(newBufferHelper));
         teller.setDepositBufferHelper(USDC, IBufferHelper(newBufferHelper));
 
-        teller.deposit(USDT, amount, 0);
+        teller.deposit(USDT, amount, 0, refferer);
 
         assertEq(boringVault.balanceOf(address(this)), amount, "Shares should be same as deposit amount");
         assertApproxEqAbs(aUSDT.balanceOf(address(boringVault)), amount, 4, "USDT should all be in aave");
@@ -572,7 +574,7 @@ contract TellerWithYieldStreamingBufferTest is Test, MerkleTreeHelper {
         assertApproxEqAbs(boringVault.balanceOf(address(this)), amount / 2, 4, "Remaining shares should be half of deposit amount");
     
         uint256 currentShares = boringVault.balanceOf(address(this));
-        teller.deposit(USDC, amount, 0);
+        teller.deposit(USDC, amount, 0, refferer);
         assertEq(boringVault.balanceOf(address(this)) - currentShares, amount, "Change in shares should be same as deposit amount");
         assertApproxEqAbs(aUSDC.balanceOf(address(boringVault)), amount, 4, "USDC should all be in aave");
 

--- a/test/integrations/CrossChainTellerIntegration.t.sol
+++ b/test/integrations/CrossChainTellerIntegration.t.sol
@@ -3,7 +3,7 @@
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
 pragma solidity 0.8.21;
-
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
@@ -12,7 +12,8 @@ import {CurveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
 contract FullTellerDecoderAndSanitizer is 
-    TellerDecoderAndSanitizer
+    TellerDecoderAndSanitizer,
+    BaseDecoderAndSanitizer
 {
 
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds referral tracking to deposits, introduces version() strings across tellers, refactors cross-chain deposit APIs, updates yield-streaming accountant, and expands tests, helpers, and deploy scripts.
> 
> - **Teller Core**:
>   - Adds referral support: `deposit(...)`/`depositWithPermit(...)` accept `referralAddress`; `Deposit` event includes `referralAddress`; `refundDeposit(...)` hash includes referral.
>   - Refactors deny-list checks via `_handleDenyList` and enforces in `_erc20Deposit`.
>   - Exposes versions: new/updated `version()` in `TellerWithMultiAssetSupport` ("Base V0.1") and overrides in Buffer/Remediation/YieldStreaming to concatenate labels.
> - **Cross-Chain**:
>   - `depositAndBridge(...)` adds `referralAddress`.
>   - `depositAndBridgeWithPermit(...)` now takes a single params struct including referral and fee fields.
>   - LayerZero tellers add `version()` overrides.
> - **Accountant (Yield Streaming)**:
>   - `YieldRecorded` now emits `(amountAdded, endVestingTime)`; adds `setFirstDepositTimestamp()`; adjusts fee sync and cumulative supply handling.
> - **Buffer/Helpers**:
>   - New `AaveV3BufferLens` to report instantly withdrawable amounts via Aave or idle vault balance.
> - **Interfaces**:
>   - Adds Aave V3 `IPool`, `IPoolAddressesProvider`, and `DataTypes` interfaces.
> - **Scripts**:
>   - New deploy scripts for InkedUSDT Accountant/Teller with Yield Streaming; queue deploy script targets Sepolia with updated names/addresses.
> - **Tests**:
>   - Broad updates to pass `referralAddress`, cover deny-list behaviors, share-lock flows, cross-chain params, and version strings; adds `TellerVersions.t.sol`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2166d8d5e275edf81352460c7b9bc19a388a3d58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->