### PR TITLE
add and deploy full fluid dex decoder

### DIFF
--- a/script/DeployDecoderAndSanitizer.s.sol
+++ b/script/DeployDecoderAndSanitizer.s.sol
@@ -127,6 +127,8 @@ import {ITBBasePositionDecoderAndSanitizer} from "src/base/DecodersAndSanitizers
 import {BoostedUSDCInkDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BoostedUSDCInkDecoderAndSanitizer.sol";
 import {WhopDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/WhopDecoderAndSanitizer.sol";
 import {TacDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/TacUSDTacDecoderAndSanitizer.sol";
+import {FullResolvDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/FullResolvDecoderAndSanitizer.sol";
+import {FullFluidDexDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/FullFluidDexDecoderAndSanitizer.sol";
 
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
@@ -157,11 +159,11 @@ contract DeployDecoderAndSanitizerScript is Script, ContractNames, MainnetAddres
         bytes memory constructorArgs;
         vm.startBroadcast(privateKey);
 
-        creationCode = type(WhopDecoderAndSanitizer).creationCode;
-        constructorArgs = abi.encode(getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"));
-        console.log("Whop Decoder and Sanitizer V0.0");
+        creationCode = type(FullFluidDexDecoderAndSanitizer).creationCode;
+        constructorArgs = abi.encode();
+        console.log("Full Fluid Dex Decoder and Sanitizer V0.0");
         console.logBytes(constructorArgs);
-        deployer.deployContract("Whop Decoder and Sanitizer V0.0", creationCode, constructorArgs, 0);
+        deployer.deployContract("Full Fluid Dex Decoder and Sanitizer V0.0", creationCode, constructorArgs, 0);
         
         vm.stopBroadcast();
     }

--- a/src/base/DecodersAndSanitizers/FullFluidDexDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/FullFluidDexDecoderAndSanitizer.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {FluidDexDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/FluidDexDecoderAndSanitizer.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+
+contract FullFluidDexDecoderAndSanitizer is FluidDexDecoderAndSanitizer, BaseDecoderAndSanitizer {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a full decoder/sanitizer for Fluid DEX and wires it into deployment.
> 
> - New `FullFluidDexDecoderAndSanitizer` (inherits `FluidDexDecoderAndSanitizer` and `BaseDecoderAndSanitizer`)
> - `DeployDecoderAndSanitizer.s.sol`: imports `FullFluidDexDecoderAndSanitizer` (and `FullResolvDecoderAndSanitizer`) and deploys "Full Fluid Dex Decoder and Sanitizer V0.0" with empty constructor args, replacing the previous Whop deployment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b146f8f53ce1c30d986a7189d1c6d4ac1823384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->