### PR TITLE
sLBTC root update: add LBTC > PYUSD supervised loan position manager

### DIFF
--- a/leafs/Mainnet/SentoraStrategistLeafs.json
+++ b/leafs/Mainnet/SentoraStrategistLeafs.json
@@ -10,8 +10,8 @@
       "Bytes4(TARGET_FUNCTION_SELECTOR)",
       "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
     ],
-    "LeafCount": 22,
-    "ManageRoot": "0x14ec0c3ae58a23ab7eac868c75e1b60747f59086fcc7d450a26b9317fb239e3e",
+    "LeafCount": 34,
+    "ManageRoot": "0x3807b04242740a24774cbf5bac137c8816770b329fad17fa94f6cc7b989dd00d",
     "ManagerAddress": "0xdd5C7C5206558e4eA66a58592fEaE13424ED6F07",
     "TreeCapacity": 128
   },
@@ -88,6 +88,36 @@
       "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
     },
     {
+      "AddressArguments": [
+        "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap PYUSD for LBTC",
+      "FunctionSelector": "0x3b635ce4",
+      "FunctionSignature": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
+      "LeafDigest": "0x4e0dacf1dfeddbf75463ffb6f66cd5d26da0408c755782837fd339b6de892a72",
+      "PackedArgumentAddresses": "0x6c3ea9036406852006290770bedfcaba0e23a0e88236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap Compact PYUSD for LBTC",
+      "FunctionSelector": "0x83bd37f9",
+      "FunctionSignature": "swapCompact()",
+      "LeafDigest": "0x41a348fd9d70a1b1109e84a9fb4a42d1abfb1c3ac6321eb528341aa7f280ef7f",
+      "PackedArgumentAddresses": "0x6c3ea9036406852006290770bedfcaba0e23a0e88236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
       "AddressArguments": ["0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
@@ -97,6 +127,47 @@
       "LeafDigest": "0xd3cac52bd91b0a78c48dd93a53b892fa1f4235118a2797e99f105a654ce60a62",
       "PackedArgumentAddresses": "0xcf5540fffcdc3d510b18bfca6d2b9987b0772559",
       "TargetAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+    },
+    {
+      "AddressArguments": [
+        "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap PYUSD for WBTC",
+      "FunctionSelector": "0x3b635ce4",
+      "FunctionSignature": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
+      "LeafDigest": "0x4d3d1fcd6b6f8a259ffdc5f9ecae29a92f1f2c8fbcf2d381e079ad9ad2bb85a5",
+      "PackedArgumentAddresses": "0x6c3ea9036406852006290770bedfcaba0e23a0e82260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap Compact PYUSD for WBTC",
+      "FunctionSelector": "0x83bd37f9",
+      "FunctionSignature": "swapCompact()",
+      "LeafDigest": "0x7e536cb4b0db880d2a0418a2c147f76f3306c9ae920cb997c6dfd6956cd418c0",
+      "PackedArgumentAddresses": "0x6c3ea9036406852006290770bedfcaba0e23a0e82260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": ["0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Approve Odos Router V2 to spend PYUSD",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0x05a149c7c82498728c25cb346a77528e308e14ed1deef657de2023657329fa17",
+      "PackedArgumentAddresses": "0xcf5540fffcdc3d510b18bfca6d2b9987b0772559",
+      "TargetAddress": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
     },
     {
       "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
@@ -140,6 +211,21 @@
       "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
     },
     {
+      "AddressArguments": [
+        "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Swap PYUSD for LBTC using 1inch router",
+      "FunctionSelector": "0x12aa3caf",
+      "FunctionSignature": "swap(address,(address,address,address,address,uint256,uint256,uint256),bytes,bytes)",
+      "LeafDigest": "0xc7da98e67754352cd995df4cb545832aca6bb42c91f8fd40545f52fba27d35dd",
+      "PackedArgumentAddresses": "0x6c3ea9036406852006290770bedfcaba0e23a0e88236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
+    },
+    {
       "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
@@ -149,6 +235,32 @@
       "LeafDigest": "0xe6977e1a74c5c253d9c3e5a98fa0276769c13d2e7a9c42019895b1fe7ff2f14f",
       "PackedArgumentAddresses": "0x1111111254eeb25477b68fb85ed929f73a960582",
       "TargetAddress": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+    },
+    {
+      "AddressArguments": [
+        "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Swap PYUSD for WBTC using 1inch router",
+      "FunctionSelector": "0x12aa3caf",
+      "FunctionSignature": "swap(address,(address,address,address,address,uint256,uint256,uint256),bytes,bytes)",
+      "LeafDigest": "0x444c93cc817c6044cad636b83806b9c35958399911cf676208c2adbe7df8a643",
+      "PackedArgumentAddresses": "0x6c3ea9036406852006290770bedfcaba0e23a0e82260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
+    },
+    {
+      "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Approve 1Inch router to spend PYUSD",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0x7c0aea73befb71ee0dbc74b3c3bea5445d92b8a630aaad8fa0747bc94d688eae",
+      "PackedArgumentAddresses": "0x1111111254eeb25477b68fb85ed929f73a960582",
+      "TargetAddress": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
     },
     {
       "AddressArguments": [],
@@ -285,134 +397,46 @@
     {
       "AddressArguments": [],
       "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+      "DecoderAndSanitizerAddress": "0xBf6199F596D7296875Faa175Ed02Dc3940C1682E",
+      "Description": "Accept ownership of the LBTC > PYUSD Supervised Loan contract",
+      "FunctionSelector": "0x79ba5097",
+      "FunctionSignature": "acceptOwnership()",
+      "LeafDigest": "0x2f6c5f1a4a1ae3b5427db8733da215bd7fc73b2c41492086cf989786aae7eebe",
       "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
+      "TargetAddress": "0xB4201A579A2cf1d321f04d98bdba2a25bEFD6b0A"
     },
     {
       "AddressArguments": [],
       "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+      "DecoderAndSanitizerAddress": "0xBf6199F596D7296875Faa175Ed02Dc3940C1682E",
+      "Description": "Withdraw from the LBTC > PYUSD Supervised Loan contract",
+      "FunctionSelector": "0xf3fef3a3",
+      "FunctionSignature": "withdraw(address,uint256)",
+      "LeafDigest": "0x0dd990d88c89013c828ff2c281ddf12436483bd54b293351d61dd7264c7e2407",
       "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
+      "TargetAddress": "0xB4201A579A2cf1d321f04d98bdba2a25bEFD6b0A"
     },
     {
       "AddressArguments": [],
       "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+      "DecoderAndSanitizerAddress": "0xBf6199F596D7296875Faa175Ed02Dc3940C1682E",
+      "Description": "Withdraw all from the LBTC > PYUSD Supervised Loan contract",
+      "FunctionSelector": "0xfa09e630",
+      "FunctionSignature": "withdrawAll(address)",
+      "LeafDigest": "0x1561960d02e9123cb740d2d61ffc00e72f27a9ae6b64e7f90b71da549ab85217",
       "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
+      "TargetAddress": "0xB4201A579A2cf1d321f04d98bdba2a25bEFD6b0A"
     },
     {
-      "AddressArguments": [],
+      "AddressArguments": ["0xB4201A579A2cf1d321f04d98bdba2a25bEFD6b0A"],
       "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
+      "DecoderAndSanitizerAddress": "0xBf6199F596D7296875Faa175Ed02Dc3940C1682E",
+      "Description": "Transfer LBTC to the LBTC > PYUSD Supervised Loan contract",
+      "FunctionSelector": "0xa9059cbb",
+      "FunctionSignature": "transfer(address,uint256)",
+      "LeafDigest": "0x065d73b9c51c9ed40c142f531fa6d8b875196f355aa40b45cad1ee8a19efbb04",
+      "PackedArgumentAddresses": "0xb4201a579a2cf1d321f04d98bdba2a25befd6b0a",
+      "TargetAddress": "0x8236a87084f8B84306f72007F36F2618A5634494"
     },
     {
       "AddressArguments": [],
@@ -1450,21 +1474,21 @@
     }
   ],
   "MerkleTree": {
-    "0": ["0x14ec0c3ae58a23ab7eac868c75e1b60747f59086fcc7d450a26b9317fb239e3e"],
+    "0": ["0x3807b04242740a24774cbf5bac137c8816770b329fad17fa94f6cc7b989dd00d"],
     "1": [
-      "0x718f836c71122551e2461af7852d81bab636780c7f9a7c4764db9d31a4c4d139",
+      "0x5a5eb545bcd2330a70ed3854d216da91a33010c9609a16b98f41ce71d5062448",
       "0xf70e6eeacf0ca2800bee387294f368bb304fe5f55d96f86ff896d1bcbe16ba34"
     ],
     "2": [
-      "0xa8b2a0c910122ac8181218102a083dcc11ed78c038fc5d18df0a26a0ac320705",
-      "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
+      "0xa7a589cf6720172c5219eb75d76fb2c75ddbb9075803d772e6c25dcccc5a5ea6",
+      "0xeffdf45bff41322861c5ea792ed52ddc5cbe3905d7ca832d60f099020a08cf1d",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a"
     ],
     "3": [
-      "0x8216aef0e6dab23f8f90735cb0bedfa2d665a3a2b53888609891c086034eea7e",
-      "0x849be0d09b42b88a7feef4ac0e470e8927d87c5d7a7504f4a01bf1ba761e1442",
-      "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
+      "0xe9fc9a77172d0f854ca8ab383ca8c245679963134d78286b2e4b0ae1e9e2fae2",
+      "0x9152c4ddc09c0570c642126489920e9ade86bcf43584ec3de211e4bc7c22c1d5",
+      "0x006cfb3d4ebc0799028cac46e36acc71f5f65c15905e248ddcd1233cd6881a1f",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
@@ -1472,11 +1496,11 @@
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
     ],
     "4": [
-      "0xdbe6f8b9f7cb3cbc2c8b976a36fb39d1bd8827b1a1756fa4f046dc78478a0288",
-      "0x0f4da48cd233f740ff826e80a96f399222988d9ac42fad238d94bc00d1c0e926",
-      "0x172c48244cfa36002c9368081f3b3c58b07260ed87fd77ae5c8f22fcc0443cfb",
-      "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
-      "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
+      "0xb17f633d9c88d0362cba06d8856adc09d837bf4180ab31b8aec076336800993d",
+      "0xc039373764b7fe28b269e3ef244bed1ce295d5dd1737eb32873ccbd41bf73900",
+      "0xeae1c96c99d4b4d2198e74dc2123a9de3032b9bb982d5c64e7301faf8e036e34",
+      "0x4b02436ffbf180acaa9c24435383bd51802d80fde2a70f0ea5d8a17a848439c8",
+      "0xa578255e1fa8e917f48c12e157a18131cd1dfc0726f7d34cd04a04342a02c686",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
@@ -1491,14 +1515,14 @@
     ],
     "5": [
       "0x1f98f067a9b0ab58af72fc1304b0b610f6ce85a3a40dc798e0fa978ca8f18353",
-      "0x0f1348ee4c54ad2837d3fbcc6d9c136c262f486ae1ed88f71dd158c8a05aa34c",
-      "0xc6cf2a5f1a0814ea0188e755df1a1fcef9bd467a482a5bca67d92bd4a5b1fddf",
+      "0xc001044a9a9166b9246e9829c8ca5548608a1eac13814acf8fffc41c6a38a14f",
+      "0x37c0484117198bbac0ecff57945c4bc0205f4cba3e92c37455aa87006d6b58c7",
+      "0x6f2d2138a698d7b71b96da207f6710b7fbf8e5870924c9b95ba7e07aba8a0031",
+      "0x118fb1408018dc403275c31938fca33ce19241157541d560aa747773eef4c1c5",
       "0xa15dfe14d521d3d42b836d5e094e309b09391668acf3a76b0f3edd6ed8acebe8",
       "0x7a72a22f97ca8df0529fbd7124603fd0717d1a3c1c974902d798ede34d5accf9",
-      "0xc95a7d8a3d4d8177fb4ce5b32b33b586e22e4eb757abfd3ef6d66e74fd3ee7db",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+      "0x30121ee17b77a216e574dff9921bc6e0c7bd50bb7da29c46f115ce6d57273de0",
+      "0x665a327f9e9ed5bb79641b3067900a93001810a4cc9c950901e229a32a0594e5",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -1526,21 +1550,21 @@
     "6": [
       "0x6e9ccf97fcf3442dbfc0461333c5913584d0401dfba00650f23eed06243a2206",
       "0xc5fe156adc2edb76a89e6b4c4f9cb17c2895397ac5f4758077088d1fe70c731d",
-      "0x028835d4976607b5c8310024316823c8365f26500a5e719f35d71c57d5be5367",
-      "0x531f995e81a639d69b43813b0b708ea3f13cb7bb8b54b179f2afa0af4f2dc7c8",
-      "0x4b59ba8a2a175f595332c496c44a7faec2395c202a98d493ef4b6fceddda07c5",
+      "0x332411b8566e79f001ac681684586e2d7896534c85fd24fe5df77c48826e6deb",
+      "0xa08c39b3dc31376d584b7c307d908a6b9c21f35c0b8a8699d8ffe950cc047a4a",
+      "0xe606a6ba7fe062dd57a74e9d479dedd788a0c556b0d4c5a35ae757b26c2cc429",
+      "0x7b4dc5102fe2e7c8a55396a6d26799032072134298e1f17b5ab868fa9dade355",
+      "0xf2b23d854335267f510fb52433ca8d05fd6edd4283e78e9e3c65e0b91358d170",
+      "0xdad39f386b2f7edf3e11ca9c6a960c3db22a96eb2aa9baffc7748237027250e9",
+      "0x381b042f411a569aef2efe3ed2a853ea8709f389a47e4fa4e9f9390187f76458",
       "0xa7d359786df8e5f47c1b0314fd3244bcce5a242e49d461ba6c3778b0a986c31c",
       "0xfaf1f673f67847aa4d5c966b166678d2ea2fcc5e42fb13f64d04a1a50214d578",
       "0xc38d3883f898cd041d565572a721e8c795205fd498a4fce6dcb7b5a45b6841b5",
       "0x57ed666a732337ab29d40926df5c3bba5199259e0c44ef9d35303a6735d86ac5",
       "0x8d20cdb4d0801644af48ac6a2201dcf4044253366703d551d3e9596c9ec24a52",
       "0x34384f1f6f0b6dd9c9a4d5920af7e87c720b9fab92647331f322acc6b9b76679",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+      "0xa711c25cc97722e177120fefc495273b29871de8b0deb8b19ec0bd1b633ee304",
+      "0x13de0c6a522e399977b81cea950362359b46a2cc9db14a36e15e90421e9bacfa",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -1595,11 +1619,19 @@
       "0xf29c9533955e821812d9bb15eb2dc5395e346bc4e8e775fbe49f53b42317a2da",
       "0x333c9a178496df00ec4c3949311352a8d1661e6bcbc950a9ed9256f58a187d30",
       "0x885283e3174aa3dd11893db9d24ddd803c8f53452c72d4c07dd37d2108ff4497",
+      "0x4e0dacf1dfeddbf75463ffb6f66cd5d26da0408c755782837fd339b6de892a72",
+      "0x41a348fd9d70a1b1109e84a9fb4a42d1abfb1c3ac6321eb528341aa7f280ef7f",
       "0xd3cac52bd91b0a78c48dd93a53b892fa1f4235118a2797e99f105a654ce60a62",
+      "0x4d3d1fcd6b6f8a259ffdc5f9ecae29a92f1f2c8fbcf2d381e079ad9ad2bb85a5",
+      "0x7e536cb4b0db880d2a0418a2c147f76f3306c9ae920cb997c6dfd6956cd418c0",
+      "0x05a149c7c82498728c25cb346a77528e308e14ed1deef657de2023657329fa17",
       "0x2ea62230d9eba8ddf71acbabf025eaa1bf25f1750a185821eeb897897cfd6fca",
       "0xf2517b40128880acda543e6b78735530abbcad569fecb2aa0e7d603e5db01151",
       "0xdb54f5303f82e56990069bb581d55390902d7e2d589f8e5a822d22dbbae756da",
+      "0xc7da98e67754352cd995df4cb545832aca6bb42c91f8fd40545f52fba27d35dd",
       "0xe6977e1a74c5c253d9c3e5a98fa0276769c13d2e7a9c42019895b1fe7ff2f14f",
+      "0x444c93cc817c6044cad636b83806b9c35958399911cf676208c2adbe7df8a643",
+      "0x7c0aea73befb71ee0dbc74b3c3bea5445d92b8a630aaad8fa0747bc94d688eae",
       "0x6e4ada845ed8d018899ee186b34755b0335a36523d97937532864d704111f7df",
       "0x1bbf2b2fa391eb0d935775bc94a8257086f37ac519e598bed48deb1021e3f4f9",
       "0xf0df85ca55d1beb5c9bf9e66ee38e40929367711be2955a4dbd261c92b88025b",
@@ -1612,18 +1644,10 @@
       "0x372a2f7068d4f013d384fc560057fb61e4342ca8b91a6b92e76b843caa583aed",
       "0x287f528da47e09216520d5f89c4e100f16c910b3c55460e81a6ebdb8271455d9",
       "0xd21cf522dc11df93db385a5907f19b6232feb10267e598ed018a5b633cbc303c",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+      "0x2f6c5f1a4a1ae3b5427db8733da215bd7fc73b2c41492086cf989786aae7eebe",
+      "0x0dd990d88c89013c828ff2c281ddf12436483bd54b293351d61dd7264c7e2407",
+      "0x1561960d02e9123cb740d2d61ffc00e72f27a9ae6b64e7f90b71da549ab85217",
+      "0x065d73b9c51c9ed40c142f531fa6d8b875196f355aa40b45cad1ee8a19efbb04",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/script/MerkleRootCreation/Mainnet/CreateSentoraMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Mainnet/CreateSentoraMerkleRoot.s.sol
@@ -44,19 +44,21 @@ contract CreateSentoraMerkleRootScript is Script, MerkleTreeHelper {
         ManageLeaf[] memory leafs = new ManageLeaf[](128);
 
         // ========================== Odos/1inch ==========================
-        address[] memory assets = new address[](2);
+        address[] memory assets = new address[](3);
         assets[0] = getAddress(sourceChain, "LBTC");
         assets[1] = getAddress(sourceChain, "WBTC");
-        SwapKind[] memory kind = new SwapKind[](2);
+        assets[2] = getAddress(sourceChain, "PYUSD");
+        SwapKind[] memory kind = new SwapKind[](3);
         kind[0] = SwapKind.BuyAndSell;
         kind[1] = SwapKind.BuyAndSell;
+        kind[2] = SwapKind.Sell;
         setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", odosOwnedDecoderAndSanitizer);
         _addOdosOwnedSwapLeafs(leafs, assets, kind);
         setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", oneInchOwnedDecoderAndSanitizer);
         _addLeafsFor1InchOwnedGeneralSwapping(leafs, assets, kind);
         setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
 
-        // ========================== ITB Position Manager ==========================
+        // ========================== ITB Position Managers ==========================
         ERC20[] memory itbTokensUsed = new ERC20[](1);
         itbTokensUsed[0] = getERC20(sourceChain, "LBTC");
         address itbPositionManager = 0x701D7Fc25577602dc77280108a8cef0B72b8F8A7;
@@ -65,6 +67,8 @@ contract CreateSentoraMerkleRootScript is Script, MerkleTreeHelper {
         _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > RLUSD > RLUSD Supervised Loan");
         itbPositionManager = 0x284D3b0eF51F0A6432948A9cCbCb5cAF30d6EE96;
         _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > PYUSD > RLUSD Supervised Loan");
+        itbPositionManager = 0xB4201A579A2cf1d321f04d98bdba2a25bEFD6b0A;
+        _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > PYUSD Supervised Loan");
 
         // ========================== Verify ==========================
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes update an on-chain allowlist/merkle root to permit additional swap routes and interactions with a new position manager contract; incorrect addresses/selectors could expand authority or break management actions.
> 
> **Overview**
> Updates the mainnet Sentora strategist permissions merkle root to include **PYUSD support** for Odos and 1inch swaps (new approve + swap leafs), expanding the swap asset set from 2 to 3 tokens.
> 
> Adds a new ITB position manager (`0xB420…6b0A`) for the **`LBTC > PYUSD` Supervised Loan**, including leafs to `acceptOwnership`, `withdraw`, `withdrawAll`, and transfer `LBTC` to that contract; the generated `SentoraStrategistLeafs.json` is regenerated accordingly (leaf count `22 -> 34` and new `ManageRoot`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92fa0ba1d360d986b489a858e901e7225fddba08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->