### PR TITLE
update Chaos roots to supply USDE/sUSDE

### DIFF
--- a/leafs/Mainnet/BalancedUSDCStrategistLeafs.json
+++ b/leafs/Mainnet/BalancedUSDCStrategistLeafs.json
@@ -10,8 +10,8 @@
       "Bytes4(TARGET_FUNCTION_SELECTOR)",
       "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
     ],
-    "LeafCount": 148,
-    "ManageRoot": "0x93dfca3ab373b8fc4fbe2b43b84d26c9fecb8b1092a45afc880c3cf63e55bf53",
+    "LeafCount": 156,
+    "ManageRoot": "0xb885f9722e185789a11c4a42091c74dee8ee201a19a239cbb6c5ae6229b8ac90",
     "ManagerAddress": "0xA0e501F98A1B5d3d8e6Ffd161c76f92570E42931",
     "TreeCapacity": 256
   },
@@ -1587,6 +1587,28 @@
       "TargetAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
     },
     {
+      "AddressArguments": ["0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Approve Aave V3 Pool to spend sUSDe",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0x4e5aa2c139420a2ec11d494392527d4bc396e81952c5df946f5208b5d654278b",
+      "PackedArgumentAddresses": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
+      "TargetAddress": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497"
+    },
+    {
+      "AddressArguments": ["0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Approve Aave V3 Pool to spend USDe",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0x6c2669775d7dd2e547503938d0ad5a89e8344eb0bd47b38f597864bb22c3309d",
+      "PackedArgumentAddresses": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
+      "TargetAddress": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"
+    },
+    {
       "AddressArguments": [
         "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "0xcaae49fb7f74cCFBE8A05E6104b01c097a78789f"
@@ -1612,6 +1634,34 @@
       "FunctionSignature": "supply(address,uint256,address,uint16)",
       "LeafDigest": "0x7d32204d64c8ba3477c895fcf68cda82b5565f0b7c6f89c8c08d03d71e024e1f",
       "PackedArgumentAddresses": "0xdac17f958d2ee523a2206206994597c13d831ec7caae49fb7f74ccfbe8a05e6104b01c097a78789f",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": [
+        "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+        "0xcaae49fb7f74cCFBE8A05E6104b01c097a78789f"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Supply sUSDe to Aave V3",
+      "FunctionSelector": "0x617ba037",
+      "FunctionSignature": "supply(address,uint256,address,uint16)",
+      "LeafDigest": "0x7eb9b2d365100b6b1370103dddabae995a6fbcaab1f91fb10fff43c568283af5",
+      "PackedArgumentAddresses": "0x9d39a5de30e57443bff2a8307a4256c8797a3497caae49fb7f74ccfbe8a05e6104b01c097a78789f",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": [
+        "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+        "0xcaae49fb7f74cCFBE8A05E6104b01c097a78789f"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Supply USDe to Aave V3",
+      "FunctionSelector": "0x617ba037",
+      "FunctionSignature": "supply(address,uint256,address,uint16)",
+      "LeafDigest": "0xeeebe3a6adac902696d90ee44df548f9b7c29549b53db492472b4d236066e3b5",
+      "PackedArgumentAddresses": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3caae49fb7f74ccfbe8a05e6104b01c097a78789f",
       "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
     },
     {
@@ -1643,6 +1693,34 @@
       "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
     },
     {
+      "AddressArguments": [
+        "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+        "0xcaae49fb7f74cCFBE8A05E6104b01c097a78789f"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Withdraw sUSDe from Aave V3",
+      "FunctionSelector": "0x69328dec",
+      "FunctionSignature": "withdraw(address,uint256,address)",
+      "LeafDigest": "0x0c47cecca4353bcdba6945880bba0ce230941f1a23127dbb47b774f2ec779994",
+      "PackedArgumentAddresses": "0x9d39a5de30e57443bff2a8307a4256c8797a3497caae49fb7f74ccfbe8a05e6104b01c097a78789f",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": [
+        "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+        "0xcaae49fb7f74cCFBE8A05E6104b01c097a78789f"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Withdraw USDe from Aave V3",
+      "FunctionSelector": "0x69328dec",
+      "FunctionSignature": "withdraw(address,uint256,address)",
+      "LeafDigest": "0xc5ecd7d0b9246e0f98aa5a84d53c71ff5d48b00bc11b0868866f94d328d1c5ee",
+      "PackedArgumentAddresses": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3caae49fb7f74ccfbe8a05e6104b01c097a78789f",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
       "AddressArguments": ["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
@@ -1662,6 +1740,28 @@
       "FunctionSignature": "setUserUseReserveAsCollateral(address,bool)",
       "LeafDigest": "0x810a02489dab4fada5ab06c9a0ae28ccb193c1be1b9026ffe705c6261c9e6a4c",
       "PackedArgumentAddresses": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": ["0x9D39A5DE30e57443BfF2A8307A4256c8797A3497"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Toggle sUSDe as collateral in Aave V3",
+      "FunctionSelector": "0x5a3b74b9",
+      "FunctionSignature": "setUserUseReserveAsCollateral(address,bool)",
+      "LeafDigest": "0xca1df14fa1763c26b22e18331b0940e06b92f436bb7d28b307e21e014e77ef0a",
+      "PackedArgumentAddresses": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": ["0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x5901da9Ca757Bf6ce3e232024840D32e0bfbc692",
+      "Description": "Toggle USDe as collateral in Aave V3",
+      "FunctionSelector": "0x5a3b74b9",
+      "FunctionSignature": "setUserUseReserveAsCollateral(address,bool)",
+      "LeafDigest": "0xb5d51b71ab9211b9ca5331ff39703c7ef03c49ffb722f978fcd284d2c297ab25",
+      "PackedArgumentAddresses": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
       "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
     },
     {
@@ -3137,114 +3237,26 @@
       "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "PackedArgumentAddresses": "0x",
       "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
     }
   ],
   "MerkleTree": {
-    "0": ["0x93dfca3ab373b8fc4fbe2b43b84d26c9fecb8b1092a45afc880c3cf63e55bf53"],
+    "0": ["0xb885f9722e185789a11c4a42091c74dee8ee201a19a239cbb6c5ae6229b8ac90"],
     "1": [
-      "0x19a687d842333fe73a2463fa15eea3dc8fc31870f494b1c83ce30881a5472203",
-      "0x41073405bdee5b4fc94e67353f258c564bde1aecf330501be23a86da00abd8d4"
+      "0xb6662756f4a3d210fc3113bc22706c0fe1ac2113d73494015fffe7d6c8a6fef5",
+      "0x1a6979fbc4d29501d89900e2ea8ba2b3b54f95398059144b8bf5fd82f85fe708"
     ],
     "2": [
       "0x1be4f6ed91e1b4f1111b2f2a2db981b675916d8e4b820f38d880f7a0b315c2bb",
-      "0xbd7dd4236b769edb75fc696bedd51e437de962fe465f4bea858b2033262d1f4c",
-      "0xbea4d759d394f7e8c88064fd7ddfbc8e05331399b240d6a937f6d7c3d23551e3",
+      "0x31853b31e874a66f49b4e950675b69c6bce78ec99da3eb4d31bb1be0a33e079a",
+      "0x0bb1000c979f488ac50144347694ef1673541bbb10ba120021969dfd6dc407b3",
       "0xf70e6eeacf0ca2800bee387294f368bb304fe5f55d96f86ff896d1bcbe16ba34"
     ],
     "3": [
       "0xb6e2c5c9e9964cb40ccc6b863eca39d1fe75c87a71ca980052a2c81bed246b10",
       "0x709145bd0778e16d366eaacecaae9d385afde2a04b671a4d88d43818c700b98f",
       "0x714dc10f7a1f6be84a90009407b4a690d57c8da46465792e0842fb1f9489a828",
-      "0x956db78c7f01f2bb62cbeb1205b5809fe7348bcdbf04eb9d2a0fad14917f24ad",
-      "0x67bf997e623b7e68022cae076f1227d5ebd535f3366577ef84ed11b943c904b5",
+      "0xfa50c2043dc02b8ddc827b392810118a8a5a7d73bada2a630abfad3b6e256955",
+      "0x9c91bdebc183ff72f56dca05cc1be1d4828b956e82285f54c9060197c908d56a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a"
@@ -3256,10 +3268,10 @@
       "0x01fecb84c02bc8294f0fb806cdbe3ee2a0105d9e904285ef5d2afd26fb290773",
       "0x9ced5d27abf5141c120fd0ea725eabc653e4ca3e5d439d4f2127199e81e3d110",
       "0x66599806822c83801e36ee3faef7ed742224baece32b03616822f2f45767014c",
-      "0xd1a797576048159626a408015b931e1803ef9be4ebe37a9f550a4f97af7ba42a",
-      "0x15fc687b6037b435cc02773a81d10dbfa4faf69d0405f0db645dcd20c57453da",
-      "0x869ce495e71be341d9cf5b717c2a7119ec8fe66bcca537e743043d3d269e577a",
-      "0x9655fb3b1103f8837ae14c362c2e3bd0bd0ee4c0a6c8242357c7f8c464bdbd46",
+      "0x458cc16c439ff593b2156c71c946e1b35deb6f059e4f08a47d245c5b4aacba81",
+      "0xdd1672bff1aac35ade8708b12527dd20c637e41368ee8755082f9d0a47ee6a44",
+      "0x6bfd24202e820fefb8d242653e181d38f78159ff8a10e24da09ed68dd0e63dae",
+      "0x0138c268ee59b5aa865eec3f91d9d587dc494685435cfb5372434af4bf4656ad",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
@@ -3281,13 +3293,13 @@
       "0x9b4f1dac14ae793f66fe7c03d9a30ff7cb59730aa9c42744b33e1c5554157968",
       "0x8911c0307354f6f2f95eeb569f12a657c572b4f12358d0a5fcc6a624bce17119",
       "0xeda26dc17e33492384276543fe1bd22fbce582bd31e2b540e3bcd99610b78fd7",
-      "0xad318d370594ca31c9b41216e187e54b3d2014ffdacdf66fe306ec98a9250ec2",
-      "0xf9e29ec8f5576fd276f3cf18e0ed0c5e96b0018deaf690025e0b10caf1214e00",
+      "0xc909be684b2beb6eb7f8bba2df830c3bc4210e51be1cef867dea90bea9e03e7a",
+      "0x906bf7d38df31ac1290fa9a6b6cde48b16b7bc318f085e1053f4bdb725d0fb7d",
+      "0x1e3553b9d32a9e877af6c049c974270c530a33fbca7ed202f9c4751f2c0dfa3b",
       "0xf9f8b7b3d4af4be0d1f54279f7492adc45a9a9632259788849dd6d0fdbd32acd",
       "0x586ec7ded32de6d5af6c387d20bda61ca00116b27687932120984669e3c73b2b",
       "0x118f6800737a27c240e57b18c038b4cc2634b8dd775188e6d6b8cd83d59a1926",
       "0x0792c79917239f955d2e8eff491890a5bf9135ed49d6bfb5df855a37c6fba35a",
-      "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
@@ -3329,8 +3341,10 @@
       "0x165f151c86c59eaf6f284bbc5ba0866c5ea8cf409fe66a08356ac6e25c2fc773",
       "0xdde1c5eda15f93495ad3a0277b018ac0f4b5e479310226820da1801e209fc72d",
       "0x4d7408a129f90c0a1b93a8980129f20474030d15fe3252ac41ec74876244d567",
-      "0x83fad5bc5525409503f790fe9feabebb545e49c71ab6cc051c25704f12bd3045",
-      "0xe2fb1a367e0329c8366ef638d130da8234b4cba6614539c50a829d3130f54c3c",
+      "0xf263b584c54eb7b97e9109780d48a289dab1954a2a83fb2bd16b5545bb799c24",
+      "0x597cd9560d95a67f24682e41081a3e5082b18da07ec9764a203310f27a13eaa2",
+      "0x483e8e2736cbd7497b00706f3594e891358d35121e82aa0cb06b7437bc070603",
+      "0x4df6666b2824f285ab2939a2131e264706e0ca81da2689506642cd4e270462b8",
       "0x7cd61532e557889232f363ff0e6543f6364cc14776eb52fa72ee2b16b1ac0e80",
       "0x43530fc970b1be3475188d8f9705a2944eabd3bf03339c335fd5602bd41e94dc",
       "0xf5915b1f4ea6d06d34cbce9a765bec1fc5bed13bb8595e533797153ca3d2fedc",
@@ -3339,8 +3353,6 @@
       "0x7aeeee3d8de546e08c2f8de22a0e69af3bb6105044516f8563efa442cf31385f",
       "0x3dcbbcf61ce2b5af0073a8fe62e78494630c2cbb0c1882d77896e170046aa6e9",
       "0xe95c06901e0a8b8faf4b8865f3d16b6ef7e427dfcd1780069fc2bb21657275e1",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -3423,9 +3435,13 @@
       "0x08667ad971a6ffd2468d2f795c94bba832668dc8701d6ecceecd87a1f945c297",
       "0xca6f009de578a99a189f08852a7ac61abc8ff364f5e2d8b2d811f9e700d82f7e",
       "0x5274ac02ced46036a659cda54921e55de8d5e4dc0f0fa7052464e6e239f0faad",
+      "0x670198d00451b56b17fcdb32838a538e4046a1a33dcfc40238b32753182482b8",
       "0xa8e075367bc116a31f47e604b965b2606d9c5601c46cde644969f22e09d4f2c4",
+      "0x9d3ca65f15ff5af1fde39d51fb35dfbc2e939bc1bec164c19163163561092f51",
       "0xd44f6c1e74846eb20b7f429397cac79f896a0c03ce79d6714136337e897a0990",
+      "0x6832a2ac8a86c08b3c5227d7d57989209fe55817dc0c9dba3ee1ae658bf61ad9",
       "0xf061df7a86da7ce2564b3b43d4fcabee8667014e334a2de30c6fb03897d6db39",
+      "0xb8e5830377c6b8bc08b11902229d6e05b9fe5210faac6f83a3763f49f8801f3b",
       "0xf8066e366580393e59331ab30ae0a134f7b397b00dd216030af9cb5f3631682e",
       "0xa388ac54910e98fac91cec13c4a15821ca889d8f6ee1c7b02f27f37ab81cc54b",
       "0x5dd48758f3d7012a0a86c8d73ab792d22c2d20c0f9b4921da0de8c1e7defd989",
@@ -3442,10 +3458,6 @@
       "0x1b2fc002c976a733908c166a69c7571256308be1af7928ed928a3da095450386",
       "0x3f1d318f271d76bbc10322d323bac61ebade2baf77fa1da658d38b4e19d681f1",
       "0xb6dec1bc685df5cb7965ac261dc04994a2eb910ce91d5d3d0c50c5b9565cbef5",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -3608,12 +3620,20 @@
       "0x002f376bafed175ce0c1c886e5f62a818bb3600fbc2daee67737b83bba6f1997",
       "0xa0a9266b69db14c79f5d3a47e45e43a47882ae460c929ba8e62bd85bf5b435f7",
       "0x7c15830271b24c49cbfc8450c8d49f80eca31d2421fb90c1ccb32baf334f6f29",
+      "0x4e5aa2c139420a2ec11d494392527d4bc396e81952c5df946f5208b5d654278b",
+      "0x6c2669775d7dd2e547503938d0ad5a89e8344eb0bd47b38f597864bb22c3309d",
       "0xdede4930fbf9cb0f7cbf9d5d56156dceb1f89c6f78c607921a980f24d8d88e40",
       "0x7d32204d64c8ba3477c895fcf68cda82b5565f0b7c6f89c8c08d03d71e024e1f",
+      "0x7eb9b2d365100b6b1370103dddabae995a6fbcaab1f91fb10fff43c568283af5",
+      "0xeeebe3a6adac902696d90ee44df548f9b7c29549b53db492472b4d236066e3b5",
       "0x3b8881304446c63f2b87a209627f6b83e70c94b65e802423ca29116b45b7618e",
       "0x1633fb378cff48dedf341288f52b41873079b9531bb028068bebc26da56a615a",
+      "0x0c47cecca4353bcdba6945880bba0ce230941f1a23127dbb47b774f2ec779994",
+      "0xc5ecd7d0b9246e0f98aa5a84d53c71ff5d48b00bc11b0868866f94d328d1c5ee",
       "0x56bf1a894bb066513184ec8aa08bd01f7f1a0aa9683cb82c51f8a8b6f0fcaa25",
       "0x810a02489dab4fada5ab06c9a0ae28ccb193c1be1b9026ffe705c6261c9e6a4c",
+      "0xca1df14fa1763c26b22e18331b0940e06b92f436bb7d28b307e21e014e77ef0a",
+      "0xb5d51b71ab9211b9ca5331ff39703c7ef03c49ffb722f978fcd284d2c297ab25",
       "0x7d61e0a83a854734397d1afd332186d6e0be3e095537dd6d58858179301f7f29",
       "0x0176a69c54298f600f7f35459199cd3d647fdf0ac45ac6b711a75845abc2345f",
       "0x9f79329ed82d2b63b9535c2c0a877a321443726705f9533e31fc2ffcff6f8676",
@@ -3646,14 +3666,6 @@
       "0x0b2ce22f8b09e3e52886e4e84a8868be4db0f7b8a7661ec9e127392f551b2689",
       "0x3854f1125f9745f926952c22812caf8f6c667de039971c6c85e26aceb0057b7f",
       "0x9a354e5befa546349409a4042a15ba32f28fb17b8e7330c5d7d5cdab9f389182",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/leafs/Mainnet/BoostedUSDCStrategistLeafs.json
+++ b/leafs/Mainnet/BoostedUSDCStrategistLeafs.json
@@ -10,8 +10,8 @@
       "Bytes4(TARGET_FUNCTION_SELECTOR)",
       "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
     ],
-    "LeafCount": 148,
-    "ManageRoot": "0x4c6347ddc28c2cc3a63204b8a56b360dfe605af407149c0548828faff2e084e9",
+    "LeafCount": 156,
+    "ManageRoot": "0x33f2c1c32f2263b596fe29216e189479c4c4f04ac325f10c6a0ac7c0b23f636d",
     "ManagerAddress": "0xEd23b12e7700BeB638562A22ED65f74291901c25",
     "TreeCapacity": 256
   },
@@ -1587,6 +1587,28 @@
       "TargetAddress": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
     },
     {
+      "AddressArguments": ["0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Approve Aave V3 Pool to spend sUSDe",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0x73ac8ffea3faa94602e3daebf3c8c1587dde6e2936f584527073effdb210eefc",
+      "PackedArgumentAddresses": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
+      "TargetAddress": "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497"
+    },
+    {
+      "AddressArguments": ["0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Approve Aave V3 Pool to spend USDe",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0xe8fbfa9d1b6fb6fefbbedf0ffcf424026a14e53225f6759d9ca94d1385367dc1",
+      "PackedArgumentAddresses": "0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2",
+      "TargetAddress": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"
+    },
+    {
       "AddressArguments": [
         "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "0xDbD87325D7b1189Dcc9255c4926076fF4a96A271"
@@ -1612,6 +1634,34 @@
       "FunctionSignature": "supply(address,uint256,address,uint16)",
       "LeafDigest": "0x3dbc4aeb7d0a31bca6e6c68c58099b45e4cd0a6f663b5c3fc3983de326339f60",
       "PackedArgumentAddresses": "0xdac17f958d2ee523a2206206994597c13d831ec7dbd87325d7b1189dcc9255c4926076ff4a96a271",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": [
+        "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+        "0xDbD87325D7b1189Dcc9255c4926076fF4a96A271"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Supply sUSDe to Aave V3",
+      "FunctionSelector": "0x617ba037",
+      "FunctionSignature": "supply(address,uint256,address,uint16)",
+      "LeafDigest": "0xdfd96a6c1acef0d1f31770b28970c99dcadfa963e1807403d7efd40db4eab6be",
+      "PackedArgumentAddresses": "0x9d39a5de30e57443bff2a8307a4256c8797a3497dbd87325d7b1189dcc9255c4926076ff4a96a271",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": [
+        "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+        "0xDbD87325D7b1189Dcc9255c4926076fF4a96A271"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Supply USDe to Aave V3",
+      "FunctionSelector": "0x617ba037",
+      "FunctionSignature": "supply(address,uint256,address,uint16)",
+      "LeafDigest": "0x2a22782de4693df719d0fd53a09e94dd676f3d2b7713be82464f06ecb5b442e3",
+      "PackedArgumentAddresses": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3dbd87325d7b1189dcc9255c4926076ff4a96a271",
       "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
     },
     {
@@ -1643,6 +1693,34 @@
       "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
     },
     {
+      "AddressArguments": [
+        "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+        "0xDbD87325D7b1189Dcc9255c4926076fF4a96A271"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Withdraw sUSDe from Aave V3",
+      "FunctionSelector": "0x69328dec",
+      "FunctionSignature": "withdraw(address,uint256,address)",
+      "LeafDigest": "0x977318e685ff8942381f33ceb60f06e9234445848ac73d772324f599b085aef7",
+      "PackedArgumentAddresses": "0x9d39a5de30e57443bff2a8307a4256c8797a3497dbd87325d7b1189dcc9255c4926076ff4a96a271",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": [
+        "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+        "0xDbD87325D7b1189Dcc9255c4926076fF4a96A271"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Withdraw USDe from Aave V3",
+      "FunctionSelector": "0x69328dec",
+      "FunctionSignature": "withdraw(address,uint256,address)",
+      "LeafDigest": "0xf67be8cba0bdbcde769e0c9c099fd7d88020c82965dff55ee800522278b0c653",
+      "PackedArgumentAddresses": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3dbd87325d7b1189dcc9255c4926076ff4a96a271",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
       "AddressArguments": ["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
@@ -1662,6 +1740,28 @@
       "FunctionSignature": "setUserUseReserveAsCollateral(address,bool)",
       "LeafDigest": "0x23b0f0f919b7a716a224ab72068aa300c5d4fce1c9ac3779ae35f89cfe35c2df",
       "PackedArgumentAddresses": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": ["0x9D39A5DE30e57443BfF2A8307A4256c8797A3497"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Toggle sUSDe as collateral in Aave V3",
+      "FunctionSelector": "0x5a3b74b9",
+      "FunctionSignature": "setUserUseReserveAsCollateral(address,bool)",
+      "LeafDigest": "0x8f146918b4a4a0d7f33ac5a1e46f1290dace2bebc249ca5ac11489992a6c3864",
+      "PackedArgumentAddresses": "0x9d39a5de30e57443bff2a8307a4256c8797a3497",
+      "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+    },
+    {
+      "AddressArguments": ["0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x7f3A794f99Db3d745DC1A924Afb0fa8CFdFADCca",
+      "Description": "Toggle USDe as collateral in Aave V3",
+      "FunctionSelector": "0x5a3b74b9",
+      "FunctionSignature": "setUserUseReserveAsCollateral(address,bool)",
+      "LeafDigest": "0xbb1dfb9ff905744e77529fbbb22cb2620849861bedabd649e8186714310fc45d",
+      "PackedArgumentAddresses": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
       "TargetAddress": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
     },
     {
@@ -3137,114 +3237,26 @@
       "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "PackedArgumentAddresses": "0x",
       "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
     }
   ],
   "MerkleTree": {
-    "0": ["0x4c6347ddc28c2cc3a63204b8a56b360dfe605af407149c0548828faff2e084e9"],
+    "0": ["0x33f2c1c32f2263b596fe29216e189479c4c4f04ac325f10c6a0ac7c0b23f636d"],
     "1": [
-      "0x85ce297e2d5e98443c0676f3e7f97f5ec54d9a82b8ee9576700936080f326bfd",
-      "0x633602d4ff9ad76aafdfccdf2807e807316750e4825e463774e552a6868c9579"
+      "0x7d1f7022711be8553aa84b369473789b014426a6dd2b162f53ec64acb0f8b156",
+      "0xa2a4cec6e6bf7aedef50a36887c11948ca551889901b24fc5e4a7561ca81d336"
     ],
     "2": [
       "0x520784338178337cbf946ad72fb88dfadf7448b672ab9668fe4362923639c25f",
-      "0x54e1e990724c2efcfa8dca3aaf2d33fe5d5ece3e4f09eabd26eebda16db45766",
-      "0x81e1e00e021c736873557dbc02052d37c3091085d1841c8ced4750d85899e3e1",
+      "0x67a7744a3f9061ee0b8ec29e742f613661ce159a8c9b87ec16ca953ace7e021f",
+      "0xaa04a2a12dedb0e23bbeb53b4fd8f955a883b07bd08c222a1c614ba288e238e5",
       "0xf70e6eeacf0ca2800bee387294f368bb304fe5f55d96f86ff896d1bcbe16ba34"
     ],
     "3": [
       "0x4fe352815a95f3d6da5ad6d765a6f25e73bcf22b33d9b6e82d41132a32f52481",
       "0x7f4583dcc6314fc2f9c6f2a7d7f4144674c7911cffc2562231ec1d1f9d769ddc",
       "0xaeb3e6a5737c2ff5b5fe2a800ff910f67eb5fdcaa3845444b0679767e0bb31a7",
-      "0xe5929e1a56dfabeec7156a6b65c3d4171134c95a50866389537e6845bca80a92",
-      "0xce98b67894f5d4593fc78762d529f296e158b21853c77b63ab5f9ff529add16c",
+      "0xebf17ec51f20516ade6e5e9b8f8f3efee98f8833a4333cb9f1a65dd9236a8f9b",
+      "0x096a416641eca03a6c1b768f92a8168200b1a57fc43bc8e44f7bc595d6bc49f6",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a"
@@ -3256,10 +3268,10 @@
       "0xcef1c834c8646dba68a975887df9bc6d61273ca60765aecf3281ab72ea987d3e",
       "0xc289305e3ff2319eae2e831b7bcb90c1dfaff14a00ae70235335b95269c445c4",
       "0xada14fe13d697f2832429e1c0d54ab94cb39371f083ec21f066acbee0e359429",
-      "0x787fbe71762aaaf3d66c5f6523ef98bba370c15109c9e0c9316a994bf67b2ae0",
-      "0xb62a6bffa2ccca7955c6325325dcd6cb167392f86f684c719b765b85676f210d",
-      "0xabcf84d35f94a64c87fbe813b0b00c0b8b04badbb00fffbdfa748454c2271014",
-      "0xb867f2676b6cb44d9ed03a2d2f0f05a1c569a35f455ee5d0025e3afa6d3f2ee9",
+      "0x673c562cf027fe379d820eed4142870be10e6061c1fbd17e8e67b2729da833a5",
+      "0xed8a82485f0d05e0fce5ca92659bc13aff523945f40ec8ef83f2db94985d4289",
+      "0x44517a58d20fd9fab875ca89363158671fe10dd8aa751b18ae042fed8d11d010",
+      "0x3087076c1b8f9a29777c04cc5a3f11de87258b57186a109907aa78647bddd85b",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
@@ -3281,13 +3293,13 @@
       "0x2ff8fcb145f93f1d4cb74fa8e6eae67562a1a1db761c6edb88d8e1dcee3154bd",
       "0x727f0aa8f60ffc53e1ddb57104fd94105ab2718e88e95ea6e980766ad7036b43",
       "0x1200b97c0b303e0d30a7a703fd7ee7a2885cea12cee03816871f5a9e074a425d",
-      "0x5801fa45ce4098da76b06bd7ebe0b6eac048720ebbef44acb840e9d55f6fb034",
-      "0x8a365cf94e5f262fe41f7662f487356a3d9d1c6e48ff256f7a5a346480c487bc",
+      "0xa945cb38af9f62a1a929bdbc344d2c715fbecf8e7550ea883076ef5bdb51262c",
+      "0xaed68c18daeec1d3a82539b6f91ccb1b11f2aba3a1021d140d91acf9e48bbd41",
+      "0x024287eb2c614b42178a587abb1624bb1a367a60ef7702e3dcd93de2fca6d37e",
       "0xc964d56557c03a8ecc6de9d3588d00b04667282393c9d5d062455dbf241d670e",
       "0x815e3b9f76dc028fe4ae9a9e111a6dccba71798f9f699d39d8ba5abb12c6703b",
       "0xbcb9bf09ca029e3e82f0037d2c8df4667d56212dd254b77ba47cb3045212cb0a",
       "0x1585898071d6a420fca45f2eac5b9be92008d73db357dd67ab9079cb666b4aa9",
-      "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
@@ -3329,8 +3341,10 @@
       "0xea14f967e8231352216cab6556da4175b813e23ea9acd814060ca0d302ed686f",
       "0x39d1fbdd1fd3c80a34217b0a58469f54a35310e1680e437f743796bdb08062d8",
       "0x5fb6d9072e7864662834c267e6e1bb75e90c7b70840a8a29a1d486f404f8ded5",
-      "0x9047630f121b9818739c49be215d5ebac97639fe8d950d7d3d04c182fec22113",
-      "0xe241441495b2c46eda921d23b6c3efcd66a4b6cf8af10a5daecd338f6dc61f20",
+      "0x57ce29252d122607eb8ca3e3ef34e812dfe25c97dabfbfb6725a7f8e18c31ffb",
+      "0x31635e27672798d30a9356aaf75f2da5ca305425a4bff7718648049511e8e6a3",
+      "0x8fb67adc4015e613a6eefa2442ebe458af6c76318ec84e1d98e93a87c2807be1",
+      "0xfff7822032b261d2835cf7d4f38cc9c57e3b478c2da68ade3e35fb747e548248",
       "0xb64221ba24a3885fa74be7edebc1b549d0456078167e2dc72552168e658b165d",
       "0x3d0f0212cffaa54f8589928af2461a4a92f5c743eed2824c4fc6c785b8076c3c",
       "0xa7e73609a766d421b710468608184174f2393c5eb17c022e5458e45326218824",
@@ -3339,8 +3353,6 @@
       "0x7bbd9c7c779a2cd1df8f99e61dd0328fc4c2be61c7e0889f1e76671b2762ce6c",
       "0x9785098dc5135520abd938e48b509d7670f3f88aa0fbc9991777166054fb4ca0",
       "0xe1d4442beb1a7837af1c7ab9cd9f3296cfdcc75c7fd141fbec325c17825c97d0",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -3423,9 +3435,13 @@
       "0x104ec8a0d250d32bfa98da746c89467b93d5ebb9cc3d597d06eccc908c303a6b",
       "0xc8a7c0d1f32e4f33f81cbc37975fab8561861bb6f09bff305f7311cafa680da9",
       "0xc0f413f430aaea6a1e551c19d073fdaf7843b7dfef7584e51bb5ea6680cbd896",
+      "0xcd0adcd9edbbd60ae6053daac47e8bc81018c0998555d950ba00e0533f03c0f0",
       "0x299edbffcd4b6fd928ed7735ec922c73c941b60f76d95a1acc1e7c7c6d067a43",
+      "0x6e54720076e29a8448ab5eae6dbf9c98bb45cb13eccffb547bb08ac7b6889002",
       "0x1632200c889a2aa28a31c7c288cab90592bb55c44d28ee8a79e22d8183270177",
+      "0xbf0fcb16bf1372c2ed66d0b98653226cc6bb0760cde342f526f0a0d2a336def9",
       "0x6ece081dda491e706b39b608712969a7da8e0c58d0de23a767fae7cb03c4e475",
+      "0xa240b39382fb75317d9e6da583210aabb38970e8474c602ea95b2121b033be17",
       "0x46e626414c2227d92aa5f163b571853dad9afa301c4a026042acfbc8acf6e127",
       "0x6b5fca96918f038666901a09cbd0ecf40513680d2091e01ba2fb4806104916ac",
       "0x7bf6a898709e20d7fde58156b0f864c3a2b4e91f97b08c59fe414656ccb7c4e5",
@@ -3442,10 +3458,6 @@
       "0x58d858c0978e43be0b9a4c51a4497dc3dec3f8de54823245912eb549a6706cfd",
       "0xd001ebaa985229b1233be92a6e8a2ae3724ceaec9de9c7eb8de38cd08d114194",
       "0x17d1a2bf0f297ccf8a4e7c89656d83b387a48f46d26450b1882d5a83ce5e6fef",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -3608,12 +3620,20 @@
       "0x495cd043ff8aa91ae77745bab81077185ceb25b1090621cd2bd1394c59698016",
       "0xbc61346778190344e20fa0b1b5b715cac4b457cbd8004f6aa74692a557f11b3d",
       "0xfce611c8a9fc7f2c503a390b90251f7e4421c913c73548423ca274ad6622ebf7",
+      "0x73ac8ffea3faa94602e3daebf3c8c1587dde6e2936f584527073effdb210eefc",
+      "0xe8fbfa9d1b6fb6fefbbedf0ffcf424026a14e53225f6759d9ca94d1385367dc1",
       "0x3e1d82ae1ecb2072883d1322d850b264ef3a15e8e7057946e5e9abe760f4be79",
       "0x3dbc4aeb7d0a31bca6e6c68c58099b45e4cd0a6f663b5c3fc3983de326339f60",
+      "0xdfd96a6c1acef0d1f31770b28970c99dcadfa963e1807403d7efd40db4eab6be",
+      "0x2a22782de4693df719d0fd53a09e94dd676f3d2b7713be82464f06ecb5b442e3",
       "0x13acbe3635319a59cb9b7276819ea949c1bbed2f428171d81dc822903d6570d9",
       "0x3b86dbd2c0a39289af7de9b1f2f99fc58911ddfcb413b0e1b859564c77a3eb42",
+      "0x977318e685ff8942381f33ceb60f06e9234445848ac73d772324f599b085aef7",
+      "0xf67be8cba0bdbcde769e0c9c099fd7d88020c82965dff55ee800522278b0c653",
       "0x41ce8f18657f2bef866f6d09015e12ce2cbed078f831ffe06348a162967ca336",
       "0x23b0f0f919b7a716a224ab72068aa300c5d4fce1c9ac3779ae35f89cfe35c2df",
+      "0x8f146918b4a4a0d7f33ac5a1e46f1290dace2bebc249ca5ac11489992a6c3864",
+      "0xbb1dfb9ff905744e77529fbbb22cb2620849861bedabd649e8186714310fc45d",
       "0xbaac99f72997aac3fd1a28aaa65a2af218e603f1ea4a7a9b76ee0edb2cee5554",
       "0x28df1cc4247c714cca38bb2a20a592f76e5319a0d51e912002d147993517db94",
       "0x2b282fad1dec164ea8daa68d6977e29742c7e4f535f2a381574d56990845e9cd",
@@ -3646,14 +3666,6 @@
       "0x4bc83cd00eb8a8dfa27dc7e289fbb9b94ae65548eae3bc831a4c39ec21a97247",
       "0x899b2a33231419cb402e04e4279cb0233b2aad281c2cbfe9823afc1f18fb5bec",
       "0x22d60b184b752e69b4d5bbbd81e97db57d301deb57439c2680883ab07aa647aa",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/script/MerkleRootCreation/Mainnet/CreateBalancedUSDCMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Mainnet/CreateBalancedUSDCMerkleRoot.s.sol
@@ -75,9 +75,11 @@ contract CreateBalancedUSDCMerkleRoot is Script, MerkleTreeHelper {
         _addNativeLeafs(leafs);
 
         // ========================== Aave V3 ==========================
-        ERC20[] memory supplyAssets = new ERC20[](2);
+        ERC20[] memory supplyAssets = new ERC20[](4);
         supplyAssets[0] = getERC20(sourceChain, "USDC");
         supplyAssets[1] = getERC20(sourceChain, "USDT");
+        supplyAssets[2] = getERC20(sourceChain, "SUSDE");
+        supplyAssets[3] = getERC20(sourceChain, "USDE");
         ERC20[] memory borrowAssets = new ERC20[](0);
         _addAaveV3Leafs(leafs, supplyAssets, borrowAssets);
 

--- a/script/MerkleRootCreation/Mainnet/CreateBoostedUSDCMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Mainnet/CreateBoostedUSDCMerkleRoot.s.sol
@@ -75,9 +75,11 @@ contract CreateBoostedUSDCMerkleRoot is Script, MerkleTreeHelper {
         _addNativeLeafs(leafs);
 
         // ========================== Aave V3 ==========================
-        ERC20[] memory supplyAssets = new ERC20[](2);
+        ERC20[] memory supplyAssets = new ERC20[](4);
         supplyAssets[0] = getERC20(sourceChain, "USDC");
         supplyAssets[1] = getERC20(sourceChain, "USDT");
+        supplyAssets[2] = getERC20(sourceChain, "SUSDE");
+        supplyAssets[3] = getERC20(sourceChain, "USDE");
         ERC20[] memory borrowAssets = new ERC20[](0);
         _addAaveV3Leafs(leafs, supplyAssets, borrowAssets);
 


### PR DESCRIPTION
https://linear.app/veda-labs/issue/SC-546/merkle-root-update-chaos

Update the merkle roots on ETH mainnet to have:
- Supply USDe to Aave market
- Supply sUSDe to Aave market  

Vaults:
- BoostedYield
- BalancedYield 

Chain: ETH Mainnet