### PR TITLE
Add yuzu decoder

### DIFF
--- a/leafs/Plasma/LiquidUSDMerkleRoot.json
+++ b/leafs/Plasma/LiquidUSDMerkleRoot.json
@@ -10,8 +10,8 @@
             "Bytes4(TARGET_FUNCTION_SELECTOR)",
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
-        "LeafCount": 30,
-        "ManageRoot": "0x43377eedcb912e5216fb97e6cc8fa52f8351916a2ae7c315e32d2ba49022efae",
+        "LeafCount": 36,
+        "ManageRoot": "0xaa2f95b61bff7e91019eb66c31cfa5118b568e5aaf7d489d6259f713156230b2",
         "ManagerAddress": "0x7b57Ad1A0AA89583130aCfAD024241170D24C13C",
         "TreeCapacity": 64
     },
@@ -424,70 +424,82 @@
             "TargetAddress": "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae"
         },
         {
-            "AddressArguments": [],
+            "AddressArguments": [
+                "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
+            ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "Approve yzUSD to spend USDT0",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0x3c2c2f917c35c104e91c37459b155b196fb8a89d380d5cb2dd9b2a72bec69e08",
+            "PackedArgumentAddresses": "0x6695c0f8706c5ace3bdf8995073179cca47926dc",
+            "TargetAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb"
+        },
+        {
+            "AddressArguments": [
+                "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "mint yzUSD with USDT0",
+            "FunctionSelector": "0x6e553f65",
+            "FunctionSignature": "deposit(uint256,address)",
+            "LeafDigest": "0x45e9d719d395e88981f8bf3c25ae0c5f1f8145e52f11c058e41c0d95d2992352",
+            "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c",
+            "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
+        },
+        {
+            "AddressArguments": [
+                "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C",
+                "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "request redemption of yzUSD for USDT0",
+            "FunctionSelector": "0x432cb54f",
+            "FunctionSignature": "createRedeemOrder(uint256,address,address)",
+            "LeafDigest": "0x023cdb7b122ff0b77eca768c6f148806474f1644d51b82ae05ec981b6b08e37f",
+            "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c08c6f91e2b681faf5e17227f2a44c307b3c1364c",
+            "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
+        },
+        {
+            "AddressArguments": [
+                "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "stake yzUSD for syzUSD",
+            "FunctionSelector": "0x6e553f65",
+            "FunctionSignature": "deposit(uint256,address)",
+            "LeafDigest": "0xcf07393b3beacae94f6dfbcd0559df4c9f5cd80bf74a70c1c339849bfe4c2077",
+            "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c",
+            "TargetAddress": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
+        },
+        {
+            "AddressArguments": [
+                "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C",
+                "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "initiate unstaking syzUSD for yzUSD",
+            "FunctionSelector": "0x8df679e3",
+            "FunctionSignature": "initiateRedeem(uint256,address,address)",
+            "LeafDigest": "0x0de133941f6e69ce8faf7c22a7a2e1989dfef29f5cd4761919486d93c4632183",
+            "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c08c6f91e2b681faf5e17227f2a44c307b3c1364c",
+            "TargetAddress": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "finalize a ready syzUSD unstaking request",
+            "FunctionSelector": "0xaff6cbf1",
+            "FunctionSignature": "finalizeRedeem(uint256)",
+            "LeafDigest": "0x525ed92ed6d5f046ca029e300384c0f3e67555dcbbf965978384b0c065694d65",
             "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
+            "TargetAddress": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
         },
         {
             "AddressArguments": [],
@@ -800,24 +812,24 @@
     ],
     "MerkleTree": {
         "0": [
-            "0x43377eedcb912e5216fb97e6cc8fa52f8351916a2ae7c315e32d2ba49022efae"
+            "0xaa2f95b61bff7e91019eb66c31cfa5118b568e5aaf7d489d6259f713156230b2"
         ],
         "1": [
-            "0xaedd1d60aef918961cab53d9f803e6ccee4a1c73d72f582170d19081209001aa",
-            "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a"
+            "0xc62aee42d1b1adcb9bcbc87ab3431db7410023accf2822669b7345c9c0b40d50",
+            "0x3051c594f0358d87958df8f1ae6170b771ab077cead749dfe7e05600a3709458"
         ],
         "2": [
             "0x50337f40e37d1668f6efdcb867ab40e3a6ec223ca9f879f68c2e1212676ccf2e",
-            "0xdd2f837eb5a49b062859f00dfb129541f17ec7a1f3b6e75add871386c03f90a7",
-            "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
+            "0x1f8a23bb022e5911e3973622a875bb1d3317a1af8464cd92c6433201911ef735",
+            "0x2cdd55ae22cc8a1f33b762214378256215f22668ab4c79d70674601994091218",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
         "3": [
             "0x5152ffa34654c8a0fae9a00e24cf40b1975419b02b1e811d6d9c8e632d7e80e5",
             "0xe5d87d0ad069e284c05c7cec0e09e84aedd9f5b376ba31043017c90b2718b2e7",
             "0x1fc452e3bc9b541bfc86fde6a711eff452c810f986a137139ea061feded7e8fe",
-            "0xc51f6645bf4dfe1b6ccef12e2c02cd3046ce4043ba22160f308ae185ebb8a295",
-            "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
+            "0x2bafc5d7bc2c8d7076bfcc933965db244ab536a6ab8287e3be5254de895f18f3",
+            "0xa9407d40bfa231625e0b1a13baaaf22cf1448637a0b851f9403ad101bca4f173",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
@@ -830,8 +842,8 @@
             "0xaae97c952bf1a9f4305167a675929bb03e56b38755296bbce094d584a50d9c80",
             "0xaf278a7829f86f87c3a36ee82705af8d5b363c5466d494e98ae20cb1bb608e11",
             "0xa85797132f8d6f370be92a680f965d729d1f6b7c260a18a8e7d31830016b3096",
-            "0x2e3416f2622eec7c86e2caf7f46e03da374b21a6caf52cdc8669135da7ccee95",
-            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0xbf67e97fb2fd2f6abc59fb6ce1997d8f8f287b9769fa26a8e05f094c481e0b34",
+            "0x69dd05fabaee996c48d2150d9484234c4fc513fb2c456cca2693c01cc9557e59",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -856,9 +868,9 @@
             "0xd889a7f8a1324d94e93a09aa0b9a339f9600d61d8b4a5a51d1a1014188159375",
             "0xb7b35cb132ea78e9ba8a584904a54b1053147599a51554ef9a7833c3ab3cea1b",
             "0x15ef1d538a0a51aaaa30d909f0f4a9631b0728eaea5adea0c2031bb867915ed7",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0x09e7d01f7463d1de4356cfa691b2d1528aaeb5aba99c88332392f6697b7ef02c",
+            "0x2d8c13e44aede7965644eb3c6b0689c4d4e0d5933b6f503201525cc9cbcb126a",
+            "0xaef795555b31b9d206416e43b6b3bb468683fc7d379a70052d5b23cb8d657b8d",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -905,12 +917,12 @@
             "0x4e194ea1d479ed15487b2a14684709e8efc22a5431417c2115e3aaf29d19d1b9",
             "0x94ef74f4518d52d47102bf640eb3ba88e06c7356bb3b0c007c191ba13eedb040",
             "0x8939eccc30ac5f129f37c1c778851278880717b7562ab2eaf675fdb309bbec78",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0x3c2c2f917c35c104e91c37459b155b196fb8a89d380d5cb2dd9b2a72bec69e08",
+            "0x45e9d719d395e88981f8bf3c25ae0c5f1f8145e52f11c058e41c0d95d2992352",
+            "0x023cdb7b122ff0b77eca768c6f148806474f1644d51b82ae05ec981b6b08e37f",
+            "0xcf07393b3beacae94f6dfbcd0559df4c9f5cd80bf74a70c1c339849bfe4c2077",
+            "0x0de133941f6e69ce8faf7c22a7a2e1989dfef29f5cd4761919486d93c4632183",
+            "0x525ed92ed6d5f046ca029e300384c0f3e67555dcbbf965978384b0c065694d65",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/leafs/Plasma/LiquidUSDMerkleRoot.json
+++ b/leafs/Plasma/LiquidUSDMerkleRoot.json
@@ -10,8 +10,8 @@
             "Bytes4(TARGET_FUNCTION_SELECTOR)",
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
-        "LeafCount": 37,
-        "ManageRoot": "0xc1343ea556fa59a026eaa1db4915341aeee608188d460eac19ef2eab77378323",
+        "LeafCount": 39,
+        "ManageRoot": "0x1e05b383374960aeeb847543e2dd2a858fb537e26977d0a2f267ce6dd7fb0c57",
         "ManagerAddress": "0x7b57Ad1A0AA89583130aCfAD024241170D24C13C",
         "TreeCapacity": 64
     },
@@ -428,11 +428,11 @@
                 "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
             ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "Approve yzUSD to spend USDT0",
             "FunctionSelector": "0x095ea7b3",
             "FunctionSignature": "approve(address,uint256)",
-            "LeafDigest": "0x3c2c2f917c35c104e91c37459b155b196fb8a89d380d5cb2dd9b2a72bec69e08",
+            "LeafDigest": "0xafb5691ee473857eb0fcf12c9173dbca2cc5b4e9a96877777b028105fb9ee018",
             "PackedArgumentAddresses": "0x6695c0f8706c5ace3bdf8995073179cca47926dc",
             "TargetAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb"
         },
@@ -441,11 +441,11 @@
                 "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
             ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "Approve syzUSD to spend yzUSD",
             "FunctionSelector": "0x095ea7b3",
             "FunctionSignature": "approve(address,uint256)",
-            "LeafDigest": "0xb0a4400796cf71f93ebb8b5432a5f82ffe43313993a241ededd38d4c72befdbd",
+            "LeafDigest": "0x4eebc7593ebe223be2c7947e727db888dc96480cf8bc4152cbb73c21c8600e70",
             "PackedArgumentAddresses": "0xc8a8df9b210243c55d31c73090f06787ad0a1bf6",
             "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
         },
@@ -454,11 +454,11 @@
                 "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
             ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "mint yzUSD with USDT0",
             "FunctionSelector": "0x6e553f65",
             "FunctionSignature": "deposit(uint256,address)",
-            "LeafDigest": "0x45e9d719d395e88981f8bf3c25ae0c5f1f8145e52f11c058e41c0d95d2992352",
+            "LeafDigest": "0xa636d40b8025dc21d572aa5a6e9eaa09e9341338d83b33897cbaee196e58bb01",
             "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c",
             "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
         },
@@ -468,12 +468,34 @@
                 "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
             ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "request redemption of yzUSD for USDT0",
             "FunctionSelector": "0x432cb54f",
             "FunctionSignature": "createRedeemOrder(uint256,address,address)",
-            "LeafDigest": "0x023cdb7b122ff0b77eca768c6f148806474f1644d51b82ae05ec981b6b08e37f",
+            "LeafDigest": "0x7b92028b844896eb24cef18e6e29411c436f5a9ccd28b39f38903c1b36d9e308",
             "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c08c6f91e2b681faf5e17227f2a44c307b3c1364c",
+            "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
+            "Description": "cancel redemption of yzUSD for USDT0",
+            "FunctionSelector": "0x9bb0bcbb",
+            "FunctionSignature": "cancelRedeemOrder(uint256)",
+            "LeafDigest": "0x6eebca2154a50eea7e895849627f210325e4c697447144dd6a71b5fc9f1e38dc",
+            "PackedArgumentAddresses": "0x",
+            "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
+        },
+        {
+            "AddressArguments": [],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
+            "Description": "finalize redemption of yzUSD for USDT0",
+            "FunctionSelector": "0xa467ea11",
+            "FunctionSignature": "finalizeRedeemOrder(uint256)",
+            "LeafDigest": "0x5a323cad11307a388febe02c5ee671d363daa4e13bc699ba00aeefc208bf4ed6",
+            "PackedArgumentAddresses": "0x",
             "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
         },
         {
@@ -481,11 +503,11 @@
                 "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
             ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "stake yzUSD for syzUSD",
             "FunctionSelector": "0x6e553f65",
             "FunctionSignature": "deposit(uint256,address)",
-            "LeafDigest": "0xcf07393b3beacae94f6dfbcd0559df4c9f5cd80bf74a70c1c339849bfe4c2077",
+            "LeafDigest": "0xbbb79a1dcf0fd244082a4f38cf343363047fdf8934c4de19d58a52f8cff3c5ef",
             "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c",
             "TargetAddress": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
         },
@@ -495,46 +517,24 @@
                 "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
             ],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "initiate unstaking syzUSD for yzUSD",
             "FunctionSelector": "0x8df679e3",
             "FunctionSignature": "initiateRedeem(uint256,address,address)",
-            "LeafDigest": "0x0de133941f6e69ce8faf7c22a7a2e1989dfef29f5cd4761919486d93c4632183",
+            "LeafDigest": "0xe6ad511ed5949a38f62273cc6ebf2278c0f9b358e3900628c8b434c76d96afa4",
             "PackedArgumentAddresses": "0x08c6f91e2b681faf5e17227f2a44c307b3c1364c08c6f91e2b681faf5e17227f2a44c307b3c1364c",
             "TargetAddress": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
         },
         {
             "AddressArguments": [],
             "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "DecoderAndSanitizerAddress": "0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF",
             "Description": "finalize a ready syzUSD unstaking request",
             "FunctionSelector": "0xaff6cbf1",
             "FunctionSignature": "finalizeRedeem(uint256)",
-            "LeafDigest": "0x525ed92ed6d5f046ca029e300384c0f3e67555dcbbf965978384b0c065694d65",
+            "LeafDigest": "0x6662a50822cdba41c3e5a6166d429aa1af0e20455a91a388fd2b62e982fdddee",
             "PackedArgumentAddresses": "0x",
             "TargetAddress": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
         },
         {
             "AddressArguments": [],
@@ -814,24 +814,24 @@
     ],
     "MerkleTree": {
         "0": [
-            "0xc1343ea556fa59a026eaa1db4915341aeee608188d460eac19ef2eab77378323"
+            "0x1e05b383374960aeeb847543e2dd2a858fb537e26977d0a2f267ce6dd7fb0c57"
         ],
         "1": [
-            "0x029475d044668f2f20bb820c053ee08df22ef628c94ccd387001fa8501bc1ce4",
-            "0x9769d565b9529090c9270bb8b7664225487b684aee201a8b02e240d41b300508"
+            "0x6010970eb53b4fdf1ac29a3a63d26bf0cf13855912da92c29499f47b067d1fd0",
+            "0x944ee35ad7223ccf715b4152ba5a369ede4bbc57a667b8602e3c6f63d6190cac"
         ],
         "2": [
             "0x50337f40e37d1668f6efdcb867ab40e3a6ec223ca9f879f68c2e1212676ccf2e",
-            "0xec9c6902dbf9c55aa701f360febf7840d6d47d4bd60a070e9ae1dfe16bdcef66",
-            "0xe23114136682f532713b412a62c5aefc9122728ed98a9fe4457d1cb16c6d57fe",
+            "0x7229f8dfd00b5609191d0184d66fa202e65b8449aa283c47d23854edd4d20019",
+            "0x922d428bac83fac82fba2e9474e13fee0dbb1c48b52073ffdba5fc0bbe2477fb",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
         "3": [
             "0x5152ffa34654c8a0fae9a00e24cf40b1975419b02b1e811d6d9c8e632d7e80e5",
             "0xe5d87d0ad069e284c05c7cec0e09e84aedd9f5b376ba31043017c90b2718b2e7",
             "0x1fc452e3bc9b541bfc86fde6a711eff452c810f986a137139ea061feded7e8fe",
-            "0x74b5f99ab7540100cf487865fd353eb30253b7d283b4daad5fe99de5a5f2da13",
-            "0x49e39fd1a4d7b28d04584230424578dbefc87d8ff5abdc49d270ee0b03ff8d43",
+            "0x99fd2be1531b6432c201339a7f8fab5bc3fa4610a8d573288c287346685df231",
+            "0x12f88bcf0b66dc0368b36341bc27e648acf188c2ea226dc48da0f5df06b00d4c",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
@@ -844,9 +844,9 @@
             "0xaae97c952bf1a9f4305167a675929bb03e56b38755296bbce094d584a50d9c80",
             "0xaf278a7829f86f87c3a36ee82705af8d5b363c5466d494e98ae20cb1bb608e11",
             "0xa85797132f8d6f370be92a680f965d729d1f6b7c260a18a8e7d31830016b3096",
-            "0xf5b27c75c1cfc4adbee8e9625e672000ec048825d5199dc8cccbc766b0e68997",
-            "0x9205b3abf2c99050b391c18da7102e3c4c0598818a89b2ed05ff44321d1eca02",
-            "0xbce935643dcc71546038f83fdc934d5af29afa335875315bb621d5da346ccfed",
+            "0xf02b623e03ab732178a294dd9e8d90b5e8396333269544d0b98007a9ebfb81d0",
+            "0x36f014cb5dd6a9c4906060bbd53fe7c729317a1dc20467127a88ed362a13e8cd",
+            "0xfe846ba4cbc7caf73a08bba02ac96ca017a135c21af91c20d3e716853c126868",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -870,11 +870,11 @@
             "0xd889a7f8a1324d94e93a09aa0b9a339f9600d61d8b4a5a51d1a1014188159375",
             "0xb7b35cb132ea78e9ba8a584904a54b1053147599a51554ef9a7833c3ab3cea1b",
             "0x15ef1d538a0a51aaaa30d909f0f4a9631b0728eaea5adea0c2031bb867915ed7",
-            "0x50fe6fd134cd88c5dbab351659c4d97e19247543a60e45125e643a999343a64f",
-            "0xb7d5edbdc2e2ec14f5178283d2a91ff149f4de1b749fa9a3bbd54350cc945eca",
-            "0xdb21ca0464aa01bc615ef1e511584d9c2e7aa454675a582fd4918e40e5a04056",
-            "0x02ae98b99275e132c14b3a76e423bae0001fb2db4c036ac201ec5cbb527360cc",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0x63df93392af7a85e54ad0d1d973306fbc02271b470083c2b1d73de930b1677cc",
+            "0xddf893493b923e3ba9800cdf3a08ff7927c7a16c3cbc8380c1786af881ee91f9",
+            "0x0036de30eb7838bf0348fa3f9b2648f79a641eff8fd669752e1c6ba007d8c171",
+            "0x6177fdeba77314d6cc67f2552430bc6111b247aee769995f50f4e0924b9e6da6",
+            "0xda822f8316eb90b4e62dbd32a0cef2ccf712171f520928cc1828d974cbe5c377",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -919,15 +919,15 @@
             "0x4e194ea1d479ed15487b2a14684709e8efc22a5431417c2115e3aaf29d19d1b9",
             "0x94ef74f4518d52d47102bf640eb3ba88e06c7356bb3b0c007c191ba13eedb040",
             "0x8939eccc30ac5f129f37c1c778851278880717b7562ab2eaf675fdb309bbec78",
-            "0x3c2c2f917c35c104e91c37459b155b196fb8a89d380d5cb2dd9b2a72bec69e08",
-            "0xb0a4400796cf71f93ebb8b5432a5f82ffe43313993a241ededd38d4c72befdbd",
-            "0x45e9d719d395e88981f8bf3c25ae0c5f1f8145e52f11c058e41c0d95d2992352",
-            "0x023cdb7b122ff0b77eca768c6f148806474f1644d51b82ae05ec981b6b08e37f",
-            "0xcf07393b3beacae94f6dfbcd0559df4c9f5cd80bf74a70c1c339849bfe4c2077",
-            "0x0de133941f6e69ce8faf7c22a7a2e1989dfef29f5cd4761919486d93c4632183",
-            "0x525ed92ed6d5f046ca029e300384c0f3e67555dcbbf965978384b0c065694d65",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
+            "0xafb5691ee473857eb0fcf12c9173dbca2cc5b4e9a96877777b028105fb9ee018",
+            "0x4eebc7593ebe223be2c7947e727db888dc96480cf8bc4152cbb73c21c8600e70",
+            "0xa636d40b8025dc21d572aa5a6e9eaa09e9341338d83b33897cbaee196e58bb01",
+            "0x7b92028b844896eb24cef18e6e29411c436f5a9ccd28b39f38903c1b36d9e308",
+            "0x6eebca2154a50eea7e895849627f210325e4c697447144dd6a71b5fc9f1e38dc",
+            "0x5a323cad11307a388febe02c5ee671d363daa4e13bc699ba00aeefc208bf4ed6",
+            "0xbbb79a1dcf0fd244082a4f38cf343363047fdf8934c4de19d58a52f8cff3c5ef",
+            "0xe6ad511ed5949a38f62273cc6ebf2278c0f9b358e3900628c8b434c76d96afa4",
+            "0x6662a50822cdba41c3e5a6166d429aa1af0e20455a91a388fd2b62e982fdddee",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/leafs/Plasma/LiquidUSDMerkleRoot.json
+++ b/leafs/Plasma/LiquidUSDMerkleRoot.json
@@ -10,8 +10,8 @@
             "Bytes4(TARGET_FUNCTION_SELECTOR)",
             "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
         ],
-        "LeafCount": 36,
-        "ManageRoot": "0xaa2f95b61bff7e91019eb66c31cfa5118b568e5aaf7d489d6259f713156230b2",
+        "LeafCount": 37,
+        "ManageRoot": "0xc1343ea556fa59a026eaa1db4915341aeee608188d460eac19ef2eab77378323",
         "ManagerAddress": "0x7b57Ad1A0AA89583130aCfAD024241170D24C13C",
         "TreeCapacity": 64
     },
@@ -438,6 +438,19 @@
         },
         {
             "AddressArguments": [
+                "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6"
+            ],
+            "CanSendValue": false,
+            "DecoderAndSanitizerAddress": "0x9574a7132780080A420f04FBE03AA2B85aF5bC76",
+            "Description": "Approve syzUSD to spend yzUSD",
+            "FunctionSelector": "0x095ea7b3",
+            "FunctionSignature": "approve(address,uint256)",
+            "LeafDigest": "0xb0a4400796cf71f93ebb8b5432a5f82ffe43313993a241ededd38d4c72befdbd",
+            "PackedArgumentAddresses": "0xc8a8df9b210243c55d31c73090f06787ad0a1bf6",
+            "TargetAddress": "0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc"
+        },
+        {
+            "AddressArguments": [
                 "0x08c6F91e2B681FaF5e17227F2a44C307b3C1364C"
             ],
             "CanSendValue": false,
@@ -797,39 +810,28 @@
             "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "PackedArgumentAddresses": "0x",
             "TargetAddress": "0x0000000000000000000000000000000000000000"
-        },
-        {
-            "AddressArguments": [],
-            "CanSendValue": false,
-            "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-            "Description": "",
-            "FunctionSelector": "0xc5d24601",
-            "FunctionSignature": "",
-            "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-            "PackedArgumentAddresses": "0x",
-            "TargetAddress": "0x0000000000000000000000000000000000000000"
         }
     ],
     "MerkleTree": {
         "0": [
-            "0xaa2f95b61bff7e91019eb66c31cfa5118b568e5aaf7d489d6259f713156230b2"
+            "0xc1343ea556fa59a026eaa1db4915341aeee608188d460eac19ef2eab77378323"
         ],
         "1": [
-            "0xc62aee42d1b1adcb9bcbc87ab3431db7410023accf2822669b7345c9c0b40d50",
-            "0x3051c594f0358d87958df8f1ae6170b771ab077cead749dfe7e05600a3709458"
+            "0x029475d044668f2f20bb820c053ee08df22ef628c94ccd387001fa8501bc1ce4",
+            "0x9769d565b9529090c9270bb8b7664225487b684aee201a8b02e240d41b300508"
         ],
         "2": [
             "0x50337f40e37d1668f6efdcb867ab40e3a6ec223ca9f879f68c2e1212676ccf2e",
-            "0x1f8a23bb022e5911e3973622a875bb1d3317a1af8464cd92c6433201911ef735",
-            "0x2cdd55ae22cc8a1f33b762214378256215f22668ab4c79d70674601994091218",
+            "0xec9c6902dbf9c55aa701f360febf7840d6d47d4bd60a070e9ae1dfe16bdcef66",
+            "0xe23114136682f532713b412a62c5aefc9122728ed98a9fe4457d1cb16c6d57fe",
             "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
         ],
         "3": [
             "0x5152ffa34654c8a0fae9a00e24cf40b1975419b02b1e811d6d9c8e632d7e80e5",
             "0xe5d87d0ad069e284c05c7cec0e09e84aedd9f5b376ba31043017c90b2718b2e7",
             "0x1fc452e3bc9b541bfc86fde6a711eff452c810f986a137139ea061feded7e8fe",
-            "0x2bafc5d7bc2c8d7076bfcc933965db244ab536a6ab8287e3be5254de895f18f3",
-            "0xa9407d40bfa231625e0b1a13baaaf22cf1448637a0b851f9403ad101bca4f173",
+            "0x74b5f99ab7540100cf487865fd353eb30253b7d283b4daad5fe99de5a5f2da13",
+            "0x49e39fd1a4d7b28d04584230424578dbefc87d8ff5abdc49d270ee0b03ff8d43",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
             "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704"
@@ -842,9 +844,9 @@
             "0xaae97c952bf1a9f4305167a675929bb03e56b38755296bbce094d584a50d9c80",
             "0xaf278a7829f86f87c3a36ee82705af8d5b363c5466d494e98ae20cb1bb608e11",
             "0xa85797132f8d6f370be92a680f965d729d1f6b7c260a18a8e7d31830016b3096",
-            "0xbf67e97fb2fd2f6abc59fb6ce1997d8f8f287b9769fa26a8e05f094c481e0b34",
-            "0x69dd05fabaee996c48d2150d9484234c4fc513fb2c456cca2693c01cc9557e59",
-            "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
+            "0xf5b27c75c1cfc4adbee8e9625e672000ec048825d5199dc8cccbc766b0e68997",
+            "0x9205b3abf2c99050b391c18da7102e3c4c0598818a89b2ed05ff44321d1eca02",
+            "0xbce935643dcc71546038f83fdc934d5af29afa335875315bb621d5da346ccfed",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
             "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -868,10 +870,10 @@
             "0xd889a7f8a1324d94e93a09aa0b9a339f9600d61d8b4a5a51d1a1014188159375",
             "0xb7b35cb132ea78e9ba8a584904a54b1053147599a51554ef9a7833c3ab3cea1b",
             "0x15ef1d538a0a51aaaa30d909f0f4a9631b0728eaea5adea0c2031bb867915ed7",
-            "0x09e7d01f7463d1de4356cfa691b2d1528aaeb5aba99c88332392f6697b7ef02c",
-            "0x2d8c13e44aede7965644eb3c6b0689c4d4e0d5933b6f503201525cc9cbcb126a",
-            "0xaef795555b31b9d206416e43b6b3bb468683fc7d379a70052d5b23cb8d657b8d",
-            "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
+            "0x50fe6fd134cd88c5dbab351659c4d97e19247543a60e45125e643a999343a64f",
+            "0xb7d5edbdc2e2ec14f5178283d2a91ff149f4de1b749fa9a3bbd54350cc945eca",
+            "0xdb21ca0464aa01bc615ef1e511584d9c2e7aa454675a582fd4918e40e5a04056",
+            "0x02ae98b99275e132c14b3a76e423bae0001fb2db4c036ac201ec5cbb527360cc",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
             "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -918,12 +920,12 @@
             "0x94ef74f4518d52d47102bf640eb3ba88e06c7356bb3b0c007c191ba13eedb040",
             "0x8939eccc30ac5f129f37c1c778851278880717b7562ab2eaf675fdb309bbec78",
             "0x3c2c2f917c35c104e91c37459b155b196fb8a89d380d5cb2dd9b2a72bec69e08",
+            "0xb0a4400796cf71f93ebb8b5432a5f82ffe43313993a241ededd38d4c72befdbd",
             "0x45e9d719d395e88981f8bf3c25ae0c5f1f8145e52f11c058e41c0d95d2992352",
             "0x023cdb7b122ff0b77eca768c6f148806474f1644d51b82ae05ec981b6b08e37f",
             "0xcf07393b3beacae94f6dfbcd0559df4c9f5cd80bf74a70c1c339849bfe4c2077",
             "0x0de133941f6e69ce8faf7c22a7a2e1989dfef29f5cd4761919486d93c4632183",
             "0x525ed92ed6d5f046ca029e300384c0f3e67555dcbbf965978384b0c065694d65",
-            "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
             "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/script/MerkleRootCreation/Plasma/CreateLiquidUSDMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Plasma/CreateLiquidUSDMerkleRoot.s.sol
@@ -20,7 +20,7 @@ contract CreateLiquidUSDMerkleRoot is Script, MerkleTreeHelper {
     address public managerAddress = 0x7b57Ad1A0AA89583130aCfAD024241170D24C13C;
     address public accountantAddress = 0xc315D6e14DDCDC7407784e2Caf815d131Bc1D3E7;
 
-    address public yuzuDecoderAndSanitizer = 0x9574a7132780080A420f04FBE03AA2B85aF5bC76;
+    address public yuzuDecoderAndSanitizer = 0x6A1Be80d1F3e762B9ff73b5FF122B68027F17abF;
 
     function setUp() external {}
 

--- a/script/MerkleRootCreation/Plasma/CreateLiquidUSDMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Plasma/CreateLiquidUSDMerkleRoot.s.sol
@@ -69,6 +69,9 @@ contract CreateLiquidUSDMerkleRoot is Script, MerkleTreeHelper {
             getAddress(sourceChain, "dev1Address")
         );
 
+        // ========================== Yuzu ============================
+        _addYuzuLeafs(leafs);
+
         // ========================== Verify ==========================
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);
 

--- a/script/MerkleRootCreation/Plasma/CreateLiquidUSDMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Plasma/CreateLiquidUSDMerkleRoot.s.sol
@@ -20,6 +20,8 @@ contract CreateLiquidUSDMerkleRoot is Script, MerkleTreeHelper {
     address public managerAddress = 0x7b57Ad1A0AA89583130aCfAD024241170D24C13C;
     address public accountantAddress = 0xc315D6e14DDCDC7407784e2Caf815d131Bc1D3E7;
 
+    address public yuzuDecoderAndSanitizer = 0x9574a7132780080A420f04FBE03AA2B85aF5bC76;
+
     function setUp() external {}
 
     function run() external {
@@ -70,7 +72,11 @@ contract CreateLiquidUSDMerkleRoot is Script, MerkleTreeHelper {
         );
 
         // ========================== Yuzu ============================
-        _addYuzuLeafs(leafs);
+        {
+            setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", yuzuDecoderAndSanitizer);
+            _addYuzuLeafs(leafs);
+            setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
+        }
 
         // ========================== Verify ==========================
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);

--- a/src/base/DecodersAndSanitizers/YuzuDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/YuzuDecoderAndSanitizer.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
+
+contract YuzuDecoderAndSanitizer is ERC4626DecoderAndSanitizer, BaseDecoderAndSanitizer {
+
+    //======================== yzUSD  ==============================
+
+    function deposit(uint256 assets, address receiver) external pure virtual returns (bytes memory addressesFound) {
+        return abi.encodePacked(receiver);
+    }
+
+    function createRedeemOrder(uint256 tokens, address receiver, address owner) external pure virtual returns (bytes memory addressesFound) {
+        return abi.encodePacked(receiver, owner);
+    }
+
+    //======================== syzUSD  =============================
+
+    function deposit(uint256 assets, address receiver) external pure virtual (bytes memory addressesFound) {
+        return abi.encodePacked(receiver);
+    }
+
+    function initiateRedeem(uint256 shares, address receiver, address owner) external pure virtual (bytes memory addressesFound) {
+        return abi.encodePacked(receiver, owner);
+    }
+
+    function initiateRedeemWithSlippage(uint256 shares, address receiver, address owner, uint256 minAssets) external pure virtual (bytes memory addressesFound) {
+        return abi.encodePacked(receiver, owner);
+    }
+
+    function finalizeRedeem(uint256 orderId) external pure virtual (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+}

--- a/src/base/DecodersAndSanitizers/YuzuDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/YuzuDecoderAndSanitizer.sol
@@ -11,9 +11,12 @@ contract YuzuDecoderAndSanitizer is ERC4626DecoderAndSanitizer, BaseDecoderAndSa
 
     //======================== yzUSD  ==============================
 
+    // Covered by by parent ERC4626 decoder
+    /*
     function deposit(uint256 assets, address receiver) external pure virtual returns (bytes memory addressesFound) {
         return abi.encodePacked(receiver);
     }
+    */
 
     function createRedeemOrder(uint256 tokens, address receiver, address owner) external pure virtual returns (bytes memory addressesFound) {
         return abi.encodePacked(receiver, owner);
@@ -21,19 +24,22 @@ contract YuzuDecoderAndSanitizer is ERC4626DecoderAndSanitizer, BaseDecoderAndSa
 
     //======================== syzUSD  =============================
 
-    function deposit(uint256 assets, address receiver) external pure virtual (bytes memory addressesFound) {
+    // Covered by by parent ERC4626 decoder
+    /*
+    function deposit(uint256 assets, address receiver) external pure virtual returns (bytes memory addressesFound) {
         return abi.encodePacked(receiver);
     }
+    */
 
-    function initiateRedeem(uint256 shares, address receiver, address owner) external pure virtual (bytes memory addressesFound) {
+    function initiateRedeem(uint256 shares, address receiver, address owner) external pure virtual returns (bytes memory addressesFound) {
         return abi.encodePacked(receiver, owner);
     }
 
-    function initiateRedeemWithSlippage(uint256 shares, address receiver, address owner, uint256 minAssets) external pure virtual (bytes memory addressesFound) {
+    function initiateRedeemWithSlippage(uint256 shares, address receiver, address owner, uint256 minAssets) external pure virtual returns (bytes memory addressesFound) {
         return abi.encodePacked(receiver, owner);
     }
 
-    function finalizeRedeem(uint256 orderId) external pure virtual (bytes memory addressesFound) {
+    function finalizeRedeem(uint256 orderId) external pure virtual returns (bytes memory addressesFound) {
         return addressesFound;
     }
 

--- a/src/base/DecodersAndSanitizers/YuzuDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/YuzuDecoderAndSanitizer.sol
@@ -22,6 +22,15 @@ contract YuzuDecoderAndSanitizer is ERC4626DecoderAndSanitizer, BaseDecoderAndSa
         return abi.encodePacked(receiver, owner);
     }
 
+    function finalizeRedeemOrder(uint256 orderId) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+    function cancelRedeemOrder(uint256 orderId) external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+
     //======================== syzUSD  =============================
 
     // Covered by by parent ERC4626 decoder

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -370,8 +370,6 @@ contract ChainValues {
         values[mainnet]["USDG"] = 0xe343167631d89B6Ffc58B88d6b7fB0228795491D.toBytes32();
         values[mainnet]["axlSAGA"] = 0xF42fCFfc27A5B8d0afEC45659407B82f9F32fA98.toBytes32();
         values[mainnet]["USD1"] = 0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d.toBytes32();
-        values[mainnet]["yzUSD"] = 0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc.toBytes32();
-        values[mainnet]["syzUSD"] = 0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6.toBytes32();
 
         // Rate providers
         values[mainnet]["WEETH_RATE_PROVIDER"] = 0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee.toBytes32();
@@ -3204,6 +3202,8 @@ contract ChainValues {
         values[plasma]["sUSDe"] = 0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2.toBytes32(); 
         values[plasma]["ENA"] = 0x58538e6A46E07434d7E7375Bc268D3cb839C0133.toBytes32(); 
         values[plasma]["wstUSR"] = 0x2a52B289bA68bBd02676640aA9F605700c9e5699.toBytes32(); // also OFT
+        values[plasma]["yzUSD"] = 0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc.toBytes32();
+        values[plasma]["syzUSD"] = 0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6.toBytes32();
         
         // Uniswap V3
         values[plasma]["uniswapV3NonFungiblePositionManager"] = 0x743E03cceB4af2efA3CC76838f6E8B50B63F184c.toBytes32();

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -370,6 +370,8 @@ contract ChainValues {
         values[mainnet]["USDG"] = 0xe343167631d89B6Ffc58B88d6b7fB0228795491D.toBytes32();
         values[mainnet]["axlSAGA"] = 0xF42fCFfc27A5B8d0afEC45659407B82f9F32fA98.toBytes32();
         values[mainnet]["USD1"] = 0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d.toBytes32();
+        values[mainnet]["yzUSD"] = 0x6695c0f8706C5ACe3Bdf8995073179cCA47926dc.toBytes32();
+        values[mainnet]["syzUSD"] = 0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6.toBytes32();
 
         // Rate providers
         values[mainnet]["WEETH_RATE_PROVIDER"] = 0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee.toBytes32();

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -9753,6 +9753,30 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
             leafIndex++;
         }
         leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "yzUSD"),
+            false,
+            "cancelRedeemOrder(uint256)",
+            new address[](0),
+            string.concat("cancel redemption of yzUSD for USDT0"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "yzUSD"),
+            false,
+            "finalizeRedeemOrder(uint256)",
+            new address[](0),
+            string.concat("finalize redemption of yzUSD for USDT0"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
             getAddress(sourceChain, "syzUSD"),
             false,
             "deposit(uint256,address)",

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -9692,12 +9692,6 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
 
     function _addYuzuLeafs(ManageLeaf[] memory leafs) internal {
 
-        /*
-        address usdt0 = getAddress(sourceChain, "USDT0");
-        address yzUSD = getAddress(sourceChain, "yzUSD");
-        address syzUSD = getAddress(sourceChain, "syzUSD");
-        */
-
         unchecked {
             leafIndex++;
         }

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -9713,6 +9713,21 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex] = ManageLeaf(
             getAddress(sourceChain, "yzUSD"),
             false,
+            "approve(address,uint256)",
+            new address[](1),
+            string.concat(
+                "Approve syzUSD to spend yzUSD"
+            ),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "syzUSD");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "yzUSD"),
+            false,
             "deposit(uint256,address)",
             new address[](1),
             string.concat("mint yzUSD with USDT0"),

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -9690,6 +9690,98 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
     }
 
+    function _addYuzuLeafs(ManageLeaf[] memory leafs) internal {
+
+        /*
+        address usdt0 = getAddress(sourceChain, "USDT0");
+        address yzUSD = getAddress(sourceChain, "yzUSD");
+        address syzUSD = getAddress(sourceChain, "syzUSD");
+        */
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "USDT0"),
+            false,
+            "approve(address,uint256)",
+            new address[](1),
+            string.concat(
+                "Approve yzUSD to spend USDT0"
+            ),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "yzUSD");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "yzUSD"),
+            false,
+            "deposit(uint256,address)",
+            new address[](1),
+            string.concat("mint yzUSD with USDT0"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "yzUSD"),
+            false,
+            "createRedeemOrder(uint256,address,address)",
+            new address[](2),
+            string.concat("request redemption of yzUSD for USDT0"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
+        leafs[leafIndex].argumentAddresses[1] = getAddress(sourceChain, "boringVault");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "syzUSD"),
+            false,
+            "deposit(uint256,address)",
+            new address[](1),
+            string.concat("stake yzUSD for syzUSD"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "syzUSD"),
+            false,
+            "initiateRedeem(uint256,address,address)",
+            new address[](2),
+            string.concat("initiate unstaking syzUSD for yzUSD"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
+        leafs[leafIndex].argumentAddresses[1] = getAddress(sourceChain, "boringVault");
+
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            getAddress(sourceChain, "syzUSD"),
+            false,
+            "finalizeRedeem(uint256)",
+            new address[](0),
+            string.concat("finalize a ready syzUSD unstaking request"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+    }
+
+
     function _addRoycoRecipeAPOfferLeafs(
         ManageLeaf[] memory leafs,
         address baseAsset,


### PR DESCRIPTION
we would like to add Yuzu finance support to the ether.fi liquid vaults

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the vault’s permitted call set by adding new protocol interactions and a new decoder/sanitizer, so incorrect selectors/address packing could broaden allowed operations or break manage-root verification.
> 
> **Overview**
> Adds Yuzu Finance support for the Plasma LiquidUSD vault by introducing a new `YuzuDecoderAndSanitizer` and wiring it into merkle-root generation.
> 
> The LiquidUSD strategist merkle root is expanded from 30 to 39 leaves to allow `yzUSD`/`syzUSD` flows (approvals, mint via `deposit`, redeem-order create/cancel/finalize, stake/unstake initiate+finalize) using the new decoder, and the generated `LiquidUSDMerkleRoot.json` `ManageRoot` is updated accordingly. Chain test resources are updated with Plasma addresses for `yzUSD` and `syzUSD`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 382616588c4de39abc51f539ced4c1d33b7db5f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->