### PR TITLE
Update ArcticArchitectureLens for BoringQueue + instant withdraw support

### DIFF
--- a/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
@@ -26,7 +26,6 @@ import {Deployer} from "src/helper/Deployer.sol";
 import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
 import {ContractNames} from "resources/ContractNames.sol";
 import {GenericRateProvider} from "src/helper/GenericRateProvider.sol";
-import {DelayedWithdraw} from "src/base/Roles/DelayedWithdraw.sol";
 import {BoringDrone} from "src/base/Drones/BoringDrone.sol";
 import {ChainValues} from "test/resources/ChainValues.sol";
 import {PaymentSplitter} from "src/helper/PaymentSplitter.sol";
@@ -130,7 +129,6 @@ contract DeployArcticArchitectureWithConfigScript is Script, ChainValues {
     address public rawDataDecoderAndSanitizer;
     TellerWithMultiAssetSupport public teller;
     AccountantWithRateProviders public accountant;
-    DelayedWithdraw public delayedWithdrawer;
     PaymentSplitter public paymentSplitter;
     BoringOnChainQueue public queue;
     BoringSolver public queueSolver;

--- a/script/ArchitectureDeployments/DeploySkeleton.s.sol
+++ b/script/ArchitectureDeployments/DeploySkeleton.s.sol
@@ -29,7 +29,6 @@ import {Deployer} from "src/helper/Deployer.sol";
 import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
 import {ContractNames} from "resources/ContractNames.sol";
 import {GenericRateProvider} from "src/helper/GenericRateProvider.sol";
-import {DelayedWithdraw} from "src/base/Roles/DelayedWithdraw.sol";
 import {BoringDrone} from "src/base/Drones/BoringDrone.sol";
 import {ChainValues} from "test/resources/ChainValues.sol";
 import {PaymentSplitter} from "src/helper/PaymentSplitter.sol";
@@ -130,7 +129,6 @@ contract DeploySkeletonScript is Script, ChainValues {
     AaveV3BufferLens public aaveV3BufferLens;
     TellerWithYieldStreaming public teller;
     AccountantWithYieldStreaming public accountant;
-    DelayedWithdraw public delayedWithdrawer;
     PaymentSplitter public paymentSplitter;
     BoringOnChainQueue public queue;
     BoringSolver public queueSolver;

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -16,7 +16,7 @@ import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 interface IPoolExtended is IPool {
-    function getReserveATokenAddress(address asset) external view returns (address);
+    function getReserveAToken(address asset) external view returns (ERC20);
 }
 
 contract ArcticArchitectureLens {
@@ -324,7 +324,7 @@ contract ArcticArchitectureLens {
                     revert("Unsupported calculation: AaveV3 pool has borrowed assets");
                 }
                 // Get the balance of the aToken in the vault
-                ERC20 aToken = ERC20(IPoolExtended(aaveV3Pool).getReserveATokenAddress(address(withdrawAsset)));
+                ERC20 aToken = IPoolExtended(aaveV3Pool).getReserveAToken(address(withdrawAsset));
                 withdrawable = aToken.balanceOf(address(boringVault)); // We will reuse withdrawable to avoid stack too deep
 
                 // Withdrawable amount is the balance of the asset in the aToken or the available liquidity, whichever is less

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -209,6 +209,7 @@ contract ArcticArchitectureLens {
         bool deadlinePassed;
         bool noShares;
         bool notEnoughAssetsForWithdraw;
+        uint256 withdrawableAssets;
     }
 
     /**
@@ -233,13 +234,12 @@ contract ArcticArchitectureLens {
 
         if (req.amountOfShares == 0) res.noShares = true;
 
-        uint256 withdrawable;
         if (address(bufferLens) != address(0)) {
-            withdrawable = bufferLens.getInstantlyWithdrawableAmount(teller, ERC20(req.assetOut));
+            res.withdrawableAssets = bufferLens.getInstantlyWithdrawableAmount(teller, ERC20(req.assetOut));
         } else {
-            withdrawable = ERC20(req.assetOut).balanceOf(address(boringVault));
+            res.withdrawableAssets = ERC20(req.assetOut).balanceOf(address(boringVault));
         }
-        if (withdrawable < req.amountOfAssets) {
+        if (res.withdrawableAssets < req.amountOfAssets) {
             res.notEnoughAssetsForWithdraw = true;
         }
     }
@@ -270,6 +270,7 @@ contract ArcticArchitectureLens {
         bool sharesLocked;
         bool notEnoughWithdrawableAssets;
         bool minimumAssetsNotMet;
+        uint256 withdrawableAssets;
     }
 
     /**
@@ -312,10 +313,10 @@ contract ArcticArchitectureLens {
         }
 
         // Calculate the withdrawable amount
-        uint256 withdrawable = bufferLens.getInstantlyWithdrawableAmount(teller, withdrawAsset);
+        res.withdrawableAssets = bufferLens.getInstantlyWithdrawableAmount(teller, withdrawAsset);
 
         // Check if the withdrawable amount is less than the requested assets out
-        if (withdrawable < res.assetsOut) {
+        if (res.withdrawableAssets < res.assetsOut) {
             res.notEnoughWithdrawableAssets = true;
         }
     }

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -6,10 +6,18 @@ pragma solidity 0.8.21;
 
 import {BoringVault, ERC20} from "src/base/BoringVault.sol";
 import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
-import {DelayedWithdraw} from "src/archive/DelayedWithdraw.sol";
+import {BoringOnChainQueue} from "src/base/Roles/BoringQueue/BoringOnChainQueue.sol";
+import {AaveV3BufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
+import {IPool} from "src/interfaces/IPool.sol";
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+interface IPoolExtended is IPool {
+    function getReserveATokenAddress(address asset) external view returns (address);
+}
 
 contract ArcticArchitectureLens {
     using FixedPointMathLib for uint256;
@@ -156,47 +164,60 @@ contract ArcticArchitectureLens {
 
     /**
      */
-    function getWithdrawAssetAndWithdrawRequest(ERC20 asset, address account, DelayedWithdraw delayedWithdraw)
+    function getWithdrawAsset(address asset, BoringOnChainQueue queue)
         public
         view
-        returns (DelayedWithdraw.WithdrawAsset memory withdrawAsset, DelayedWithdraw.WithdrawRequest memory req)
+        returns (BoringOnChainQueue.WithdrawAsset memory withdrawAsset)
     {
         (
             withdrawAsset.allowWithdraws,
-            withdrawAsset.withdrawDelay,
-            withdrawAsset.completionWindow,
-            withdrawAsset.outstandingShares,
-            withdrawAsset.withdrawFee,
-            withdrawAsset.maxLoss
-        ) = delayedWithdraw.withdrawAssets(asset);
-        (req.allowThirdPartyToComplete, req.maxLoss, req.maturity, req.shares, req.exchangeRateAtTimeOfRequest) =
-            delayedWithdraw.withdrawRequests(account, asset);
+            withdrawAsset.secondsToMaturity,
+            withdrawAsset.minimumSecondsToDeadline,
+            withdrawAsset.minDiscount,
+            withdrawAsset.maxDiscount,
+            withdrawAsset.minimumShares,
+            withdrawAsset.withdrawCapacity
+        ) = queue.withdrawAssets(asset);
     }
 
-    function getWithdrawAssetAndWithdrawRequests(
-        ERC20[] calldata assets,
-        address[] calldata accounts,
-        DelayedWithdraw delayedWithdraw
+    function getWithdrawAssets(
+        address[] calldata assets,
+        BoringOnChainQueue queue
     )
         external
         view
-        returns (DelayedWithdraw.WithdrawAsset[] memory withdrawAssets, DelayedWithdraw.WithdrawRequest[] memory reqs)
+        returns (BoringOnChainQueue.WithdrawAsset[] memory withdrawAssets)
     {
         uint256 assetsLength = assets.length;
-        withdrawAssets = new DelayedWithdraw.WithdrawAsset[](assetsLength);
-        reqs = new DelayedWithdraw.WithdrawRequest[](assetsLength);
+        withdrawAssets = new BoringOnChainQueue.WithdrawAsset[](assetsLength);
 
         for (uint256 i = 0; i < assetsLength; i++) {
-            (withdrawAssets[i], reqs[i]) = getWithdrawAssetAndWithdrawRequest(assets[i], accounts[i], delayedWithdraw);
+            withdrawAssets[i] = getWithdrawAsset(assets[i], queue);
         }
+    }
+
+    /**
+     * @notice Helper function to preview the assets out for a given asset and amount of shares.
+     * @param queue The BoringOnChainQueue contract.
+     * @param assetOut The asset to preview the assets out for.
+     * @param amountOfShares The amount of shares to preview the assets out for.
+     * @param discount The discount to apply to the assets out.
+     * @return amountOfAssets The amount of assets out.
+     */
+    function previewAssetsOut(BoringOnChainQueue queue, address assetOut, uint128 amountOfShares, uint16 discount)
+        external
+        view
+        returns (uint128 amountOfAssets)
+    {
+        amountOfAssets = queue.previewAssetsOut(assetOut, amountOfShares, discount);
     }
 
     struct PreviewWithdrawResult {
         uint256 assetsOut;
         bool withdrawsNotAllowed;
         bool withdrawNotMatured;
+        bool deadlinePassed;
         bool noShares;
-        bool maxLossExceeded;
         bool notEnoughAssetsForWithdraw;
     }
 
@@ -205,82 +226,112 @@ contract ArcticArchitectureLens {
      */
     function previewWithdraw(
         ERC20 asset,
-        address account,
+        BoringOnChainQueue.OnChainWithdraw memory req,
         BoringVault boringVault,
-        AccountantWithRateProviders accountant,
-        DelayedWithdraw delayedWithdraw
+        BoringOnChainQueue queue
     ) public view returns (PreviewWithdrawResult memory res) {
-        // Not all DelayedWithdraw contracts support pullFundsFromVault,
-        // so use staticcall to query it.
-        bool pullFundsFromVault = true;
-        {
-            (bool success, bytes memory result) =
-                address(delayedWithdraw).staticcall(abi.encodeWithSignature("pullFundsFromVault()"));
-            if (success && !abi.decode(result, (bool))) {
-                pullFundsFromVault = false;
-            }
-        }
-
-        (DelayedWithdraw.WithdrawAsset memory withdrawAsset, DelayedWithdraw.WithdrawRequest memory req) =
-            getWithdrawAssetAndWithdrawRequest(asset, account, delayedWithdraw);
+        BoringOnChainQueue.WithdrawAsset memory withdrawAsset = getWithdrawAsset(address(asset), queue);
 
         if (!withdrawAsset.allowWithdraws) res.withdrawsNotAllowed = true;
 
-        if (block.timestamp < req.maturity) res.withdrawNotMatured = true;
-        if (req.shares == 0) res.noShares = true;
+        uint256 maturity = uint256(req.creationTime) + uint256(req.secondsToMaturity);
+        if (block.timestamp < maturity) res.withdrawNotMatured = true;
 
-        uint256 currentExchangeRate = accountant.getRateInQuoteSafe(asset);
+        uint256 deadline = maturity + uint256(req.secondsToDeadline);
+        if (block.timestamp > deadline) res.deadlinePassed = true;
 
-        uint256 minRate = req.exchangeRateAtTimeOfRequest < currentExchangeRate
-            ? req.exchangeRateAtTimeOfRequest
-            : currentExchangeRate;
-        uint256 maxRate = req.exchangeRateAtTimeOfRequest < currentExchangeRate
-            ? currentExchangeRate
-            : req.exchangeRateAtTimeOfRequest;
+        if (req.amountOfShares == 0) res.noShares = true;
 
-        // If user has set a maxLoss use that, otherwise use the global maxLoss.
-        uint16 maxLoss = req.maxLoss > 0 ? req.maxLoss : withdrawAsset.maxLoss;
+        // In BoringOnChainQueue, amountOfAssets is pre-calculated at request time
+        res.assetsOut = req.amountOfAssets;
 
-        // Make sure minRate * maxLoss is greater than or equal to maxRate.
-        if (minRate.mulDivDown(1e4 + maxLoss, 1e4) < maxRate) res.maxLossExceeded = true;
-
-        uint256 shares = req.shares;
-
-        if (withdrawAsset.withdrawFee > 0) {
-            // Handle withdraw fee.
-            uint256 fee = uint256(shares).mulDivDown(withdrawAsset.withdrawFee, 1e4);
-            shares -= fee;
-        }
-
-        // Calculate assets out.
-        res.assetsOut = shares.mulDivDown(minRate, 10 ** boringVault.decimals());
-
-        if (pullFundsFromVault) {
-            if (asset.balanceOf(address(boringVault)) < res.assetsOut) {
-                res.notEnoughAssetsForWithdraw = true;
-            }
-        } else {
-            if (asset.balanceOf(address(this)) < res.assetsOut) {
-                res.notEnoughAssetsForWithdraw = true;
-            }
+        if (asset.balanceOf(address(boringVault)) < res.assetsOut) {
+            res.notEnoughAssetsForWithdraw = true;
         }
     }
 
     /**
-     * @notice Helper function to preview a multiple users withdraw for multiple assets.
+     * @notice Helper function to preview multiple users withdraw requests.
      */
     function previewWithdraws(
-        ERC20[] calldata assets,
-        address[] calldata accounts,
+        BoringOnChainQueue.OnChainWithdraw[] calldata requests,
+        BoringVault boringVault,
+        BoringOnChainQueue queue
+    ) external view returns (PreviewWithdrawResult[] memory res) {
+        uint256 requestsLength = requests.length;
+        res = new PreviewWithdrawResult[](requestsLength);
+
+        for (uint256 i = 0; i < requestsLength; i++) {
+            res[i] = previewWithdraw(ERC20(requests[i].assetOut), requests[i], boringVault, queue);
+        }
+    }
+
+    struct PreviewInstantWithdrawResult {
+        uint256 assetsOut;
+        bool tellerPaused;
+        bool withdrawsNotAllowed;
+        bool noShares;
+        bool sharesLocked;
+        bool notEnoughWithdrawableAssets;
+        bool minimumAssetsNotMet;
+    }
+
+    /**
+     * @notice Helper function to preview an instant withdraw through TellerWithYieldStreaming.
+     * @param account The address of the user withdrawing.
+     * @param withdrawAsset The asset to withdraw.
+     * @param shareAmount The amount of shares to withdraw.
+     * @param boringVault The BoringVault contract.
+     * @param accountant The AccountantWithRateProviders contract.
+     * @param teller The TellerWithYieldStreaming contract.
+     */
+    function previewInstantWithdraw(
+        address account,
+        ERC20 withdrawAsset,
+        uint256 shareAmount,
+        uint256 minimumAssets,
         BoringVault boringVault,
         AccountantWithRateProviders accountant,
-        DelayedWithdraw delayedWithdraw
-    ) external view returns (PreviewWithdrawResult[] memory res) {
-        uint256 assetsLength = assets.length;
-        res = new PreviewWithdrawResult[](assetsLength);
+        TellerWithYieldStreaming teller
+    ) external view returns (PreviewInstantWithdrawResult memory res) {
+        if (teller.isPaused()) res.tellerPaused = true;
 
-        for (uint256 i = 0; i < assetsLength; i++) {
-            res[i] = previewWithdraw(assets[i], accounts[i], boringVault, accountant, delayedWithdraw);
+        (,bool allowWithdraws,) = teller.assetData(withdrawAsset);
+        if (!allowWithdraws) res.withdrawsNotAllowed = true;
+
+        if (shareAmount == 0) res.noShares = true;
+
+        // Check if user's shares are locked
+        (,,,, uint256 shareUnlockTime) = teller.beforeTransferData(account);
+        if (shareUnlockTime > block.timestamp) res.sharesLocked = true;
+
+        // Calculate expected assets out
+        {
+            uint8 shareDecimals = boringVault.decimals();
+            res.assetsOut = shareAmount.mulDivDown(accountant.getRateInQuoteSafe(withdrawAsset), 10 ** shareDecimals);
+            if (res.assetsOut < minimumAssets) res.minimumAssetsNotMet = true;
+        }
+
+        // Withdrawable amount is at least the balance of the asset in the vault
+        uint256 withdrawable = withdrawAsset.balanceOf(address(boringVault));
+        // Check if there is a buffer helper for the asset
+        (, IBufferHelper withdrawBufferHelper) = teller.currentBufferHelpers(withdrawAsset);
+        if (address(withdrawBufferHelper) != address(0)) {
+            // We only support AaveV3 supply-only buffer helpers for now
+            try AaveV3BufferHelper(address(withdrawBufferHelper)).aaveV3Pool() returns (address aaveV3Pool) {
+                (uint256 totalCollateralBase,,,,,) = IPool(aaveV3Pool).getUserAccountData(address(boringVault));
+                if (totalCollateralBase > 0) {
+                    revert("Unsupported calculation: AaveV3 pool has borrowed assets");
+                }
+                ERC20 aToken = ERC20(IPoolExtended(aaveV3Pool).getReserveATokenAddress(address(withdrawAsset)));
+                withdrawable += aToken.balanceOf(address(boringVault));
+            } catch {
+                revert("Unsupported buffer type: AaveV3 pool not found");
+            }
+        }
+
+        if (withdrawable < res.assetsOut) {
+            res.notEnoughWithdrawableAssets = true;
         }
     }
 }

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -319,13 +319,17 @@ contract ArcticArchitectureLens {
         if (address(withdrawBufferHelper) != address(0)) {
             // We only support AaveV3 supply-only buffer helpers for now
             try AaveV3BufferHelper(address(withdrawBufferHelper)).aaveV3Pool() returns (address aaveV3Pool) {
-                (uint256 totalCollateralBase,,,,,) = IPool(aaveV3Pool).getUserAccountData(address(boringVault));
-                if (totalCollateralBase > 0) {
+                (, uint256 totalDebtBase,,,,) = IPool(aaveV3Pool).getUserAccountData(address(boringVault));
+                if (totalDebtBase > 0) {
                     revert("Unsupported calculation: AaveV3 pool has borrowed assets");
                 }
-                // Withdrawable amount is the balance of the aToken in the vault
+                // Get the balance of the aToken in the vault
                 ERC20 aToken = ERC20(IPoolExtended(aaveV3Pool).getReserveATokenAddress(address(withdrawAsset)));
-                withdrawable = aToken.balanceOf(address(boringVault));
+                withdrawable = aToken.balanceOf(address(boringVault)); // We will reuse withdrawable to avoid stack too deep
+
+                // Withdrawable amount is the balance of the asset in the aToken or the available liquidity, whichever is less
+                uint256 availableLiquidity = withdrawAsset.balanceOf(address(aToken));
+                withdrawable = withdrawable > availableLiquidity ? availableLiquidity : withdrawable;
             } catch {
                 revert("Unsupported buffer type: AaveV3 pool not found");
             }
@@ -334,6 +338,7 @@ contract ArcticArchitectureLens {
             withdrawable = withdrawAsset.balanceOf(address(boringVault));
         }
 
+        // Check if the withdrawable amount is less than the requested assets out
         if (withdrawable < res.assetsOut) {
             res.notEnoughWithdrawableAssets = true;
         }

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -174,10 +174,7 @@ contract ArcticArchitectureLens {
         ) = queue.withdrawAssets(asset);
     }
 
-    function getWithdrawAssets(
-        address[] calldata assets,
-        BoringOnChainQueue queue
-    )
+    function getWithdrawAssets(address[] calldata assets, BoringOnChainQueue queue)
         external
         view
         returns (BoringOnChainQueue.WithdrawAsset[] memory withdrawAssets)
@@ -286,7 +283,7 @@ contract ArcticArchitectureLens {
     ) external view returns (PreviewInstantWithdrawResult memory res) {
         if (teller.isPaused()) res.tellerPaused = true;
 
-        (,bool allowWithdraws,) = teller.assetData(withdrawAsset);
+        (, bool allowWithdraws,) = teller.assetData(withdrawAsset);
         if (!allowWithdraws) res.withdrawsNotAllowed = true;
 
         if (shareAmount == 0) res.noShares = true;

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -9,7 +9,7 @@ import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSu
 import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
 import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
 import {BoringOnChainQueue} from "src/base/Roles/BoringQueue/BoringOnChainQueue.sol";
-import {AaveV3BufferLens} from "src/helper/AaveV3BufferLens.sol";
+import {IBufferLens} from "src/interfaces/IBufferLens.sol";
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
@@ -218,7 +218,7 @@ contract ArcticArchitectureLens {
         BoringOnChainQueue.OnChainWithdraw memory req,
         BoringVault boringVault,
         BoringOnChainQueue queue,
-        AaveV3BufferLens aaveV3BufferLens
+        IBufferLens bufferLens
     ) public view returns (PreviewWithdrawResult memory res) {
         BoringOnChainQueue.WithdrawAsset memory withdrawAsset = getWithdrawAsset(req.assetOut, queue);
 
@@ -233,9 +233,10 @@ contract ArcticArchitectureLens {
         if (req.amountOfShares == 0) res.noShares = true;
 
         uint256 withdrawable;
-        if (address(aaveV3BufferLens) != address(0)) {
+        if (address(bufferLens) != address(0)) {
             address teller = address(boringVault.hook());
-            withdrawable = aaveV3BufferLens.getInstantlyWithdrawableAmount(TellerWithYieldStreaming(teller), ERC20(req.assetOut));
+            withdrawable =
+                bufferLens.getInstantlyWithdrawableAmount(TellerWithYieldStreaming(teller), ERC20(req.assetOut));
         } else {
             withdrawable = ERC20(req.assetOut).balanceOf(address(boringVault));
         }
@@ -251,13 +252,13 @@ contract ArcticArchitectureLens {
         BoringOnChainQueue.OnChainWithdraw[] calldata requests,
         BoringVault boringVault,
         BoringOnChainQueue queue,
-        AaveV3BufferLens aaveV3BufferLens
+        IBufferLens bufferLens
     ) external view returns (PreviewWithdrawResult[] memory res) {
         uint256 requestsLength = requests.length;
         res = new PreviewWithdrawResult[](requestsLength);
 
         for (uint256 i = 0; i < requestsLength; i++) {
-            res[i] = previewWithdraw(requests[i], boringVault, queue, aaveV3BufferLens);
+            res[i] = previewWithdraw(requests[i], boringVault, queue, bufferLens);
         }
     }
 
@@ -288,7 +289,7 @@ contract ArcticArchitectureLens {
         BoringVault boringVault,
         AccountantWithRateProviders accountant,
         TellerWithYieldStreaming teller,
-        AaveV3BufferLens aaveV3BufferLens
+        IBufferLens bufferLens
     ) external view returns (PreviewInstantWithdrawResult memory res) {
         if (teller.isPaused()) res.tellerPaused = true;
 
@@ -309,7 +310,7 @@ contract ArcticArchitectureLens {
         }
 
         // Calculate the withdrawable amount
-        uint256 withdrawable = aaveV3BufferLens.getInstantlyWithdrawableAmount(teller, withdrawAsset);
+        uint256 withdrawable = bufferLens.getInstantlyWithdrawableAmount(teller, withdrawAsset);
 
         // Check if the withdrawable amount is less than the requested assets out
         if (withdrawable < res.assetsOut) {

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -7,17 +7,11 @@ pragma solidity 0.8.21;
 import {BoringVault, ERC20} from "src/base/BoringVault.sol";
 import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
 import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
-import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
 import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
 import {BoringOnChainQueue} from "src/base/Roles/BoringQueue/BoringOnChainQueue.sol";
-import {AaveV3BufferHelper} from "src/base/Roles/AaveV3BufferHelper.sol";
-import {IPool} from "src/interfaces/IPool.sol";
+import {AaveV3BufferLens} from "src/helper/AaveV3BufferLens.sol";
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-
-interface IPoolExtended is IPool {
-    function getReserveAToken(address asset) external view returns (ERC20);
-}
 
 contract ArcticArchitectureLens {
     using FixedPointMathLib for uint256;
@@ -287,7 +281,8 @@ contract ArcticArchitectureLens {
         uint256 minimumAssets,
         BoringVault boringVault,
         AccountantWithRateProviders accountant,
-        TellerWithYieldStreaming teller
+        TellerWithYieldStreaming teller,
+        AaveV3BufferLens aaveV3BufferLens
     ) external view returns (PreviewInstantWithdrawResult memory res) {
         if (teller.isPaused()) res.tellerPaused = true;
 
@@ -308,30 +303,7 @@ contract ArcticArchitectureLens {
         }
 
         // Calculate the withdrawable amount
-        uint256 withdrawable;
-        // Check if there is a buffer helper for the asset
-        (, IBufferHelper withdrawBufferHelper) = teller.currentBufferHelpers(withdrawAsset);
-        if (address(withdrawBufferHelper) != address(0)) {
-            // We only support AaveV3 supply-only buffer helpers for now
-            try AaveV3BufferHelper(address(withdrawBufferHelper)).aaveV3Pool() returns (address aaveV3Pool) {
-                (, uint256 totalDebtBase,,,,) = IPool(aaveV3Pool).getUserAccountData(address(boringVault));
-                if (totalDebtBase > 0) {
-                    revert("Unsupported calculation: AaveV3 pool has borrowed assets");
-                }
-                // Get the balance of the aToken in the vault
-                ERC20 aToken = IPoolExtended(aaveV3Pool).getReserveAToken(address(withdrawAsset));
-                withdrawable = aToken.balanceOf(address(boringVault)); // We will reuse withdrawable to avoid stack too deep
-
-                // Withdrawable amount is the balance of the asset in the aToken or the available liquidity, whichever is less
-                uint256 availableLiquidity = withdrawAsset.balanceOf(address(aToken));
-                withdrawable = withdrawable > availableLiquidity ? availableLiquidity : withdrawable;
-            } catch {
-                revert("Unsupported buffer type: AaveV3 pool not found");
-            }
-        } else {
-            // Withdrawable amount is the balance of the asset in the vault
-            withdrawable = withdrawAsset.balanceOf(address(boringVault));
-        }
+        uint256 withdrawable = aaveV3BufferLens.getInstantlyWithdrawableAmount(teller, withdrawAsset);
 
         // Check if the withdrawable amount is less than the requested assets out
         if (withdrawable < res.assetsOut) {

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -312,8 +312,8 @@ contract ArcticArchitectureLens {
             if (res.assetsOut < minimumAssets) res.minimumAssetsNotMet = true;
         }
 
-        // Withdrawable amount is at least the balance of the asset in the vault
-        uint256 withdrawable = withdrawAsset.balanceOf(address(boringVault));
+        // Calculate the withdrawable amount
+        uint256 withdrawable;
         // Check if there is a buffer helper for the asset
         (, IBufferHelper withdrawBufferHelper) = teller.currentBufferHelpers(withdrawAsset);
         if (address(withdrawBufferHelper) != address(0)) {
@@ -323,11 +323,15 @@ contract ArcticArchitectureLens {
                 if (totalCollateralBase > 0) {
                     revert("Unsupported calculation: AaveV3 pool has borrowed assets");
                 }
+                // Withdrawable amount is the balance of the aToken in the vault
                 ERC20 aToken = ERC20(IPoolExtended(aaveV3Pool).getReserveATokenAddress(address(withdrawAsset)));
-                withdrawable += aToken.balanceOf(address(boringVault));
+                withdrawable = aToken.balanceOf(address(boringVault));
             } catch {
                 revert("Unsupported buffer type: AaveV3 pool not found");
             }
+        } else {
+            // Withdrawable amount is the balance of the asset in the vault
+            withdrawable = withdrawAsset.balanceOf(address(boringVault));
         }
 
         if (withdrawable < res.assetsOut) {

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -213,7 +213,6 @@ contract ArcticArchitectureLens {
     }
 
     struct PreviewWithdrawResult {
-        uint256 assetsOut;
         bool withdrawsNotAllowed;
         bool withdrawNotMatured;
         bool deadlinePassed;
@@ -225,12 +224,11 @@ contract ArcticArchitectureLens {
      * @notice Helper function to preview a users withdraw for a specific asset.
      */
     function previewWithdraw(
-        ERC20 asset,
         BoringOnChainQueue.OnChainWithdraw memory req,
         BoringVault boringVault,
         BoringOnChainQueue queue
     ) public view returns (PreviewWithdrawResult memory res) {
-        BoringOnChainQueue.WithdrawAsset memory withdrawAsset = getWithdrawAsset(address(asset), queue);
+        BoringOnChainQueue.WithdrawAsset memory withdrawAsset = getWithdrawAsset(req.assetOut, queue);
 
         if (!withdrawAsset.allowWithdraws) res.withdrawsNotAllowed = true;
 
@@ -242,10 +240,7 @@ contract ArcticArchitectureLens {
 
         if (req.amountOfShares == 0) res.noShares = true;
 
-        // In BoringOnChainQueue, amountOfAssets is pre-calculated at request time
-        res.assetsOut = req.amountOfAssets;
-
-        if (asset.balanceOf(address(boringVault)) < res.assetsOut) {
+        if (ERC20(req.assetOut).balanceOf(address(boringVault)) < req.amountOfAssets) {
             res.notEnoughAssetsForWithdraw = true;
         }
     }
@@ -262,7 +257,7 @@ contract ArcticArchitectureLens {
         res = new PreviewWithdrawResult[](requestsLength);
 
         for (uint256 i = 0; i < requestsLength; i++) {
-            res[i] = previewWithdraw(ERC20(requests[i].assetOut), requests[i], boringVault, queue);
+            res[i] = previewWithdraw(requests[i], boringVault, queue);
         }
     }
 

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -218,6 +218,7 @@ contract ArcticArchitectureLens {
         BoringOnChainQueue.OnChainWithdraw memory req,
         BoringVault boringVault,
         BoringOnChainQueue queue,
+        TellerWithYieldStreaming teller,
         IBufferLens bufferLens
     ) public view returns (PreviewWithdrawResult memory res) {
         BoringOnChainQueue.WithdrawAsset memory withdrawAsset = getWithdrawAsset(req.assetOut, queue);
@@ -234,9 +235,7 @@ contract ArcticArchitectureLens {
 
         uint256 withdrawable;
         if (address(bufferLens) != address(0)) {
-            address teller = address(boringVault.hook());
-            withdrawable =
-                bufferLens.getInstantlyWithdrawableAmount(TellerWithYieldStreaming(teller), ERC20(req.assetOut));
+            withdrawable = bufferLens.getInstantlyWithdrawableAmount(teller, ERC20(req.assetOut));
         } else {
             withdrawable = ERC20(req.assetOut).balanceOf(address(boringVault));
         }
@@ -252,13 +251,14 @@ contract ArcticArchitectureLens {
         BoringOnChainQueue.OnChainWithdraw[] calldata requests,
         BoringVault boringVault,
         BoringOnChainQueue queue,
+        TellerWithYieldStreaming teller,
         IBufferLens bufferLens
     ) external view returns (PreviewWithdrawResult[] memory res) {
         uint256 requestsLength = requests.length;
         res = new PreviewWithdrawResult[](requestsLength);
 
         for (uint256 i = 0; i < requestsLength; i++) {
-            res[i] = previewWithdraw(requests[i], boringVault, queue, bufferLens);
+            res[i] = previewWithdraw(requests[i], boringVault, queue, teller, bufferLens);
         }
     }
 

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -217,7 +217,8 @@ contract ArcticArchitectureLens {
     function previewWithdraw(
         BoringOnChainQueue.OnChainWithdraw memory req,
         BoringVault boringVault,
-        BoringOnChainQueue queue
+        BoringOnChainQueue queue,
+        AaveV3BufferLens aaveV3BufferLens
     ) public view returns (PreviewWithdrawResult memory res) {
         BoringOnChainQueue.WithdrawAsset memory withdrawAsset = getWithdrawAsset(req.assetOut, queue);
 
@@ -231,7 +232,14 @@ contract ArcticArchitectureLens {
 
         if (req.amountOfShares == 0) res.noShares = true;
 
-        if (ERC20(req.assetOut).balanceOf(address(boringVault)) < req.amountOfAssets) {
+        uint256 withdrawable;
+        if (address(aaveV3BufferLens) != address(0)) {
+            address teller = address(boringVault.hook());
+            withdrawable = aaveV3BufferLens.getInstantlyWithdrawableAmount(TellerWithYieldStreaming(teller), ERC20(req.assetOut));
+        } else {
+            withdrawable = ERC20(req.assetOut).balanceOf(address(boringVault));
+        }
+        if (withdrawable < req.amountOfAssets) {
             res.notEnoughAssetsForWithdraw = true;
         }
     }
@@ -242,13 +250,14 @@ contract ArcticArchitectureLens {
     function previewWithdraws(
         BoringOnChainQueue.OnChainWithdraw[] calldata requests,
         BoringVault boringVault,
-        BoringOnChainQueue queue
+        BoringOnChainQueue queue,
+        AaveV3BufferLens aaveV3BufferLens
     ) external view returns (PreviewWithdrawResult[] memory res) {
         uint256 requestsLength = requests.length;
         res = new PreviewWithdrawResult[](requestsLength);
 
         for (uint256 i = 0; i < requestsLength; i++) {
-            res[i] = previewWithdraw(requests[i], boringVault, queue);
+            res[i] = previewWithdraw(requests[i], boringVault, queue, aaveV3BufferLens);
         }
     }
 

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -291,6 +291,8 @@ contract ArcticArchitectureLens {
         TellerWithYieldStreaming teller,
         IBufferLens bufferLens
     ) external view returns (PreviewInstantWithdrawResult memory res) {
+        require(address(bufferLens) != address(0), "Buffer lens required for instant withdraw");
+
         if (teller.isPaused()) res.tellerPaused = true;
 
         (, bool allowWithdraws,) = teller.assetData(withdrawAsset);

--- a/src/interfaces/IBufferLens.sol
+++ b/src/interfaces/IBufferLens.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {TellerWithBuffer} from "src/base/Roles/TellerWithBuffer.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+interface IBufferLens {
+    /**
+     * @notice Gets the instantly withdrawable amount for a given asset.
+     * @param teller The teller contract.
+     * @param asset The asset to get the instantly withdrawable amount for.
+     * @return withdrawableAmount The instantly withdrawable amount.
+     */
+    function getInstantlyWithdrawableAmount(TellerWithBuffer teller, ERC20 asset)
+        external
+        view
+        returns (uint256 withdrawableAmount);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates withdrawal-preview helpers to target `BoringOnChainQueue` and adds instant-withdraw preview logic for `TellerWithYieldStreaming`, which could affect downstream UIs/ops tooling that rely on these view helpers. Core protocol contracts aren’t modified, but the new maturity/deadline/withdrawable-asset checks change expected outputs.
> 
> **Overview**
> Updates `ArcticArchitectureLens` to replace legacy `DelayedWithdraw`-based helpers with `BoringOnChainQueue` equivalents, including new helpers to fetch queue withdraw-asset config and to `previewAssetsOut`/`previewWithdraw(s)` using queue request semantics (maturity + deadline).
> 
> Adds instant-withdraw preview support for `TellerWithYieldStreaming` via a new `IBufferLens` interface, exposing checks for teller pause state, per-asset withdraw enablement, share lock, minimum-assets constraints, and buffer-limited withdrawable liquidity.
> 
> Cleans up deployment scripts by removing `DelayedWithdraw` imports/state, aligning the deployment surface with the queue-based withdrawal flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f05bdea530101fcb904b83ddd2f8cef1dc843a0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->