### PR TITLE
Add invariant fuzzing suite for BoringVault

### DIFF
--- a/test/fuzzing/BaseSetup.sol
+++ b/test/fuzzing/BaseSetup.sol
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test, console} from "@forge-std/Test.sol";
+
+// Core contracts
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+
+// Auth
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+
+// Tokens
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+// Mocks
+import {MockWETH} from "./mocks/MockWETH.sol";
+import {MockERC20Extended} from "./mocks/MockERC20Extended.sol";
+import {MockRateProvider} from "./mocks/MockRateProvider.sol";
+
+/**
+ * @title BaseSetup
+ * @notice Base setup contract for invariant fuzzing tests
+ * @dev Deploys BoringVault with dual Accountant/Teller configurations:
+ *      - AccountantWithRateProviders + TellerWithMultiAssetSupport
+ *      - AccountantWithYieldStreaming + TellerWithYieldStreaming
+ */
+contract BaseSetup is Test {
+    // ============================================
+    // CONSTANTS
+    // ============================================
+    
+    uint8 public constant MINTER_ROLE = 1;
+    uint8 public constant BURNER_ROLE = 2;
+    uint8 public constant MANAGER_ROLE = 3;
+    uint8 public constant ADMIN_ROLE = 4;
+    uint8 public constant UPDATE_EXCHANGE_RATE_ROLE = 5;
+    uint8 public constant SOLVER_ROLE = 6;
+    uint8 public constant OWNER_ROLE = 7;
+    uint8 public constant STRATEGIST_ROLE = 8;
+    uint8 public constant DENIER_ROLE = 9;
+    
+    uint256 public constant ONE_SHARE = 1e18;
+    uint256 public constant INITIAL_EXCHANGE_RATE = 1e18;
+    uint256 public constant INITIAL_MINT = 1_000_000e18;
+    
+    // ============================================
+    // CORE CONTRACTS - TWO SEPARATE SYSTEMS
+    // ============================================
+    // Each vault uses ONE accounting system to avoid cross-contamination
+    // This matches production deployments where a vault is either RP or YS
+    
+    // RP System: Multi-asset support with rate providers
+    BoringVault public vaultRP;
+    RolesAuthority public rolesAuthorityRP;
+    AccountantWithRateProviders public accountantRP;
+    TellerWithMultiAssetSupport public tellerMAS;
+    
+    // YS System: Yield streaming with vesting
+    BoringVault public vaultYS;
+    RolesAuthority public rolesAuthorityYS;
+    AccountantWithYieldStreaming public accountantYS;
+    TellerWithYieldStreaming public tellerYS;
+    
+    // ============================================
+    // MOCK TOKENS
+    // ============================================
+    
+    // Number of alternative assets for multi-asset testing (RP system)
+    uint256 public constant NUM_ALT_ASSETS = 5;
+    
+    // Decimals for each alternative asset (mimics real-world assets)
+    // Index 0: 18 decimals (standard ERC20)
+    // Index 1: 6 decimals (USDC-like)
+    // Index 2: 6 decimals (USDT-like)
+    // Index 3: 8 decimals (WBTC-like)
+    // Index 4: 11 decimals (unusual, edge case)
+    uint8[5] public ALT_ASSET_DECIMALS = [18, 6, 6, 8, 11];
+    
+    MockWETH public weth;
+    MockERC20Extended public baseAsset;
+    
+    // Alternative assets array for RP multi-asset support
+    MockERC20Extended[] public alternativeAssets;
+    MockRateProvider[] public altAssetRateProviders;
+    
+    // Legacy single asset reference (for backward compatibility / convenience)
+    // Points to alternativeAssets[0]
+    MockERC20Extended public alternativeAsset;
+    MockRateProvider public altAssetRateProvider;
+    
+    // ============================================
+    // ACTORS
+    // ============================================
+    
+    address public owner;
+    address public payoutAddress;
+    address public strategist;
+    address public solver;
+    address public user1;
+    address public user2;
+    address public user3;
+    address public deniedUser;
+    
+    address[] public actors;
+    
+    // ============================================
+    // CONFIGURATION
+    // ============================================
+    
+    // Accountant configuration
+    uint16 public constant ALLOWED_EXCHANGE_RATE_CHANGE_UPPER = 10100; // 101%
+    uint16 public constant ALLOWED_EXCHANGE_RATE_CHANGE_LOWER = 9900;  // 99%
+    uint24 public constant MINIMUM_UPDATE_DELAY = 1 hours;
+    uint16 public constant PLATFORM_FEE = 100;     // 1%
+    uint16 public constant PERFORMANCE_FEE = 1000; // 10%
+    
+    // Teller configuration
+    uint64 public constant SHARE_LOCK_PERIOD = 1 days;
+    
+    // ============================================
+    // SETUP
+    // ============================================
+    
+    function setUp() public virtual {
+        // Setup actors
+        _setupActors();
+        
+        // Deploy mocks (shared between both systems)
+        _deployMocks();
+        
+        // Deploy RP System (vault + accountant + teller)
+        _deployRPSystem();
+        
+        // Deploy YS System (vault + accountant + teller)
+        _deployYSSystem();
+        
+        // Setup roles and permissions for both systems
+        _setupRoles();
+        
+        // Configure assets for both systems
+        _configureAssets();
+        
+        // Initial funding for both vaults
+        _fundActors();
+    }
+    
+    // ============================================
+    // INTERNAL SETUP FUNCTIONS
+    // ============================================
+    
+    function _setupActors() internal {
+        owner = address(this);
+        payoutAddress = makeAddr("payoutAddress");
+        strategist = makeAddr("strategist");
+        solver = makeAddr("solver");
+        user1 = makeAddr("user1");
+        user2 = makeAddr("user2");
+        user3 = makeAddr("user3");
+        deniedUser = makeAddr("deniedUser");
+        
+        actors.push(user1);
+        actors.push(user2);
+        actors.push(user3);
+    }
+    
+    function _deployMocks() internal {
+        // Deploy WETH mock
+        weth = new MockWETH();
+        
+        // Deploy base asset (18 decimals)
+        baseAsset = new MockERC20Extended("Base Asset", "BASE", 18);
+        
+        // Deploy multiple alternative assets with rate providers for RP multi-asset testing
+        // Each asset has different decimals to test decimal diversity
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            string memory name = string(abi.encodePacked("Alternative Asset ", vm.toString(i)));
+            string memory symbol = string(abi.encodePacked("ALT", vm.toString(i)));
+            
+            // Use the decimal configuration for this asset index
+            uint8 assetDecimals = ALT_ASSET_DECIMALS[i];
+            MockERC20Extended altAsset = new MockERC20Extended(name, symbol, assetDecimals);
+            
+            // Each alt asset starts with a slightly different rate for diversity
+            // IMPORTANT: Rates must be in QUOTE TOKEN's decimals, not 18 decimals!
+            // This is required by getRateInQuote formula: rateInQuote = oneQuote * exchangeRate / quoteRate
+            // ALT0 (18 dec): 1.0, ALT1 (6 dec): 0.9, ALT2 (6 dec): 1.1, ALT3 (8 dec): 0.8, ALT4 (11 dec): 1.2
+            uint256 oneUnit = 10 ** assetDecimals;
+            uint256 initialRate;
+            if (i == 0) initialRate = oneUnit;              // 1.0 * 10^18 = 1e18
+            else if (i == 1) initialRate = oneUnit * 9 / 10; // 0.9 * 10^6 = 9e5
+            else if (i == 2) initialRate = oneUnit * 11 / 10; // 1.1 * 10^6 = 1.1e6
+            else if (i == 3) initialRate = oneUnit * 8 / 10;  // 0.8 * 10^8 = 8e7
+            else initialRate = oneUnit * 12 / 10;            // 1.2 * 10^11 = 1.2e11
+            
+            MockRateProvider rateProvider = new MockRateProvider(initialRate, assetDecimals);
+            
+            alternativeAssets.push(altAsset);
+            altAssetRateProviders.push(rateProvider);
+        }
+        
+        // Set legacy references for backward compatibility
+        alternativeAsset = alternativeAssets[0];
+        altAssetRateProvider = altAssetRateProviders[0];
+    }
+    
+    function _deployRPSystem() internal {
+        // Deploy RP vault
+        vaultRP = new BoringVault(
+            owner,
+            "Boring Vault RP",
+            "BVRP",
+            18
+        );
+        
+        // Deploy RP roles authority
+        rolesAuthorityRP = new RolesAuthority(owner, Authority(address(0)));
+        vaultRP.setAuthority(rolesAuthorityRP);
+        
+        // Deploy accountant with rate providers
+        accountantRP = new AccountantWithRateProviders(
+            owner,
+            address(vaultRP),
+            payoutAddress,
+            uint96(INITIAL_EXCHANGE_RATE),
+            address(baseAsset),
+            ALLOWED_EXCHANGE_RATE_CHANGE_UPPER,
+            ALLOWED_EXCHANGE_RATE_CHANGE_LOWER,
+            MINIMUM_UPDATE_DELAY,
+            PLATFORM_FEE,
+            PERFORMANCE_FEE
+        );
+        accountantRP.setAuthority(rolesAuthorityRP);
+        
+        // Deploy teller with multi-asset support
+        tellerMAS = new TellerWithMultiAssetSupport(
+            owner,
+            address(vaultRP),
+            address(accountantRP),
+            address(weth)
+        );
+        tellerMAS.setAuthority(rolesAuthorityRP);
+    }
+    
+    function _deployYSSystem() internal {
+        // Deploy YS vault
+        vaultYS = new BoringVault(
+            owner,
+            "Boring Vault YS",
+            "BVYS",
+            18
+        );
+        
+        // Deploy YS roles authority
+        rolesAuthorityYS = new RolesAuthority(owner, Authority(address(0)));
+        vaultYS.setAuthority(rolesAuthorityYS);
+        
+        // Deploy accountant with yield streaming
+        accountantYS = new AccountantWithYieldStreaming(
+            owner,
+            address(vaultYS),
+            payoutAddress,
+            uint96(INITIAL_EXCHANGE_RATE),
+            address(baseAsset),
+            ALLOWED_EXCHANGE_RATE_CHANGE_UPPER,
+            ALLOWED_EXCHANGE_RATE_CHANGE_LOWER,
+            MINIMUM_UPDATE_DELAY,
+            PLATFORM_FEE,
+            PERFORMANCE_FEE
+        );
+        accountantYS.setAuthority(rolesAuthorityYS);
+        
+        // Deploy teller with yield streaming
+        tellerYS = new TellerWithYieldStreaming(
+            owner,
+            address(vaultYS),
+            address(accountantYS),
+            address(weth)
+        );
+        tellerYS.setAuthority(rolesAuthorityYS);
+    }
+    
+    function _setupRoles() internal {
+        // ============================================
+        // RP SYSTEM ROLES
+        // ============================================
+        _setupRPRoles();
+        
+        // ============================================
+        // YS SYSTEM ROLES
+        // ============================================
+        _setupYSRoles();
+    }
+    
+    function _setupRPRoles() internal {
+        // VaultRP capabilities
+        rolesAuthorityRP.setRoleCapability(MINTER_ROLE, address(vaultRP), BoringVault.enter.selector, true);
+        rolesAuthorityRP.setRoleCapability(BURNER_ROLE, address(vaultRP), BoringVault.exit.selector, true);
+        rolesAuthorityRP.setRoleCapability(MANAGER_ROLE, address(vaultRP), bytes4(keccak256("manage(address,bytes,uint256)")), true);
+        rolesAuthorityRP.setRoleCapability(MANAGER_ROLE, address(vaultRP), bytes4(keccak256("manage(address[],bytes[],uint256[])")), true);
+        rolesAuthorityRP.setRoleCapability(OWNER_ROLE, address(vaultRP), BoringVault.setBeforeTransferHook.selector, true);
+        
+        // AccountantRP capabilities
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.pause.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.unpause.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.updateDelay.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.updateUpper.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.updateLower.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.updatePlatformFee.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.updatePerformanceFee.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.updatePayoutAddress.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.setRateProviderData.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(accountantRP), AccountantWithRateProviders.resetHighwaterMark.selector, true);
+        rolesAuthorityRP.setRoleCapability(UPDATE_EXCHANGE_RATE_ROLE, address(accountantRP), AccountantWithRateProviders.updateExchangeRate.selector, true);
+        rolesAuthorityRP.setRoleCapability(MINTER_ROLE, address(accountantRP), AccountantWithRateProviders.claimFees.selector, true);
+        
+        // TellerMAS capabilities
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.pause.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.unpause.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.updateAssetData.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.setShareLockPeriod.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.setDepositCap.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.denyAll.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.allowAll.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.denyFrom.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.allowFrom.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.denyTo.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.allowTo.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.denyOperator.selector, true);
+        rolesAuthorityRP.setRoleCapability(DENIER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.allowOperator.selector, true);
+        rolesAuthorityRP.setRoleCapability(ADMIN_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.refundDeposit.selector, true);
+        rolesAuthorityRP.setRoleCapability(SOLVER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.bulkDeposit.selector, true);
+        rolesAuthorityRP.setRoleCapability(SOLVER_ROLE, address(tellerMAS), TellerWithMultiAssetSupport.bulkWithdraw.selector, true);
+        rolesAuthorityRP.setPublicCapability(address(tellerMAS), TellerWithMultiAssetSupport.deposit.selector, true);
+        rolesAuthorityRP.setPublicCapability(address(tellerMAS), TellerWithMultiAssetSupport.depositWithPermit.selector, true);
+        rolesAuthorityRP.setPublicCapability(address(tellerMAS), TellerWithMultiAssetSupport.withdraw.selector, true);
+        
+        // Assign roles for RP system
+        rolesAuthorityRP.setUserRole(owner, OWNER_ROLE, true);
+        rolesAuthorityRP.setUserRole(owner, ADMIN_ROLE, true);
+        rolesAuthorityRP.setUserRole(owner, UPDATE_EXCHANGE_RATE_ROLE, true);
+        rolesAuthorityRP.setUserRole(owner, DENIER_ROLE, true);
+        rolesAuthorityRP.setUserRole(address(tellerMAS), MINTER_ROLE, true);
+        rolesAuthorityRP.setUserRole(address(tellerMAS), BURNER_ROLE, true);
+        rolesAuthorityRP.setUserRole(strategist, STRATEGIST_ROLE, true);
+        rolesAuthorityRP.setUserRole(solver, SOLVER_ROLE, true);
+        rolesAuthorityRP.setUserRole(address(vaultRP), MINTER_ROLE, true); // For fee claiming
+    }
+    
+    function _setupYSRoles() internal {
+        // VaultYS capabilities
+        rolesAuthorityYS.setRoleCapability(MINTER_ROLE, address(vaultYS), BoringVault.enter.selector, true);
+        rolesAuthorityYS.setRoleCapability(BURNER_ROLE, address(vaultYS), BoringVault.exit.selector, true);
+        rolesAuthorityYS.setRoleCapability(MANAGER_ROLE, address(vaultYS), bytes4(keccak256("manage(address,bytes,uint256)")), true);
+        rolesAuthorityYS.setRoleCapability(MANAGER_ROLE, address(vaultYS), bytes4(keccak256("manage(address[],bytes[],uint256[])")), true);
+        rolesAuthorityYS.setRoleCapability(OWNER_ROLE, address(vaultYS), BoringVault.setBeforeTransferHook.selector, true);
+        
+        // AccountantYS capabilities
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.pause.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.unpause.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.updateDelay.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.updateUpper.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.updateLower.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.updatePlatformFee.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.updatePerformanceFee.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.updatePayoutAddress.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.setRateProviderData.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(accountantYS), AccountantWithRateProviders.resetHighwaterMark.selector, true);
+        rolesAuthorityYS.setRoleCapability(STRATEGIST_ROLE, address(accountantYS), AccountantWithYieldStreaming.vestYield.selector, true);
+        rolesAuthorityYS.setRoleCapability(STRATEGIST_ROLE, address(accountantYS), AccountantWithYieldStreaming.postLoss.selector, true);
+        rolesAuthorityYS.setRoleCapability(STRATEGIST_ROLE, address(accountantYS), bytes4(keccak256("updateExchangeRate()")), true);
+        rolesAuthorityYS.setRoleCapability(MINTER_ROLE, address(accountantYS), AccountantWithYieldStreaming.setFirstDepositTimestamp.selector, true);
+        rolesAuthorityYS.setRoleCapability(MINTER_ROLE, address(accountantYS), AccountantWithRateProviders.claimFees.selector, true);
+        
+        // TellerYS capabilities
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(tellerYS), TellerWithMultiAssetSupport.pause.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(tellerYS), TellerWithMultiAssetSupport.unpause.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(tellerYS), TellerWithMultiAssetSupport.updateAssetData.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(tellerYS), TellerWithMultiAssetSupport.setShareLockPeriod.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(tellerYS), TellerWithMultiAssetSupport.setDepositCap.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.denyAll.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.allowAll.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.denyFrom.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.allowFrom.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.denyTo.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.allowTo.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.denyOperator.selector, true);
+        rolesAuthorityYS.setRoleCapability(DENIER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.allowOperator.selector, true);
+        rolesAuthorityYS.setRoleCapability(ADMIN_ROLE, address(tellerYS), TellerWithMultiAssetSupport.refundDeposit.selector, true);
+        rolesAuthorityYS.setRoleCapability(SOLVER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.bulkDeposit.selector, true);
+        rolesAuthorityYS.setRoleCapability(SOLVER_ROLE, address(tellerYS), TellerWithMultiAssetSupport.bulkWithdraw.selector, true);
+        rolesAuthorityYS.setPublicCapability(address(tellerYS), TellerWithMultiAssetSupport.deposit.selector, true);
+        rolesAuthorityYS.setPublicCapability(address(tellerYS), TellerWithMultiAssetSupport.depositWithPermit.selector, true);
+        rolesAuthorityYS.setPublicCapability(address(tellerYS), TellerWithMultiAssetSupport.withdraw.selector, true);
+        
+        // Assign roles for YS system
+        rolesAuthorityYS.setUserRole(owner, OWNER_ROLE, true);
+        rolesAuthorityYS.setUserRole(owner, ADMIN_ROLE, true);
+        rolesAuthorityYS.setUserRole(owner, DENIER_ROLE, true);
+        rolesAuthorityYS.setUserRole(address(tellerYS), MINTER_ROLE, true);
+        rolesAuthorityYS.setUserRole(address(tellerYS), BURNER_ROLE, true);
+        rolesAuthorityYS.setUserRole(address(tellerYS), STRATEGIST_ROLE, true); // For updateExchangeRate() calls in deposit/withdraw
+        rolesAuthorityYS.setUserRole(strategist, STRATEGIST_ROLE, true);
+        rolesAuthorityYS.setUserRole(solver, SOLVER_ROLE, true);
+        rolesAuthorityYS.setUserRole(address(vaultYS), MINTER_ROLE, true); // For fee claiming
+    }
+    
+    function _configureAssets() internal {
+        // ============================================
+        // RP System Asset Configuration
+        // ============================================
+        // Configure base asset for RP accountant
+        accountantRP.setRateProviderData(baseAsset, true, address(0));
+        
+        // Configure ALL alternative assets with their rate providers (multi-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            accountantRP.setRateProviderData(
+                alternativeAssets[i], 
+                false, 
+                address(altAssetRateProviders[i])
+            );
+            // Allow deposits/withdraws for each alternative asset
+            tellerMAS.updateAssetData(alternativeAssets[i], true, true, 0);
+        }
+        
+        // Allow deposits/withdraws for base asset
+        tellerMAS.updateAssetData(baseAsset, true, true, 0);
+        tellerMAS.setShareLockPeriod(SHARE_LOCK_PERIOD);
+        vaultRP.setBeforeTransferHook(address(tellerMAS));
+        
+        // ============================================
+        // YS System Asset Configuration
+        // ============================================
+        // Configure base asset for YS accountant (YS only uses base asset)
+        accountantYS.setRateProviderData(baseAsset, true, address(0));
+        
+        // Allow deposits/withdraws for base asset only
+        tellerYS.updateAssetData(baseAsset, true, true, 0);
+        tellerYS.setShareLockPeriod(SHARE_LOCK_PERIOD);
+        vaultYS.setBeforeTransferHook(address(tellerYS));
+    }
+    
+    function _fundActors() internal {
+        uint256 fundAmount = INITIAL_MINT;
+        
+        // Fund actors with base asset (enough for both systems)
+        baseAsset.mint(user1, fundAmount * 2);
+        baseAsset.mint(user2, fundAmount * 2);
+        baseAsset.mint(user3, fundAmount * 2);
+        baseAsset.mint(solver, fundAmount * 2);
+        baseAsset.mint(deniedUser, fundAmount);
+        
+        // Fund actors with ALL alternative assets (for RP system multi-asset)
+        // Amount is scaled by decimals: 1_000_000 tokens in each asset's native decimals
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            uint256 altFundAmount = 1_000_000 * (10 ** ALT_ASSET_DECIMALS[i]);
+            alternativeAssets[i].mint(user1, altFundAmount);
+            alternativeAssets[i].mint(user2, altFundAmount);
+            alternativeAssets[i].mint(user3, altFundAmount);
+            alternativeAssets[i].mint(solver, altFundAmount);
+        }
+        
+        // Fund RP vault with initial assets for withdrawals (all alternative assets)
+        baseAsset.mint(address(vaultRP), fundAmount);
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            uint256 altFundAmount = 1_000_000 * (10 ** ALT_ASSET_DECIMALS[i]);
+            alternativeAssets[i].mint(address(vaultRP), altFundAmount);
+        }
+        
+        // Fund YS vault with base asset only
+        baseAsset.mint(address(vaultYS), fundAmount);
+        
+        // Give ETH to actors
+        vm.deal(user1, 100 ether);
+        vm.deal(user2, 100 ether);
+        vm.deal(user3, 100 ether);
+        vm.deal(solver, 100 ether);
+    }
+    
+}
+

--- a/test/fuzzing/BoringVault_Invariant_Documentation.md
+++ b/test/fuzzing/BoringVault_Invariant_Documentation.md
@@ -1,0 +1,2485 @@
+# BoringVault Fuzzing Invariant Suite - Comprehensive Documentation
+
+This document provides an exhaustive explanation of all 47 invariants implemented in the BoringVault Foundry Invariant Test Suite. Each invariant includes:
+- **Description**: What the invariant verifies
+- **Mathematical Formula**: The precise mathematical relationship being checked
+- **Source Contract Code**: The relevant code from the source contracts
+- **Invariant Test Code**: The implementation in the modular test suite
+
+---
+
+## Architecture Overview
+
+The fuzzing suite uses a **modular, inheritance-based architecture** to test two independent accounting systems:
+
+### Systems Under Test
+| System | Accountant | Teller | Vault | Assets |
+|--------|-----------|--------|-------|--------|
+| **Rate Provider (RP)** | `AccountantWithRateProviders` | `TellerWithMultiAssetSupport` | `vaultRP` | Base + 5 alternative assets |
+| **Yield Streaming (YS)** | `AccountantWithYieldStreaming` | `TellerWithYieldStreaming` | `vaultYS` | Base asset only |
+
+### N-Asset Support (RP System)
+The Rate Provider system supports **N alternative assets** (configured to 5 by default via `NUM_ALT_ASSETS`). Each alternative asset has its own:
+- `MockERC20Extended` token instance with configurable decimals
+- `MockRateProvider` for exchange rate conversion (always returns 18-decimal rates)
+- Handler functions parameterized by asset index (e.g., `depositAltMAS(uint256 assetIndex, ...)`)
+
+#### Decimal Diversity
+Alternative assets are configured with varying decimals to simulate real-world tokens:
+
+| Index | Decimals | Simulates | Initial Rate |
+|-------|----------|-----------|--------------|
+| 0 | 18 | Standard ERC20 (WETH, DAI) | 1e18 (1.0) |
+| 1 | 6 | USDC | 9e5 (0.9) |
+| 2 | 6 | USDT | 1.1e6 (1.1) |
+| 3 | 8 | WBTC | 8e7 (0.8) |
+| 4 | 11 | Edge case testing | 1.2e11 (1.2) |
+
+**Critical: Rate Provider Decimals**
+
+Rate providers must return rates in the **QUOTE token's decimals**, not 18 decimals. This is required by the `getRateInQuote` formula:
+
+```solidity
+rateInQuote = oneQuote.mulDivDown(exchangeRateInQuoteDecimals, quoteRate);
+// where oneQuote = 10 ** quoteDecimals
+```
+
+For a 6-decimal asset at 1:1 with base, the rate should be `1e6`, not `1e18`.
+
+This configuration is defined in `BaseSetup.sol`:
+```solidity
+uint8[5] public ALT_ASSET_DECIMALS = [18, 6, 6, 8, 11];
+```
+
+The Yield Streaming system remains **base-asset-only** as per its design.
+
+### File Structure
+```
+test/fuzzing/
+├── BaseSetup.sol              # Shared setup for both systems
+├── InvariantTestRP.sol        # RP system test contract (concrete)
+├── InvariantTestYS.sol        # YS system test contract (concrete)
+├── handlers/
+│   ├── AccountantHandler.sol  # Handles both accountant types
+│   └── TellerHandler.sol      # Handles both teller types
+├── invariants/
+│   ├── BaseInvariants.sol     # 31 shared invariants (abstract)
+│   └── YSOnlyInvariants.sol   # 16 YS-specific invariants (abstract)
+├── mocks/
+│   ├── MockERC20Extended.sol
+│   ├── MockRateProvider.sol
+│   └── MockWETH.sol
+└── FUZZING_NOTES.md           # Findings & violations log
+```
+
+### Inheritance Chain
+```
+Test (forge-std)
+  ↑
+StdInvariant (forge-std)
+  ↑
+BaseSetup (deploys both systems)
+  ↑
+BaseInvariants (31 shared invariants - abstract)
+  ↑
+├── InvariantTestRP (implements abstract getters for RP)
+└── YSOnlyInvariants (16 YS-only invariants - abstract)
+      ↑
+      └── InvariantTestYS (implements abstract getters for YS)
+```
+
+### Running Tests
+```bash
+# RP system only
+forge test --match-contract InvariantTestRP -vv
+
+# YS system only  
+forge test --match-contract InvariantTestYS -vv
+
+# Both systems
+forge test --match-path "test/fuzzing/Invariant*.sol" -vv
+
+# With custom depth (default is 15 in foundry.toml)
+FOUNDRY_INVARIANT_DEPTH=64 forge test --match-contract InvariantTestRP -vv
+
+# With Medusa (alternative fuzzer)
+medusa fuzz --config medusa.json
+```
+
+### Handler Functions (N-Asset Support)
+
+The handlers expose parameterized functions for operating on specific alternative assets:
+
+| Handler | Function | Signature | Description |
+|---------|----------|-----------|-------------|
+| `AccountantHandler` | `setAltAssetRate` | `(uint256 assetIndex, uint256 newRate)` | Set rate for alt asset at index |
+| `TellerHandler` | `depositAltMAS` | `(uint256 assetIndex, uint256 amount, ...)` | Deposit specific alt asset |
+| `TellerHandler` | `withdrawAltMAS` | `(uint256 assetIndex, uint256 shares, ...)` | Withdraw specific alt asset |
+
+The `assetIndex` parameter (0 to `NUM_ALT_ASSETS-1`) selects which alternative asset to operate on.
+
+#### Deposit Tracking Requirements
+
+All deposit handlers only track deposits that actually mint shares. When tiny amounts are deposited with a `sharePremium > 0`, the share calculation can round down to zero. These 0-share deposits are not tracked to avoid false positives in `invariant_integrityOfDeposit`:
+
+```solidity
+try teller.deposit(asset, amount, minShares, address(0)) returns (uint256 shares) {
+    // Only track deposits that actually minted shares
+    if (shares > 0) {
+        depositCalls++;
+        lastDepositAssets = amount;
+        lastDepositShares = shares;
+    }
+} catch {}
+```
+
+#### Withdrawal Minimum Asset Requirements
+
+All withdrawal handlers enforce `minAssets >= 1` to reflect realistic user behavior. No rational user would accept 0 tokens in exchange for burning shares. This prevents the protocol from allowing withdrawals where rate calculations round to zero due to decimal precision differences.
+
+For low-decimal assets (e.g., 6 decimals), the handler also enforces a minimum share amount:
+```solidity
+// Calculate minimum shares to produce at least 1 token output
+uint256 minShareAmount = assetDecimals < 18 
+    ? 10 ** (18 - assetDecimals)  // e.g., 1e12 for 6-decimal asset
+    : 1;
+```
+
+#### Handler Error Handling Strategy
+
+All TellerHandler deposit/withdraw functions use **smart error handling** that distinguishes between expected and unexpected reverts:
+
+```solidity
+try teller.deposit(...) returns (uint256 shares) {
+    if (shares > 0) { depositCalls++; /* ... */ }
+} catch (bytes memory reason) {
+    if (!_isExpectedRevert(reason)) {
+        // Unexpected - propagate it!
+        assembly { revert(add(reason, 32), mload(reason)) }
+    }
+    // Expected - skip silently
+}
+```
+
+**Expected errors (silently skipped):**
+| Error | Reason |
+|-------|--------|
+| `TellerWithMultiAssetSupport__Paused()` | Teller is paused |
+| `TellerWithMultiAssetSupport__AssetNotSupported()` | Asset not configured |
+| `TellerWithMultiAssetSupport__SharesAreLocked()` | Time lock not elapsed |
+| `TellerWithMultiAssetSupport__DepositExceedsCap()` | Cap reached |
+| `TellerWithMultiAssetSupport__MinimumMintNotMet()` | Slippage check |
+| `TellerWithMultiAssetSupport__MinimumAssetsNotMet()` | Slippage check |
+| `TellerWithMultiAssetSupport__TransferDenied()` | User on deny list |
+| `AccountantWithRateProviders__Paused()` | Accountant paused |
+
+**Unexpected errors (propagated):**
+Any error NOT in the expected list is considered a potential bug and will fail the test. This ensures we catch real protocol issues while ignoring state-based rejections.
+
+---
+
+## Table of Contents
+
+### Group 1: Accountant Common Logic (Rules 1-7) - BaseInvariants.sol
+- [Rule 1: accountantDoesntHoldTokens](#rule-1-accountantdoesntholdtokens)
+- [Rule 2: accountantPaused_valuesFrozen](#rule-2-accountantpaused_valuesfrozen)
+- [Rule 3: feesCanOnlyDecreaseViaClaimFees](#rule-3-feescanonlydecreaseviaclaimfees)
+- [Rule 4: highwaterMarkNeverDecreases](#rule-4-highwatermarkneverdecreases)
+- [Rule 5: lastUpdateTimestampNeverDecreases](#rule-5-lastupdatetimestampneverdecreases)
+- [Rule 6: allowedExchangeRateChangeBounds](#rule-6-allowedexchangeratechangebounds)
+- [Rule 7: exchangeRateLEhighwaterMark](#rule-7-exchangeratele-highwatermark)
+
+### Group 2: Accountant Yield Specific (16 invariants) - YSOnlyInvariants.sol
+- [Rule 8: cumulativeSupplyBounded](#rule-8-cumulativesupplybounded)
+- [Rule 9: exchangeRateEqlastSharePrice](#rule-9-exchangerateeqlastshareprice)
+- [Rule 10: sharePriceBoundedUpper](#rule-10-sharepriceboundedupper)
+- [Rule 11: sharePriceBoundedLower](#rule-11-sharepriceboundedlower)
+- [Rule 12: sharePriceMoreThanOne](#rule-12-sharepricemoreThanone)
+- [Rule 13: totalAssetsCovered](#rule-13-totalassetscovered)
+- [Rule 14: startVestingTimeLEendVestingTime](#rule-14-startvestingtimeleendvestingtime)
+- [Rule 15: vestingGainsIntegrity](#rule-15-vestinggainsintegrity)
+- [Rule 16: lastVestingUpdateNeverDecreases](#rule-16-lastvestingupdateneverdecreases)
+- [Rule 17: integrityOfVestYield](#rule-17-integrityofvestyield)
+- [Rule 18: exchangeRatePostLoss](#rule-18-exchangeratepostloss)
+- [Rule 19: vaultSolvency_1Asset_Vesting](#rule-19-vaultsolvency_1asset_vesting)
+- [Rule 20: yieldIntegrity](#rule-20-yieldintegrity)
+- [Rule 21: yieldAccrualsMonotonic](#rule-21-yieldaccrualsmonotonic)
+- [Rule 22: streamingRateConsistency](#rule-22-streamingrateconsistency)
+- [Rule 23: accessControlYieldParams](#rule-23-accesscontrolyieldparams)
+
+### Group 3: Teller & Vault Integrity (14 invariants) - BaseInvariants.sol
+- [Rule 24: integrityOfDeposit](#rule-24-integrityofdeposit)
+- [Rule 25: integrityOfWithdraw](#rule-25-integrityofwithdraw)
+- [Rule 26: noFreeAssets](#rule-26-nofreeassets)
+- [Rule 27: tellerDoesntHoldTokens](#rule-27-tellerdoesntholdtokens)
+- [Rule 28: vaultCannotChange](#rule-28-vaultcannotchange)
+- [Rule 29: depositNonceNeverGoesDown](#rule-29-depositnoncenevergoesdown)
+- [Rule 30: tellerPaused_valuesFrozen](#rule-30-tellerpaused_valuesfrozen)
+- [Rule 31: tellerPaused_methodsRevert](#rule-31-tellerpaused_methodsrevert)
+- [Rule 32: dustFavorsTheHouse](#rule-32-dustfavorsthehouse)
+- [Rule 33: noDynamicCalls](#rule-33-nodynamiccalls)
+- [Rule 34: onlyContributionMethodsReduceAssets](#rule-34-onlycontributionmethodsreduceassets)
+- [Rule 35: withdrawingProducesAssets](#rule-35-withdrawingproducesassets)
+- [Rule 36: feesIntegrity](#rule-36-feesintegrity)
+- [Rule 37: deniedUsers_balanceNonDecreasing](#rule-37-deniedusers_balancenondecreasing)
+- [Rule 38: deniedUsers_balanceNonIncreasing](#rule-38-deniedusers_balancenonincreasing)
+
+### Group 4: Math & Solvency (9 invariants) - BaseInvariants.sol
+- [Rule 39: vaultSolvencyMulti](#rule-39-vaultsolvencymulti)
+- [Rule 40: vaultSolvency_1Asset](#rule-40-vaultsolvency_1asset)
+- [Rule 41: convertToAssetsWeakAdditivity](#rule-41-converttoassetsweakadditivity)
+- [Rule 42: convertToSharesWeakAdditivity](#rule-42-converttosharesweakadditivity)
+- [Rule 43: conversionWeakMonotonicity](#rule-43-conversionweakmonotonicity)
+- [Rule 44: conversionWeakIntegrity](#rule-44-conversionweakintegrity)
+- [Rule 45: zeroAllowanceOnAssets](#rule-45-zeroallowanceonassets)
+- [Rule 46: conversionOfZero](#rule-46-conversionofzero)
+- [Rule 47: totalSupplyLEqCap](#rule-47-totalsupplyleqcap)
+
+---
+
+## Group 1: Accountant Common Logic (Rules 1-8)
+
+### Rule 1: accountantDoesntHoldTokens
+
+**Description**: The Accountant contracts should never hold any tokens. They act as pass-through entities for rate calculations and fee management. The payout address must also not be the accountant itself.
+
+**Assumption**: `payoutAddress != accountant`
+
+**Goal**: Ensure the Accountant is a pass-through and never retains user assets.
+
+**Mathematical Formula**:
+```
+∀ asset ∈ {baseAsset, alternativeAssets[0..N-1]}:
+    balanceOf(accountant, asset) == 0
+
+payoutAddress ≠ address(accountant)
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+struct AccountantState {
+    address payoutAddress;        // Line 37
+    uint96 highwaterMark;
+    uint128 feesOwedInBase;
+    // ...
+}
+
+// Fees are transferred FROM the vault TO the payout address
+// Lines 338-339
+feeAsset.safeTransferFrom(msg.sender, state.payoutAddress, feesOwedInFeeAsset);
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_accountantDoesntHoldTokens() public view {
+    address acc = address(_accountant());
+    
+    assertEq(
+        baseAsset.balanceOf(acc),
+        0,
+        "Invariant 1: Accountant should not hold base tokens"
+    );
+    
+    // Check ALL alternative assets (N-asset support)
+    for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+        assertEq(
+            alternativeAssets[i].balanceOf(acc),
+            0,
+            "Invariant 1: Accountant should not hold alt tokens"
+        );
+    }
+
+    (address payout,,,,,,,,,,, ) = _accountant().accountantState();
+    assertTrue(payout != acc, "Invariant 1: Payout should not be Accountant");
+}
+```
+
+---
+
+### Rule 2: accountantPaused_valuesFrozen
+
+**Description**: When the Accountant is paused, the exchange rate and fees should remain frozen. State changes are blocked during emergency pauses.
+
+**Assumption**: Excludes `resetHighwaterMark` which can still be called when paused.
+
+**Goal**: Prevent state changes during emergency pauses.
+
+**Mathematical Formula**:
+```
+paused ∧ selector ≠ resetHighwaterMark ⟹ 
+    (rate_post == rate_pre) ∧ (fees_post == fees_pre)
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 160-163: pause() sets isPaused = true
+function pause() external requiresAuth {
+    accountantState.isPaused = true;
+    emit Paused();
+}
+
+// Line 284-305: updateExchangeRate reverts if paused
+function updateExchangeRate(uint96 newExchangeRate) external virtual requiresAuth {
+    (
+        bool shouldPause,
+        AccountantState storage state,
+        // ...
+    ) = _beforeUpdateExchangeRate(newExchangeRate);
+    // ...
+}
+
+// Line 467: _beforeUpdateExchangeRate reverts when paused
+function _beforeUpdateExchangeRate(uint96 newExchangeRate) internal view returns (...) {
+    state = accountantState;
+    if (state.isPaused) revert AccountantWithRateProviders__Paused();
+    // ...
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_accountantPaused_valuesFrozen() public view {
+    AccountantHandler.RPState memory pre = _getPreState();
+    AccountantHandler.RPState memory post = _getPostState();
+    bytes4 selector = _accountantHandler().lastSelector();
+
+    if (pre.isPaused && selector != AccountantWithRateProviders.resetHighwaterMark.selector) {
+        assertEq(
+            post.feesOwedInBase,
+            pre.feesOwedInBase,
+            "Invariant 2: Fees should be frozen when paused"
+        );
+    }
+}
+```
+
+---
+
+### Rule 3: feesCanOnlyDecreaseViaClaimFees
+
+**Description**: The accumulated fees (`feesOwedInBase`) can only decrease when the `claimFees` function is called. This ensures fees are monotonically increasing except during authorized claims.
+
+**Goal**: Ensure fees are monotonic and only reduced by authorized claims.
+
+**Mathematical Formula**:
+```
+fees_post < fees_pre ⟹ selector == claimFees
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 313-342: claimFees is the ONLY function that decreases feesOwedInBase
+function claimFees(ERC20 feeAsset) external {
+    if (msg.sender != address(vault)) revert AccountantWithRateProviders__OnlyCallableByBoringVault();
+
+    AccountantState storage state = accountantState;
+    if (state.isPaused) revert AccountantWithRateProviders__Paused();
+    if (state.feesOwedInBase == 0) revert AccountantWithRateProviders__ZeroFeesOwed();
+
+    // ... calculate feesOwedInFeeAsset ...
+    
+    // Line 337: Zero out fees owed (DECREASE)
+    state.feesOwedInBase = 0;
+    // Transfer fee asset to payout address.
+    feeAsset.safeTransferFrom(msg.sender, state.payoutAddress, feesOwedInFeeAsset);
+}
+
+// Line 570: _calculateFeesOwed only INCREASES fees
+state.feesOwedInBase += uint128(newFeesOwedInBase);
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_feesCanOnlyDecreaseViaClaimFees() public view {
+    AccountantHandler.RPState memory pre = _getPreState();
+    AccountantHandler.RPState memory post = _getPostState();
+    bytes4 selector = _accountantHandler().lastSelector();
+
+    if (post.feesOwedInBase < pre.feesOwedInBase) {
+        assertEq(
+            selector,
+            AccountantWithRateProviders.claimFees.selector,
+            "Invariant 3: Fees should only decrease via claimFees"
+        );
+    }
+}
+```
+
+---
+
+### Rule 4: highwaterMarkNeverDecreases
+
+**Description**: The highwater mark (the peak exchange rate ever recorded) should never decrease, except when explicitly reset via `resetHighwaterMark`.
+
+**Assumption**: Excludes `resetHighwaterMark`
+
+**Goal**: Maintain integrity of the performance fee baseline.
+
+**Mathematical Formula**:
+```
+selector ≠ resetHighwaterMark ⟹ HWM_post ≥ HWM_pre
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 564-567: In _calculateFeesOwed, HWM is only updated upward
+if (newExchangeRate > state.highwaterMark) {
+    // ... calculate performance fees ...
+    // Always update the highwater mark if the new exchange rate is higher.
+    state.highwaterMark = newExchangeRate;
+}
+
+// Line 259-274: resetHighwaterMark is the only way to DECREASE HWM
+function resetHighwaterMark() external virtual requiresAuth {
+    AccountantState storage state = accountantState;
+
+    if (state.exchangeRate > state.highwaterMark) {
+        revert AccountantWithRateProviders__ExchangeRateAboveHighwaterMark();
+    }
+    // ...
+    state.highwaterMark = accountantState.exchangeRate; // Can be lower than previous HWM
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_highwaterMarkNeverDecreases() public view {
+    AccountantHandler.RPState memory pre = _getPreState();
+    AccountantHandler.RPState memory post = _getPostState();
+    bytes4 selector = _accountantHandler().lastSelector();
+
+    if (selector != AccountantWithRateProviders.resetHighwaterMark.selector) {
+        assertGe(
+            post.highwaterMark,
+            pre.highwaterMark,
+            "Invariant 4: Highwater mark should never decrease"
+        );
+    }
+}
+```
+
+---
+
+### Rule 5: lastUpdateTimestampNeverDecreases
+
+**Description**: The `lastUpdateTimestamp` should only move forward in time, never backward. This ensures linear time progression for yield calculations.
+
+**Goal**: Ensure linear time progression for yield calculations.
+
+**Mathematical Formula**:
+```
+timestamp_post ≥ timestamp_pre
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 302: In updateExchangeRate, timestamp is always set to current time
+state.lastUpdateTimestamp = currentTime;
+
+// Line 468: currentTime is always block.timestamp
+currentTime = uint64(block.timestamp);
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_lastUpdateTimestampNeverDecreases() public view {
+    AccountantHandler.RPState memory pre = _getPreState();
+    AccountantHandler.RPState memory post = _getPostState();
+
+    assertGe(
+        post.lastUpdateTimestamp,
+        pre.lastUpdateTimestamp,
+        "Invariant 5: Timestamp should never decrease"
+    );
+}
+```
+
+---
+
+### Rule 6: allowedExchangeRateChangeBounds
+
+**Description**: The exchange rate change bounds must maintain sanity: `allowedExchangeRateChangeUpper >= 10000` (100%) and `allowedExchangeRateChangeLower <= 10000` (100%). This prevents misconfiguration of the rate provider.
+
+**Goal**: Sanity check on the rate provider configuration.
+
+**Mathematical Formula**:
+```
+upper ≥ 10000 (100%)
+lower ≤ 10000 (100%)
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 192-197: updateUpper enforces minimum
+function updateUpper(uint16 allowedExchangeRateChangeUpper) external requiresAuth {
+    if (allowedExchangeRateChangeUpper < 1e4) revert AccountantWithRateProviders__UpperBoundTooSmall();
+    uint16 oldBound = accountantState.allowedExchangeRateChangeUpper;
+    accountantState.allowedExchangeRateChangeUpper = allowedExchangeRateChangeUpper;
+}
+
+// Line 203-208: updateLower enforces maximum
+function updateLower(uint16 allowedExchangeRateChangeLower) external requiresAuth {
+    if (allowedExchangeRateChangeLower > 1e4) revert AccountantWithRateProviders__LowerBoundTooLarge();
+    uint16 oldBound = accountantState.allowedExchangeRateChangeLower;
+    accountantState.allowedExchangeRateChangeLower = allowedExchangeRateChangeLower;
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_allowedExchangeRateChangeBounds() public view {
+    (, , , , , uint16 upper, uint16 lower, , , , , ) = _accountant().accountantState();
+
+    assertGe(upper, 10000, "Invariant 6: Upper bound should be >= 100%");
+    assertLe(lower, 10000, "Invariant 6: Lower bound should be <= 100%");
+}
+```
+
+---
+
+### Rule 7: exchangeRateLEhighwaterMark
+
+**Description**: When the system is not paused, the exchange rate should never exceed the highwater mark. This is checked specifically after `updateExchangeRate` calls.
+
+**Note**: The protocol allows rate updates while paused that may exceed HWM. When unpaused without a fresh rate update, rate may temporarily exceed HWM. This is expected protocol behavior.
+
+**Goal**: Ensure the current rate never exceeds the peak recorded rate when active.
+
+**Mathematical Formula**:
+```
+!paused ∧ selector == updateExchangeRate ⟹ exchangeRate ≤ highwaterMark
+```
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 564-568: When rate exceeds HWM, HWM is updated to match
+if (newExchangeRate > state.highwaterMark) {
+    (uint256 performanceFeesOwedInBase,) =
+        _calculatePerformanceFee(newExchangeRate, shareSupplyToUse, state.highwaterMark, state.performanceFee);
+    newFeesOwedInBase += performanceFeesOwedInBase;
+    // Always update the highwater mark if the new exchange rate is higher.
+    state.highwaterMark = newExchangeRate;
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_exchangeRateLEhighwaterMark() public view {
+    bytes4 selector = _accountantHandler().lastSelector();
+    
+    // Only check after updateExchangeRate calls
+    if (selector != AccountantWithRateProviders.updateExchangeRate.selector) {
+        return;
+    }
+    
+    (, uint96 hwm, , , uint96 rate, , , , bool paused, , , ) = _accountant().accountantState();
+    
+    if (!paused) {
+        assertLe(rate, hwm, "Invariant 7: Exchange rate should be <= highwater mark when not paused");
+    }
+}
+```
+
+---
+
+### Rule 8: cumulativeSupplyBounded
+
+**Description**: The cumulative supply tracking maintains monotonicity: `cumulativeSupplyLast <= cumulativeSupply`. This is used for TWAS (Time-Weighted Average Supply) calculations.
+
+**Goal**: Verify monotonicity of tracked supply history.
+
+**Mathematical Formula**:
+```
+supplyObservation.cumulativeSupplyLast ≤ supplyObservation.cumulativeSupply
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 34-38: SupplyObservation struct
+struct SupplyObservation {
+    uint256 cumulativeSupply;
+    uint256 cumulativeSupplyLast;
+    uint256 lastUpdateTimestamp;
+}
+
+// Line 477-487: _updateCumulative only increases cumulativeSupply
+function _updateCumulative() internal {
+    uint256 currentTime = block.timestamp;
+    uint256 timeElapsed = currentTime - supplyObservation.lastUpdateTimestamp;
+
+    if (timeElapsed > 0) {
+        // cumulativeSupply always INCREASES
+        supplyObservation.cumulativeSupply += vault.totalSupply() * timeElapsed;
+        supplyObservation.lastUpdateTimestamp = currentTime;
+    }
+}
+
+// Line 179: cumulativeSupplyLast is set FROM cumulativeSupply
+supplyObservation.cumulativeSupplyLast = supplyObservation.cumulativeSupply;
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_cumulativeSupplyBounded() public view {
+    (uint256 cumSupply, uint256 cumSupplyLast, ) = _accountantYS().supplyObservation();
+    
+    assertGe(cumSupply, cumSupplyLast, "Invariant 8: Cumulative supply last should be <= cumulative supply");
+}
+```
+
+---
+
+## Group 2: Accountant Yield Specific (Rules 8-23)
+
+### Rule 9: exchangeRateEqlastSharePrice
+
+**Description**: For the Yield Streaming Accountant, the `exchangeRate` in `accountantState` should equal `lastSharePrice` in `vestingState` after sync operations (`vestYield`, `postLoss`, `updateExchangeRate`).
+
+**Note**: This sync only happens during `_collectFees()` which is called by these operations.
+
+**Goal**: Maintain synchronization between the public rate and internal vesting state.
+
+**Mathematical Formula**:
+```
+!paused ∧ isSyncOp ∧ lastSharePrice ≤ type(uint96).max ⟹ 
+    exchangeRate == uint96(lastSharePrice)
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 492-504: _collectFees syncs the values
+function _collectFees() internal {
+    AccountantState storage state = accountantState;
+    uint256 currentTotalShares = vault.totalSupply();
+    uint64 currentTime = uint64(block.timestamp);
+
+    _calculateFeesOwed(
+        state, uint96(vestingState.lastSharePrice), state.exchangeRate, currentTotalShares, currentTime
+    );
+
+    // Line 502: exchangeRate is set FROM lastSharePrice
+    state.exchangeRate = uint96(vestingState.lastSharePrice);
+    state.lastUpdateTimestamp = currentTime;
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_exchangeRateEqlastSharePrice() public view {
+    (, , , , uint96 rate, , , , bool isPaused, , , ) = _accountantYS().accountantState();
+    (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+
+    if (isPaused) return;
+
+    bytes4 selector = _accountantHandler().lastSelector();
+    bool isSyncOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                    selector == AccountantWithYieldStreaming.postLoss.selector ||
+                    selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+    
+    if (!isSyncOp) return;
+
+    if (lastSharePrice <= type(uint96).max) {
+        assertEq(rate, uint96(lastSharePrice), "Invariant 9: Exchange rate should equal last share price");
+    }
+}
+```
+
+---
+
+### Rule 10: sharePriceBoundedUpper
+
+**Description**: The share price (from `getRate()`) multiplied by total supply should not exceed total assets plus a 1-wei rounding buffer.
+
+**Important**: Must use `getRate()` instead of `lastSharePrice` because `lastSharePrice` does NOT include pending vesting gains, but `totalAssets()` does.
+
+**Goal**: Prevent share price inflation beyond available assets.
+
+**Mathematical Formula**:
+```
+getRate() × totalSupply / ONE_SHARE ≤ totalAssets + 1
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 339-345: getRate includes pending gains via totalAssets
+function getRate() public view override returns (uint256 rate) {
+    uint256 currentShares = vault.totalSupply();
+    if (currentShares == 0) {
+        return rate = vestingState.lastSharePrice;
+    }
+    rate = totalAssets().mulDivDown(ONE_SHARE, currentShares);
+}
+
+// Line 414-417: totalAssets includes pending gains
+function totalAssets() public view returns (uint256) {
+    uint256 currentShares = vault.totalSupply();
+    return uint256(vestingState.lastSharePrice).mulDivDown(currentShares, ONE_SHARE) + getPendingVestingGains();
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_sharePriceBoundedUpper() public view {
+    if (_isAccountantYSPaused()) return;
+    
+    uint256 totalSupply = _vault().totalSupply();
+
+    if (totalSupply > 0) {
+        uint256 rate = _accountantYS().getRate();
+        uint256 totalAssets = _accountantYS().totalAssets();
+        
+        uint256 lhs = rate.mulDivUp(totalSupply, ONE_SHARE);
+        assertLe(lhs, totalAssets + 1, "Invariant 10: Share price upper bound violated");
+    }
+}
+```
+
+---
+
+### Rule 11: sharePriceBoundedLower
+
+**Description**: The share price (from `getRate()`) multiplied by total supply should be at least equal to total assets (minus a small tolerance for rounding).
+
+**Important**: Must use `getRate()` instead of `lastSharePrice` because `getRate() = totalAssets().mulDivDown(ONE_SHARE, currentShares)` properly accounts for pending vesting gains.
+
+**Goal**: Ensure the share price accurately represents the asset floor.
+
+**Mathematical Formula**:
+```
+getRate() × totalSupply / ONE_SHARE + tolerance ≥ totalAssets
+
+where tolerance = max(totalAssets / 1e6, 1)
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 339-345: getRate is derived from totalAssets
+function getRate() public view override returns (uint256 rate) {
+    uint256 currentShares = vault.totalSupply();
+    if (currentShares == 0) {
+        return rate = vestingState.lastSharePrice;
+    }
+    rate = totalAssets().mulDivDown(ONE_SHARE, currentShares);
+}
+
+// Line 414-417: totalAssets = principal + pendingVestingGains
+function totalAssets() public view returns (uint256) {
+    uint256 currentShares = vault.totalSupply();
+    return uint256(vestingState.lastSharePrice).mulDivDown(currentShares, ONE_SHARE) + getPendingVestingGains();
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_sharePriceBoundedLower() public view {
+    if (_isAccountantYSPaused()) return;
+    
+    uint256 totalSupply = _vault().totalSupply();
+
+    if (totalSupply > 0) {
+        uint256 rate = _accountantYS().getRate();
+        uint256 totalAssets = _accountantYS().totalAssets();
+        
+        uint256 lhs = rate.mulDivDown(totalSupply, ONE_SHARE);
+        
+        uint256 tolerance = totalAssets / 1e6;
+        if (tolerance == 0) tolerance = 1;
+        
+        assertGe(lhs + tolerance, totalAssets, "Invariant 11: Share price lower bound violated");
+    }
+}
+```
+
+---
+
+### Rule 12: sharePriceMoreThanOne
+
+**Description**: The share price should remain non-zero. Originally intended to verify a minimum floor of 1.0 per share, but this is NOT a strict invariant because `postLoss` can legitimately reduce the share price below any specific floor.
+
+**Note**: This is a relaxed check - losses via `postLoss` can legitimately reduce rate below any floor.
+
+**Goal**: Verify share price is non-zero (minimal sanity check).
+
+**Mathematical Formula**:
+```
+getRate() > 0
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 199-244: postLoss can reduce share price significantly
+function postLoss(uint256 lossAmount) external requiresAuth {
+    // ...
+    uint256 principalLoss = lossAmount - vestingState.vestingGains;
+    vestingState.vestingGains = 0;
+    
+    // Line 222-223: Share price is REDUCED (potentially below 1.0)
+    vestingState.lastSharePrice =
+        uint128((totalAssets() - principalLoss).mulDivDown(ONE_SHARE, currentShares));
+    // ...
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_sharePriceMoreThanOne() public view {
+    if (_isAccountantYSPaused()) return;
+    if (_vault().totalSupply() == 0) return;
+
+    uint256 rate = _accountantYS().getRate();
+    uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+    
+    if (vaultBalance > 0) {
+        assertGt(rate, 0, "Invariant 12: Share price should be non-zero when assets exist");
+    }
+}
+```
+
+---
+
+### Rule 13: totalAssetsCovered
+
+**Description**: The accountant's reported `totalAssets` should not exceed the actual vault balance of the base asset.
+
+**Note**: 
+- Exempt if `downCastOverflow` occurred
+- **Only valid in single-asset scenarios** - when alternative assets are deposited via `depositAltMAS`, this check is skipped because `totalAssets` is calculated from `shares × rate` which may differ from actual vault holdings due to rate provider changes.
+
+**Goal**: Prevent the Accountant from "phantomizing" assets not held in the vault.
+
+**Mathematical Formula**:
+```
+(altBalance ≤ INITIAL_MINT) ⟹ accountant.totalAssets() ≤ vault.balanceOf(baseAsset) + tolerance
+
+where tolerance = max(totalAssets / 10000, 1)
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 414-417: totalAssets is calculated from shares × price + pending gains
+function totalAssets() public view returns (uint256) {
+    uint256 currentShares = vault.totalSupply();
+    return uint256(vestingState.lastSharePrice).mulDivDown(currentShares, ONE_SHARE) + getPendingVestingGains();
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_totalAssetsCovered() public view {
+    if (_isAccountantYSPaused()) return;
+    if (_accountantHandler().feesRecentlyClaimed()) return;
+
+    uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+    uint256 totalAssets = _accountantYS().totalAssets();
+    
+    uint256 tolerance = totalAssets / 10000;
+    if (tolerance == 0) tolerance = 1;
+    
+    assertLe(
+        totalAssets,
+        vaultBalance + tolerance,
+        "Invariant 13: Total assets should be covered by vault balance"
+    );
+}
+```
+
+---
+
+### Rule 14: startVestingTimeLEendVestingTime
+
+**Description**: The vesting start time must always be less than or equal to the vesting end time.
+
+**Goal**: Ensure a valid temporal window for yield streaming.
+
+**Mathematical Formula**:
+```
+startVestingTime ≤ endVestingTime
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 26-32: VestingState struct
+struct VestingState {
+    uint128 lastSharePrice;
+    uint128 vestingGains;
+    uint128 lastVestingUpdate;
+    uint64 startVestingTime;
+    uint64 endVestingTime;
+}
+
+// Line 185-186: In vestYield, start is set to now, end is now + duration
+vestingState.startVestingTime = uint64(block.timestamp);
+vestingState.endVestingTime = uint64(block.timestamp + duration);
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_startVestingTimeLEendVestingTime() public view {
+    (, , , uint64 startTime, uint64 endTime) = _accountantYS().vestingState();
+    
+    assertLe(startTime, endTime, "Invariant 14: Start vesting time should be <= end vesting time");
+}
+```
+
+---
+
+### Rule 15: vestingGainsIntegrity
+
+**Description**: If there are any vesting gains (yield being streamed), then the vesting period must be positive (start < end).
+
+**Goal**: Ensure yield streaming only occurs over a positive time duration.
+
+**Mathematical Formula**:
+```
+vestingGains > 0 ⟹ startTime < endTime
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 151-191: vestYield always sets duration > 0
+function vestYield(uint256 yieldAmount, uint256 duration) external requiresAuth {
+    // ...
+    if (duration > uint256(maximumVestingTime)) revert AccountantWithYieldStreaming__DurationExceedsMaximum();
+    if (duration < uint256(minimumVestingTime)) revert AccountantWithYieldStreaming__DurationUnderMinimum();
+    if (yieldAmount == 0) revert AccountantWithYieldStreaming__ZeroYieldUpdate();
+    // ...
+    vestingState.vestingGains = uint128(yieldAmount);
+    vestingState.startVestingTime = uint64(block.timestamp);
+    vestingState.endVestingTime = uint64(block.timestamp + duration);
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_vestingGainsIntegrity() public view {
+    (, uint128 vestingGains, , uint64 startTime, uint64 endTime) = _accountantYS().vestingState();
+
+    if (vestingGains > 0) {
+        assertLt(startTime, endTime, "Invariant 15: If vesting gains > 0, start must be < end");
+    }
+}
+```
+
+---
+
+### Rule 16: lastVestingUpdateNeverDecreases
+
+**Description**: The `lastVestingUpdate` timestamp should only move forward, never backward.
+
+**Goal**: Prevent retroactive yield streaming through timestamp manipulation.
+
+**Mathematical Formula**:
+```
+lastVestingUpdate_post ≥ lastVestingUpdate_pre
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 467: In _updateExchangeRate, lastVestingUpdate is always set to current time
+vestingState.lastVestingUpdate = uint128(block.timestamp);
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_lastVestingUpdateNeverDecreases() public view {
+    AccountantHandler.YSState memory preYS = _getPreYS();
+    AccountantHandler.YSState memory postYS = _getPostYS();
+
+    assertGe(
+        postYS.lastVestingUpdate,
+        preYS.lastVestingUpdate,
+        "Invariant 16: Last vesting update should never decrease"
+    );
+}
+```
+
+---
+
+### Rule 17: integrityOfVestYield
+
+**Description**: After `vestYield` is called, the `lastVestingUpdate` should be properly set (≥ startTime).
+
+**Goal**: Ensure continuous and accurate yield accrual.
+
+**Mathematical Formula**:
+```
+selector == vestYield ⟹ lastVestingUpdate ≥ startTime
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_integrityOfVestYield() public view {
+    bytes4 selector = _accountantHandler().lastSelector();
+    
+    if (selector == AccountantWithYieldStreaming.vestYield.selector) {
+        (, , uint128 lastVestingUpdate, uint64 startTime, ) = _accountantYS().vestingState();
+        assertGe(lastVestingUpdate, startTime, "Invariant 17: Vesting update should be >= start time");
+    }
+}
+```
+
+---
+
+### Rule 18: exchangeRatePostLoss
+
+**Description**: After a `postLoss` event, the exchange rate must be ≤ the highwater mark.
+
+**Goal**: Correctly reset the performance baseline after recognized losses.
+
+**Mathematical Formula**:
+```
+selector == postLoss ⟹ exchangeRate ≤ highwaterMark
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 199-244: postLoss reduces share price
+function postLoss(uint256 lossAmount) external requiresAuth {
+    // ...
+    if (vestingState.vestingGains >= lossAmount) {
+        vestingState.vestingGains -= uint128(lossAmount);
+    } else {
+        uint256 principalLoss = lossAmount - vestingState.vestingGains;
+        vestingState.vestingGains = 0;
+        
+        // Line 222-223: Share price is REDUCED
+        uint128 cachedSharePrice = vestingState.lastSharePrice;
+        vestingState.lastSharePrice =
+            uint128((totalAssets() - principalLoss).mulDivDown(ONE_SHARE, currentShares));
+    }
+    
+    // Line 238: exchangeRate synced to (reduced) lastSharePrice
+    state.exchangeRate = uint96(vestingState.lastSharePrice);
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_exchangeRatePostLoss() public view {
+    bytes4 selector = _accountantHandler().lastSelector();
+    
+    if (selector == AccountantWithYieldStreaming.postLoss.selector && _accountantHandler().lastCallSucceeded()) {
+        (, uint96 hwm, , , uint96 rate, , , , , , , ) = _accountantYS().accountantState();
+        
+        uint256 tolerance = uint256(hwm) / 1e16;
+        if (tolerance == 0) tolerance = 100;
+        
+        uint256 diff = rate > hwm ? rate - hwm : hwm - rate;
+        assertLe(
+            diff,
+            tolerance,
+            "Invariant 18: After postLoss, rate should approximately equal HWM"
+        );
+    }
+}
+```
+
+---
+
+### Rule 19: vaultSolvency_1Asset_Vesting
+
+**Description**: The vault must remain solvent accounting for pending vesting gains. The vault balance minus pending vesting should still cover the supply at the current rate.
+
+**Note**: **This invariant is specifically for SINGLE-ASSET scenarios.** When alternative assets are deposited via `depositAltMAS`, this check is skipped because shares can be backed by multiple asset types.
+
+**Goal**: Ensure solvency while accounting for unvested yield streaming.
+
+**Mathematical Formula**:
+```
+(altBalance ≤ INITIAL_MINT) ⟹ 
+    VaultBalance × ONE_SHARE + tolerance ≥ Supply × Rate + PendingVest × ONE_SHARE
+
+where tolerance = max(rhs / 1000, 1)  // 0.1% tolerance for edge cases
+```
+
+**Source Contract Code** (`AccountantWithYieldStreaming.sol`):
+```solidity
+// Line 359-381: getPendingVestingGains calculates unvested yield
+function getPendingVestingGains() public view returns (uint256 amountVested) {
+    uint256 currentTime = block.timestamp;
+    if (currentTime >= vestingState.endVestingTime) {
+        return vestingState.vestingGains;
+    }
+    if (vestingState.vestingGains == 0) {
+        return 0;
+    }
+    uint256 timeSinceLastUpdate = currentTime - vestingState.lastVestingUpdate;
+    uint256 totalRemainingTime = vestingState.endVestingTime - vestingState.lastVestingUpdate;
+    return amountVested = uint256(vestingState.vestingGains).mulDivDown(timeSinceLastUpdate, totalRemainingTime);
+}
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_vaultSolvency_1Asset_Vesting() public view {
+    uint256 totalSupply = _vault().totalSupply();
+
+    if (totalSupply == 0) return;
+    if (_isAccountantYSPaused()) return;
+    if (_accountantHandler().feesRecentlyClaimed()) return;
+
+    uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+    uint256 pendingVest = _accountantYS().getPendingVestingGains();
+    uint256 rate = _accountantYS().getRateInQuoteSafe(baseAsset);
+
+    uint256 lhs = vaultBalance * ONE_SHARE;
+    uint256 rhs = totalSupply.mulDivUp(rate, 1) + pendingVest * ONE_SHARE;
+    
+    uint256 tolerance = rhs / 1000;
+    if (tolerance == 0) tolerance = 1;
+    
+    assertGe(lhs + tolerance, rhs, "Invariant 19: Vesting solvency check");
+}
+```
+
+---
+
+## Group 2 (continued): YS-Only Invariants (Rules 20-23)
+
+### Rule 20: yieldIntegrity
+
+**Description**: Ensures that yield realization during vestYield/postLoss/updateExchangeRate does not exceed the amount that has actually vested (streamed over time). This is a core safety property preventing over-distribution of yield.
+
+**Goal**: Prevent "time-travel" exploits or logic errors that could allow claiming more yield than has vested.
+
+**Mathematical Formula**:
+```
+realizedYield ≤ pendingGains_pre
+
+where realizedYield = lastSharePrice_post - lastSharePrice_pre (if positive)
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_yieldIntegrity() public view {
+    AccountantHandler.YSState memory preYS = _getPreYS();
+    AccountantHandler.YSState memory postYS = _getPostYS();
+    bytes4 selector = _accountantHandler().lastSelector();
+    
+    bool isYieldRealizingOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                              selector == AccountantWithYieldStreaming.postLoss.selector ||
+                              selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+    
+    if (!isYieldRealizingOp) return;
+    if (!_accountantHandler().lastCallSucceeded()) return;
+    
+    uint256 realizedYield = postYS.lastSharePrice > preYS.lastSharePrice
+        ? postYS.lastSharePrice - preYS.lastSharePrice
+        : 0;
+    
+    assertLe(
+        realizedYield,
+        preYS.pendingGains,
+        "Invariant 20: Realized yield cannot exceed pending vested gains"
+    );
+}
+```
+
+---
+
+### Rule 21: yieldAccrualsMonotonic
+
+**Description**: Available yield should only increase over time (assuming no claims).
+
+**Goal**: Ensure yield accrual only moves forward.
+
+**Mathematical Formula**:
+```
+!isReducingOp ⟹ lastVestingUpdate_post ≥ lastVestingUpdate_pre
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_yieldAccrualsMonotonic() public view {
+    AccountantHandler.YSState memory preYS = _getPreYS();
+    AccountantHandler.YSState memory postYS = _getPostYS();
+    bytes4 selector = _accountantHandler().lastSelector();
+    
+    bool isReducingOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                        selector == AccountantWithYieldStreaming.postLoss.selector ||
+                        selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+    
+    if (!isReducingOp) {
+        assertGe(
+            postYS.lastVestingUpdate,
+            preYS.lastVestingUpdate,
+            "Invariant 21: Yield accrual timestamp should be monotonic"
+        );
+    }
+}
+```
+
+---
+
+### Rule 22: streamingRateConsistency
+
+**Description**: The available yield follows a linear streaming formula over time.
+
+**Goal**: Mathematical verification of the streaming algorithm.
+
+**Mathematical Formula**:
+```
+pendingGains ≤ vestingGains
+block.timestamp ≥ endTime ⟹ pendingGains == vestingGains
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_streamingRateConsistency() public view {
+    (, uint128 vestingGains, , , uint64 endTime) = _accountantYS().vestingState();
+    
+    uint256 pendingGains = _accountantYS().getPendingVestingGains();
+    
+    assertLe(
+        pendingGains,
+        uint256(vestingGains),
+        "Invariant 22: Pending gains should not exceed total vesting gains"
+    );
+    
+    if (block.timestamp >= endTime && vestingGains > 0) {
+        assertEq(
+            pendingGains,
+            uint256(vestingGains),
+            "Invariant 22: Past end time, pending should equal all remaining gains"
+        );
+    }
+}
+```
+
+---
+
+### Rule 23: accessControlYieldParams
+
+**Description**: Only authorized roles can modify yield parameters. This checks that min/max vesting times remain consistent.
+
+**Goal**: Restrict yield configuration to authorized personnel.
+
+**Mathematical Formula**:
+```
+minimumVestingTime ≤ maximumVestingTime
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_accessControlYieldParams() public view {
+    uint64 minVest = _accountantYS().minimumVestingTime();
+    uint64 maxVest = _accountantYS().maximumVestingTime();
+    
+    assertLe(minVest, maxVest, "Invariant 35: min vesting time should be <= max vesting time");
+}
+```
+
+---
+
+### Virtual Share Price Invariants (Rules 36-38)
+
+These invariants verify the consistency between `lastVirtualSharePrice` (stored in RAY precision, 27 decimals) and `lastSharePrice` (stored as uint128 in asset decimals).
+
+---
+
+### Rule 36: virtualPriceUpperBound
+
+**Description**: The converted virtual price should not exceed `lastSharePrice + 1`. This verifies that `_calculateSharePriceFromVirtual()` correctly converts from RAY precision.
+
+**Note**: **Conditionally Verified** - Skipped when:
+- `totalSupply == 0` (no shares exist)
+- Accountant is paused
+- `virtualPrice == 0` (not initialized)
+- `convertedPrice > type(uint128).max` (truncation occurred - see Finding 2 in FINDINGS.md)
+
+**Mathematical Formula**:
+```
+virtualPrice × ONE_SHARE / RAY ≤ lastSharePrice + 1
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_virtualPriceUpperBound() public view returns (bool) {
+    uint256 totalSupply = _vault().totalSupply();
+    if (totalSupply == 0) return true;
+    if (_isAccountantYSPaused()) return true;
+    
+    uint256 virtualPrice = _accountantYS().lastVirtualSharePrice();
+    (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+    
+    if (virtualPrice == 0) return true;
+    
+    uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+    
+    // Skip when truncation would occur (Finding 2)
+    if (convertedPrice > type(uint128).max) return true;
+    
+    assertLe(
+        convertedPrice, 
+        uint256(lastSharePrice) + 1, 
+        "Invariant 36: Virtual price conversion should be <= lastSharePrice + 1"
+    );
+    return true;
+}
+```
+
+---
+
+### Rule 37: virtualPriceLowerBound
+
+**Description**: The `lastSharePrice` should not exceed the converted virtual price. Together with Rule 36, this ensures bidirectional consistency.
+
+**Note**: **Conditionally Verified** - Same skip conditions as Rule 36.
+
+**Mathematical Formula**:
+```
+lastSharePrice ≤ virtualPrice × ONE_SHARE / RAY
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_virtualPriceLowerBound() public view returns (bool) {
+    uint256 totalSupply = _vault().totalSupply();
+    if (totalSupply == 0) return true;
+    if (_isAccountantYSPaused()) return true;
+    
+    uint256 virtualPrice = _accountantYS().lastVirtualSharePrice();
+    (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+    
+    if (virtualPrice == 0) return true;
+    
+    uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+    if (convertedPrice > type(uint128).max) return true;
+    
+    assertLe(
+        lastSharePrice, 
+        convertedPrice,
+        "Invariant 37: lastSharePrice should be <= converted virtual price"
+    );
+    return true;
+}
+```
+
+---
+
+### Rule 38: pendingGainsRateRelationship
+
+**Description**: Verifies the mathematical relationship between `getRate()`, `lastSharePrice`, and `pendingGains`. When no pending gains exist, rate should equal lastSharePrice (±1 for rounding).
+
+**Mathematical Formula**:
+```
+totalSupply == 0 ⟹ rate == lastSharePrice
+pendingGains == 0 ⟹ |rate - lastSharePrice| ≤ 1
+rate ≈ lastSharePrice ⟹ pendingGains ≤ negligible
+```
+
+**Invariant Test Code** (in `YSOnlyInvariants.sol`):
+```solidity
+function invariant_pendingGainsRateRelationship() public view returns (bool) {
+    uint256 pendingGains = _accountantYS().getPendingVestingGains();
+    uint256 rate = _accountantYS().getRate();
+    (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+    uint256 totalSupply = _vault().totalSupply();
+    
+    if (totalSupply == 0) {
+        assertEq(rate, lastSharePrice, "Invariant 38: With 0 shares, rate == lastSharePrice");
+        return true;
+    }
+    
+    if (pendingGains == 0) {
+        uint256 diff = rate > lastSharePrice ? rate - lastSharePrice : uint256(lastSharePrice) - rate;
+        assertLe(diff, 1, "Invariant 38: Zero pending gains implies rate == lastSharePrice (+/-1)");
+    }
+    
+    if (rate <= uint256(lastSharePrice) + 1 && rate >= uint256(lastSharePrice)) {
+        uint256 maxNegligibleGains = (2 * totalSupply) / ONE_SHARE + 1;
+        assertLe(
+            pendingGains, 
+            maxNegligibleGains, 
+            "Invariant 38: Rate approx lastSharePrice implies negligible pending gains"
+        );
+    }
+    return true;
+}
+```
+
+---
+
+## Group 3: Teller & Vault Integrity (Rules 20-35)
+
+### Rule 24: integrityOfDeposit
+
+**Description**: When depositing, users must receive at least `minimumMint` shares, and exactly `depositAmount` assets must be taken.
+
+**Goal**: Ensure users receive the correct amount of shares for assets provided.
+
+**Mathematical Formula**:
+```
+sharesMinted ≥ minimumMint ∧ assetsTaken == depositAmount
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 580-599: _erc20Deposit enforces these checks
+function _erc20Deposit(...) internal virtual returns (uint256 shares) {
+    _handleDenyList(from, to, msg.sender);
+    uint112 cap = depositCap;
+    if (depositAmount == 0) revert TellerWithMultiAssetSupport__ZeroAssets();
+    shares = depositAmount.mulDivDown(ONE_SHARE, accountant.getRateInQuoteSafe(depositAsset));
+    shares = asset.sharePremium > 0 ? shares.mulDivDown(1e4 - asset.sharePremium, 1e4) : shares;
+    
+    // Line 593: Enforce minimum mint
+    if (shares < minimumMint) revert TellerWithMultiAssetSupport__MinimumMintNotMet();
+    
+    if (cap != type(uint112).max) {
+        if (shares + vault.totalSupply() > cap) revert TellerWithMultiAssetSupport__DepositExceedsCap();
+    }
+    // Line 597: Exactly depositAmount is transferred
+    vault.enter(from, depositAsset, depositAmount, to, shares);
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_integrityOfDeposit() public view {
+    bytes4 selector = _tellerHandler().lastSelector();
+    
+    bool isDepositOp = selector == TellerWithMultiAssetSupport.deposit.selector ||
+                       selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+    
+    if (!isDepositOp) return;
+    
+    uint256 lastDepositAssets = _tellerHandler().lastDepositAssets();
+    uint256 lastDepositShares = _tellerHandler().lastDepositShares();
+    
+    if (lastDepositAssets > 0 && _tellerHandler().depositCalls() > 0) {
+        assertGt(lastDepositShares, 0, "Invariant 24: Deposit should mint shares");
+    }
+}
+```
+
+**Note on Handler Tracking**: The handler only tracks deposits that mint `shares > 0`. Tiny deposits with `sharePremium > 0` can legitimately round down to 0 shares, which the protocol allows but would cause false positive failures if tracked.
+
+---
+
+### Rule 25: integrityOfWithdraw
+
+**Description**: When withdrawing, users must receive at least `minimumAssets` and exactly `shareAmount` shares must be burned.
+
+**Goal**: Ensure users receive the correct assets for shares burned.
+
+**Mathematical Formula**:
+```
+assetsReceived ≥ minimumAssets ∧ sharesBurned == sharesAmount
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 604-614: _withdraw enforces these checks
+function _withdraw(ERC20 withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) 
+    internal virtual returns (uint256 assetsOut) 
+{
+    if (isPaused) revert TellerWithMultiAssetSupport__Paused();
+    Asset memory asset = assetData[withdrawAsset];
+    if (!asset.allowWithdraws) revert TellerWithMultiAssetSupport__AssetNotSupported();
+
+    if (shareAmount == 0) revert TellerWithMultiAssetSupport__ZeroShares();
+    assetsOut = shareAmount.mulDivDown(accountant.getRateInQuoteSafe(withdrawAsset), ONE_SHARE);
+    
+    // Line 611: Enforce minimum assets
+    if (assetsOut < minimumAssets) revert TellerWithMultiAssetSupport__MinimumAssetsNotMet();
+    
+    _beforeWithdraw(withdrawAsset, assetsOut);
+    // Line 613: Exactly shareAmount is burned
+    vault.exit(to, withdrawAsset, assetsOut, msg.sender, shareAmount);
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_integrityOfWithdraw() public view {
+    bytes4 selector = _tellerHandler().lastSelector();
+    
+    bool isWithdrawOp = selector == TellerWithMultiAssetSupport.withdraw.selector ||
+                        selector == TellerWithMultiAssetSupport.bulkWithdraw.selector;
+    
+    if (!isWithdrawOp) return;
+    
+    uint256 lastWithdrawShares = _tellerHandler().lastWithdrawShares();
+    uint256 lastWithdrawAssets = _tellerHandler().lastWithdrawAssets();
+    
+    // DUST_THRESHOLD accounts for lowest decimal asset (6 decimals)
+    // Need 1e12 shares minimum to produce 1 token output for 6-decimal assets
+    uint256 DUST_THRESHOLD = 1e12;
+    if (lastWithdrawShares > DUST_THRESHOLD && _tellerHandler().withdrawCalls() > 0) {
+        assertGt(lastWithdrawAssets, 0, "Invariant 25: Withdraw should produce assets");
+    }
+}
+```
+
+**Note on DUST_THRESHOLD**: The threshold is set to `1e12` (not `100`) to account for decimal diversity in alternative assets. For a 6-decimal asset, at least `1e12` shares (in 18-decimal terms) are needed to produce 1 token of output, assuming a ~1:1 exchange rate.
+
+---
+
+### Rule 26: noFreeAssets
+
+**Description**: A round-trip of deposit followed by withdraw should never produce more assets than originally deposited. `withdraw(deposit(X)) <= X`
+
+**Goal**: Prevent value extraction through rounding manipulation (Dust favors the house).
+
+**Mathematical Formula**:
+```
+withdraw(deposit(X)) ≤ X
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_noFreeAssets() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+    
+    uint256 testAmount = _tellerHandler().lastDepositAssets();
+    if (testAmount == 0) testAmount = 1000e18;
+    
+    uint256 shares = testAmount.mulDivDown(ONE_SHARE, rate);
+    uint256 recoveredAssets = shares.mulDivDown(rate, ONE_SHARE);
+    
+    assertLe(recoveredAssets, testAmount, "Invariant 26: Round-trip should not create free assets");
+}
+```
+
+---
+
+### Rule 27: tellerDoesntHoldTokens
+
+**Description**: The Teller contracts should never hold any user tokens. They act as pass-through entities.
+
+**Goal**: Ensure the Teller contract never retains user funds.
+
+**Mathematical Formula**:
+```
+∀ teller ∈ {tellerMAS, tellerYS}:
+    balanceOf(teller, baseAsset) == 0
+    ∀ i ∈ [0, NUM_ALT_ASSETS): balanceOf(teller, alternativeAssets[i]) == 0
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Deposits go directly to vault (Line 597)
+vault.enter(from, depositAsset, depositAmount, to, shares);
+
+// Withdrawals go directly from vault to recipient (Line 613)
+vault.exit(to, withdrawAsset, assetsOut, msg.sender, shareAmount);
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_tellerDoesntHoldTokens() public view {
+    address teller = address(_teller());
+    
+    assertEq(
+        baseAsset.balanceOf(teller),
+        0,
+        "Invariant 27: Teller should not hold base tokens"
+    );
+    
+    // Check ALL alternative assets (N-asset support)
+    for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+        assertEq(
+            alternativeAssets[i].balanceOf(teller),
+            0,
+            "Invariant 27: Teller should not hold alt tokens"
+        );
+    }
+}
+```
+
+---
+
+### Rule 28: vaultCannotChange
+
+**Description**: The vault address in the Teller contract is immutable and cannot be changed.
+
+**Goal**: Prevent the Teller from being re-pointed to a malicious vault.
+
+**Mathematical Formula**:
+```
+teller.vault() == initialVault (constant)
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 179: vault is immutable
+BoringVault public immutable vault;
+
+// Line 199: Set once in constructor
+vault = BoringVault(payable(_vault));
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_vaultCannotChange() public view {
+    assertEq(address(_teller().vault()), address(_vault()), "Invariant 28: Teller vault should be immutable");
+}
+```
+
+---
+
+### Rule 29: depositNonceNeverGoesDown
+
+**Description**: The deposit nonce should only increase, never decrease, ensuring unique sequential transaction tracking.
+
+**Goal**: Maintain unique, sequential transaction tracking.
+
+**Mathematical Formula**:
+```
+nonce_post ≥ nonce_pre
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 79: depositNonce state variable
+uint64 public depositNonce;
+
+// Line 637: Nonce is only incremented, never decremented
+function _afterPublicDeposit(...) internal {
+    // Increment then assign as its slightly more gas efficient.
+    uint256 nonce = ++depositNonce;
+    // ...
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_depositNonceNeverGoesDown() public view {
+    TellerHandler.TellerState memory pre = _getTellerPreState();
+    TellerHandler.TellerState memory post = _getTellerPostState();
+
+    assertGe(post.depositNonce, pre.depositNonce, "Invariant 29: Deposit nonce should never decrease");
+}
+```
+
+---
+
+### Rule 30: tellerPaused_valuesFrozen
+
+**Description**: When the Teller is paused, the nonce and deposit history should remain frozen (except for `refundDeposit`).
+
+**Assumption**: Excludes `refundDeposit`
+
+**Goal**: Lock the Teller state during emergency pauses.
+
+**Mathematical Formula**:
+```
+paused ∧ selector ≠ refundDeposit ⟹ nonce_post == nonce_pre
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 619-623: _beforeDeposit checks pause state
+function _beforeDeposit(ERC20 depositAsset) internal view returns (Asset memory asset) {
+    if (isPaused) revert TellerWithMultiAssetSupport__Paused();
+    // ...
+}
+
+// Line 605: _withdraw also checks pause state
+function _withdraw(...) internal virtual returns (uint256 assetsOut) {
+    if (isPaused) revert TellerWithMultiAssetSupport__Paused();
+    // ...
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_tellerPaused_valuesFrozen() public view {
+    TellerHandler.TellerState memory pre = _getTellerPreState();
+    TellerHandler.TellerState memory post = _getTellerPostState();
+    bytes4 selector = _tellerHandler().lastSelector();
+
+    if (pre.isPaused && selector != TellerWithMultiAssetSupport.refundDeposit.selector) {
+        assertEq(post.depositNonce, pre.depositNonce, "Invariant 30: Nonce frozen when paused");
+    }
+}
+```
+
+---
+
+### Rule 31: tellerPaused_methodsRevert
+
+**Description**: When paused, public deposit/withdraw methods must revert.
+
+**Goal**: Halt all user interactions during a pause.
+
+**Mathematical Formula**:
+```
+paused ⟹ publicMethods.revert()
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Lines 619-620 and 605: Both _beforeDeposit and _withdraw revert when paused
+if (isPaused) revert TellerWithMultiAssetSupport__Paused();
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_tellerPaused_methodsRevert() public view {
+    TellerHandler.TellerState memory pre = _getTellerPreState();
+    TellerHandler.TellerState memory post = _getTellerPostState();
+    bytes4 selector = _tellerHandler().lastSelector();
+    
+    if (pre.isPaused) {
+        bool isPublicDepositWithdraw = 
+            selector == TellerWithMultiAssetSupport.deposit.selector ||
+            selector == TellerWithMultiAssetSupport.withdraw.selector;
+        
+        if (isPublicDepositWithdraw) {
+            assertEq(
+                post.vaultTotalSupply,
+                pre.vaultTotalSupply,
+                "Invariant 31: Paused teller should reject deposits/withdrawals"
+            );
+        }
+    }
+}
+```
+
+---
+
+### Rule 32: dustFavorsTheHouse
+
+**Description**: Any rounding errors from deposit→withdraw sequences should favor the vault (house), not create free assets for users.
+
+**Goal**: Ensure no asset leakage due to rounding errors.
+
+**Mathematical Formula**:
+```
+deposit → withdraw ⟹ vaultBalance_post ≥ vaultBalance_pre
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_dustFavorsTheHouse() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+    
+    uint256 testAmount = 12345678901234567890;
+    
+    uint256 sharesFromDeposit = testAmount.mulDivDown(ONE_SHARE, rate);
+    uint256 assetsFromWithdraw = sharesFromDeposit.mulDivDown(rate, ONE_SHARE);
+    
+    assertLe(assetsFromWithdraw, testAmount, "Invariant 32: Rounding should favor the vault");
+}
+```
+
+---
+
+### Rule 33: noDynamicCalls
+
+**Description**: The handlers must never make unauthorized `call` or `delegatecall` to non-whitelisted addresses.
+
+**Goal**: Prevent the Teller from being used to perform unauthorized external calls.
+
+**Mathematical Formula**:
+```
+!callMade ∧ !delegatecallMade
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_noDynamicCalls() public view {
+    assertFalse(_tellerHandler().callMade(), "Invariant 33: No unauthorized calls should be made");
+    assertFalse(_tellerHandler().delegatecallMade(), "Invariant 33: No unauthorized delegatecalls should be made");
+    assertFalse(_accountantHandler().callMade(), "Invariant 33: No unauthorized calls should be made");
+    assertFalse(_accountantHandler().delegatecallMade(), "Invariant 33: No unauthorized delegatecalls should be made");
+}
+```
+
+---
+
+### Rule 34: onlyContributionMethodsReduceAssets
+
+**Description**: User assets should only decrease if the operation is a deposit-type method.
+
+**Goal**: Ensure user assets only decrease during authorized deposit operations.
+
+**Mathematical Formula**:
+```
+userAssets_post < userAssets_pre ⟹ isContributionMethod(selector)
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Only deposit methods transfer FROM user:
+// - deposit() Line 467-495
+// - depositWithPermit() Line 501-524
+// - bulkDeposit() Line 531-542
+
+// Withdraw methods transfer TO user (not reduce assets):
+// - withdraw() Line 563-573
+// - bulkWithdraw() Line 548-557
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_onlyContributionMethodsReduceAssets() public view {
+    bytes4 selector = _tellerHandler().lastSelector();
+    address actor = _tellerHandler().currentActor();
+
+    if (actor == address(0)) return;
+
+    TellerHandler.UserState memory preUser = _tellerHandler().getPreUserState(actor);
+    TellerHandler.UserState memory postUser = _tellerHandler().getPostUserState(actor);
+
+    if (postUser.baseBalance < preUser.baseBalance) {
+        bool isDepositMethod = 
+            selector == TellerWithMultiAssetSupport.deposit.selector ||
+            selector == TellerWithMultiAssetSupport.depositWithPermit.selector ||
+            selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+        
+        assertTrue(isDepositMethod, "Invariant 34: Only deposit methods should reduce user assets");
+    }
+}
+```
+
+---
+
+### Rule 35: withdrawingProducesAssets
+
+**Description**: When shares are withdrawn, the user must receive assets in return (unless withdrawing dust amounts).
+
+**Note**: Due to integer division rounding and decimal diversity, withdrawing small share amounts to low-decimal assets can legitimately return 0 assets. The threshold accounts for 6-decimal assets where `1e12` shares are needed for 1 token output.
+
+**Goal**: Maintain the integrity of the withdrawal exchange.
+
+**Mathematical Formula**:
+```
+sharesWithdrawn > DUST_THRESHOLD ⟹ assetsReceived > 0
+
+where DUST_THRESHOLD = 1e12 (accounts for 6-decimal assets)
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 610: Assets calculation uses mulDivDown (rounds down)
+assetsOut = shareAmount.mulDivDown(accountant.getRateInQuoteSafe(withdrawAsset), ONE_SHARE);
+
+// For low-decimal assets with rate conversion:
+// 6-decimal asset rate: _changeDecimals(1e18, 18, 6) = 1e6
+// assetsOut = 1e11 * 1e6 / 1e18 = 0 (rounds to 0)
+// assetsOut = 1e12 * 1e6 / 1e18 = 1 (minimum viable)
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_withdrawingProducesAssets() public view {
+    uint256 withdrawCalls = _tellerHandler().withdrawCalls();
+    uint256 bulkWithdrawCalls = _tellerHandler().bulkWithdrawCalls();
+    
+    if (withdrawCalls == 0 && bulkWithdrawCalls == 0) {
+        return;
+    }
+    
+    uint256 sharesWithdrawn = _tellerHandler().lastWithdrawShares();
+    uint256 assetsReceived = _tellerHandler().lastWithdrawAssets();
+
+    // DUST_THRESHOLD accounts for lowest decimal asset (6 decimals)
+    // Need 1e12 shares minimum to produce 1 token output for 6-decimal assets
+    uint256 DUST_THRESHOLD = 1e12;
+    
+    if (sharesWithdrawn > DUST_THRESHOLD) {
+        assertGt(assetsReceived, 0, "Invariant 35: Withdrawing shares should produce assets");
+    }
+}
+```
+
+---
+
+### Rule 36: feesIntegrity
+
+**Description**: The fees claimed cannot exceed the fees that were available. This verifies that `claimFees` never extracts more value than has been accrued.
+
+**Goal**: Prevent claiming more fees than have been accrued.
+
+**Mathematical Formula**:
+```
+feesClaimed ≤ feesOwedInBase_pre
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_feesIntegrity() public view {
+    AccountantHandler.RPState memory pre = _getPreState();
+    AccountantHandler.RPState memory post = _getPostState();
+    bytes4 selector = _accountantHandler().lastSelector();
+    
+    if (selector == AccountantWithRateProviders.claimFees.selector) {
+        uint256 claimedAmount = pre.feesOwedInBase > post.feesOwedInBase 
+            ? pre.feesOwedInBase - post.feesOwedInBase 
+            : 0;
+        
+        assertLe(
+            claimedAmount,
+            pre.feesOwedInBase,
+            "feesIntegrity: Claimed fees should not exceed available fees"
+        );
+    }
+}
+```
+
+**Note**: For yield streaming integrity (YS system), see `invariant_yieldIntegrity` in `YSOnlyInvariants.sol` which verifies that yield claims don't exceed vested gains.
+
+---
+
+### Rule 37: deniedUsers_balanceNonDecreasing
+
+**Description**: If a user is on the `denyFrom` list, their share balance should not decrease (they cannot transfer out).
+
+**Assumption**: Excludes withdraw and refund operations.
+
+**Goal**: Prevent outflow from blacklisted addresses.
+
+**Mathematical Formula**:
+```
+denyFrom == true ⟹ shares_post ≥ shares_pre
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 378-388: beforeTransfer hook enforces deny list
+function beforeTransfer(address from, address to, address operator) public view virtual {
+    _handleDenyList(from, to, operator);
+    // ...
+}
+
+// Line 409-416: _handleDenyList reverts if from is denied
+function _handleDenyList(address from, address to, address operator) internal view {
+    if (
+        beforeTransferData[from].denyFrom || beforeTransferData[to].denyTo
+            || beforeTransferData[operator].denyOperator
+    ) {
+        revert TellerWithMultiAssetSupport__TransferDenied(from, to, operator);
+    }
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_deniedUsers_balanceNonDecreasing() public view {
+    TellerHandler.UserState memory preDenied = _tellerHandler().getPreUserState(deniedUser);
+    TellerHandler.UserState memory postDenied = _tellerHandler().getPostUserState(deniedUser);
+
+    if (preDenied.denyFrom) {
+        assertGe(
+            postDenied.shares,
+            preDenied.shares,
+            "Invariant 37: Denied user (denyFrom) shares should not decrease"
+        );
+    }
+}
+```
+
+---
+
+### Rule 38: deniedUsers_balanceNonIncreasing
+
+**Description**: If a user is on the `denyTo` list, their share balance should not increase (they cannot receive transfers).
+
+**Goal**: Prevent inflow to blacklisted addresses.
+
+**Mathematical Formula**:
+```
+denyTo == true ⟹ shares_post ≤ shares_pre
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Same as Rule 36 - _handleDenyList also checks denyTo
+if (beforeTransferData[to].denyTo) {
+    revert TellerWithMultiAssetSupport__TransferDenied(from, to, operator);
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_deniedUsers_balanceNonIncreasing() public view {
+    TellerHandler.UserState memory preDenied = _tellerHandler().getPreUserState(deniedUser);
+    TellerHandler.UserState memory postDenied = _tellerHandler().getPostUserState(deniedUser);
+
+    if (preDenied.denyTo) {
+        assertLe(
+            postDenied.shares,
+            preDenied.shares,
+            "Invariant 38: Denied user (denyTo) shares should not increase"
+        );
+    }
+}
+```
+
+---
+
+## Group 4: Math & Solvency (Rules 39-47)
+
+### Rule 39: vaultSolvencyMulti
+
+**Description**: Multi-asset solvency check ensuring the combined value of all N assets covers all outstanding shares. Supports arbitrary number of alternative assets with **decimal diversity** (6, 8, 11, 18 decimals).
+
+**Note**: Converts all asset balances to **share-equivalent terms** (18 decimals) using the accountant's `getRateInQuoteSafe()` function, which correctly handles decimal conversion via `_changeDecimals()`. This aligns with how the Teller calculates shares during deposits.
+
+**Fee Handling**: Fees are NOT added separately to the solvency calculation. Fees are part of `totalAssets` - when shares represent a claim on vault assets, that claim includes the fee portion. The vault balance should cover `totalSupply * rate`, which inherently includes fees.
+
+**IMPORTANT**: This invariant can fail if rate provider rates change AFTER deposits. When deposits occur at rate X and rate later changes to Y, existing shares may be "underwater". This is expected behavior - rate provider changes should be done carefully in production. **The check is skipped after `setAltAssetRate`**.
+
+**Goal**: Ensure total asset value (in share terms) covers all shares across N assets.
+
+**Mathematical Formula**:
+```
+(selector ≠ setAltAssetRate) ⟹ 
+    totalValueInShares + tolerance ≥ totalSupply
+
+where:
+    // Convert each asset balance to share-equivalent using accountant's rate
+    totalValueInShares = Σ(assetBalance[i] × ONE_SHARE / rate[i]) for all assets
+    tolerance = max(totalSupply / 100, 1)  // 1% tolerance for fuzzing edge cases
+    
+    Solvency: totalValueInShares + tolerance ≥ totalSupply
+```
+
+**Note on Calculation Method**: The solvency check calculates total value in **share terms** (18 decimals) rather than base asset terms. This aligns with how the Teller calculates shares during deposits and correctly handles decimal diversity across assets with different decimal precisions (6, 8, 11, 18 decimals).
+
+**Source Contract Code** (`AccountantWithRateProviders.sol`):
+```solidity
+// Line 368-383: getRateInQuote handles multi-asset rate conversion with decimal adjustment
+function getRateInQuote(ERC20 quote) public virtual view returns (uint256 rateInQuote) {
+    if (address(quote) == address(base)) {
+        rateInQuote = accountantState.exchangeRate;
+    } else {
+        RateProviderData memory data = rateProviderData[quote];
+        uint8 quoteDecimals = ERC20(quote).decimals();
+        uint256 exchangeRateInQuoteDecimals = _changeDecimals(accountantState.exchangeRate, decimals, quoteDecimals);
+        if (data.isPeggedToBase) {
+            rateInQuote = exchangeRateInQuoteDecimals;
+        } else {
+            uint256 quoteRate = data.rateProvider.getRate();
+            uint256 oneQuote = 10 ** quoteDecimals;
+            rateInQuote = oneQuote.mulDivDown(exchangeRateInQuoteDecimals, quoteRate);
+        }
+    }
+}
+
+// _changeDecimals handles scaling between different decimal precisions
+function _changeDecimals(uint256 value, uint8 fromDecimals, uint8 toDecimals) internal pure returns (uint256) {
+    if (fromDecimals == toDecimals) return value;
+    if (fromDecimals < toDecimals) return value * 10 ** (toDecimals - fromDecimals);
+    return value / 10 ** (fromDecimals - toDecimals);
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_vaultSolvencyMulti() public view {
+    uint256 totalSupply = _vault().totalSupply();
+
+    if (totalSupply == 0) return;
+    if (_isAccountantPaused()) return;
+    if (_accountantHandler().feesRecentlyClaimed()) return;
+    if (_accountantHandler().altAssetRateChanged()) return;
+
+    address vault = address(_vault());
+    
+    // Calculate total value in SHARE terms (not base asset terms)
+    // This aligns with how the Teller calculates shares during deposits
+    uint256 totalValueInShares = 0;
+    
+    // Base asset contribution
+    uint256 baseBalance = baseAsset.balanceOf(vault);
+    uint256 baseRate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (baseRate > 0 && baseBalance > 0) {
+        totalValueInShares += baseBalance.mulDivDown(ONE_SHARE, baseRate);
+    }
+    
+    // Alternative assets contribution (N-asset support with decimal diversity)
+    for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+        uint256 altBalance = alternativeAssets[i].balanceOf(vault);
+        if (altBalance > 0) {
+            try _accountant().getRateInQuoteSafe(ERC20(address(alternativeAssets[i]))) returns (uint256 altRate) {
+                if (altRate > 0) {
+                    // Convert alt asset balance to share terms using accountant's rate
+                    // The rate already accounts for decimal differences via _changeDecimals
+                    totalValueInShares += altBalance.mulDivDown(ONE_SHARE, altRate);
+                }
+            } catch {}
+        }
+    }
+    
+    // Note: Fees are NOT added separately - they are part of totalAssets.
+    // The vault balance should cover totalSupply * rate, which includes fees.
+
+    // Solvency check: totalValueInShares >= totalSupply (with 1% tolerance)
+    uint256 tolerance = totalSupply / 100;
+    if (tolerance == 0) tolerance = 1;
+
+    assertGe(totalValueInShares + tolerance, totalSupply, "Invariant 38: Multi-asset solvency check (N assets)");
+}
+```
+
+---
+
+### Rule 40: vaultSolvency_1Asset
+
+**Description**: Single-asset solvency check ensuring the vault balance covers all shares at the current rate.
+
+**Important**: 
+- **Fees are NOT added separately** - they are part of `totalAssets`. The vault balance should cover `totalSupply * rate`, which inherently includes the fee portion.
+- **This invariant is specifically for SINGLE-ASSET scenarios.** When ANY alternative asset is deposited via `depositAltMAS`, this check is skipped because shares are backed by multiple asset types.
+
+**Goal**: Single asset variant of the solvency check.
+
+**Mathematical Formula**:
+```
+(∀ i ∈ [0, N): altBalance[i] == 0) ⟹ 
+    vaultBalance × ONE_SHARE + tolerance ≥ totalSupply × rate
+
+where tolerance = max(rhs / 1000, 1)  // 0.1% tolerance for edge cases
+```
+
+**Note on Fee Handling**: Fees are NOT added to the LHS. The vault balance should cover `totalSupply * rate`, and fees are part of that total value (not separate from it). When fees are claimed, they come FROM the vault balance.
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_vaultSolvency_1Asset() public view {
+    uint256 totalSupply = _vault().totalSupply();
+
+    if (totalSupply == 0) return;
+    if (_isAccountantPaused()) return;
+    if (_accountantHandler().feesRecentlyClaimed()) return;
+
+    // This is a SINGLE-asset solvency check - skip if ANY alt asset is present (N-asset support)
+    address vault = address(_vault());
+    for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+        if (alternativeAssets[i].balanceOf(vault) > 0) return;
+    }
+
+    uint256 vaultBalance = baseAsset.balanceOf(vault);
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+
+    uint256 lhs = vaultBalance * ONE_SHARE;
+    uint256 rhs = totalSupply * rate;
+
+    uint256 tolerance = rhs / 1000;
+    if (tolerance == 0) tolerance = 1;
+
+    assertGe(lhs + tolerance, rhs, "Invariant 39: Single-asset solvency check");
+}
+```
+
+---
+
+### Rule 41: convertToAssetsWeakAdditivity
+
+**Description**: Converting shares to assets satisfies weak additivity: the sum of individual conversions is ≤ the conversion of the sum.
+
+**Goal**: Ensure rounding in asset conversion favors the system.
+
+**Mathematical Formula**:
+```
+convert(A) + convert(B) ≤ convert(A + B)
+
+where convert(shares) = shares × rate / ONE_SHARE (using mulDivDown)
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_convertToAssetsWeakAdditivity() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+
+    uint256 sharesA = 100e18;
+    uint256 sharesB = 200e18;
+
+    uint256 assetsA = sharesA.mulDivDown(rate, ONE_SHARE);
+    uint256 assetsB = sharesB.mulDivDown(rate, ONE_SHARE);
+    uint256 assetsAB = (sharesA + sharesB).mulDivDown(rate, ONE_SHARE);
+
+    assertLe(assetsA + assetsB, assetsAB + 1, "Invariant 41: Weak additivity for convertToAssets");
+}
+```
+
+---
+
+### Rule 42: convertToSharesWeakAdditivity
+
+**Description**: Converting assets to shares satisfies weak additivity: the sum of individual conversions is ≤ the conversion of the sum.
+
+**Goal**: Ensure rounding in share conversion favors the system.
+
+**Mathematical Formula**:
+```
+convert(A) + convert(B) ≤ convert(A + B)
+
+where convert(assets) = assets × ONE_SHARE / rate (using mulDivDown)
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_convertToSharesWeakAdditivity() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+
+    uint256 assetsA = 100e18;
+    uint256 assetsB = 200e18;
+
+    uint256 sharesA = assetsA.mulDivDown(ONE_SHARE, rate);
+    uint256 sharesB = assetsB.mulDivDown(ONE_SHARE, rate);
+    uint256 sharesAB = (assetsA + assetsB).mulDivDown(ONE_SHARE, rate);
+
+    assertLe(sharesA + sharesB, sharesAB + 1, "Invariant 42: Weak additivity for convertToShares");
+}
+```
+
+---
+
+### Rule 43: conversionWeakMonotonicity
+
+**Description**: Conversion functions are weakly monotonic: larger inputs produce larger or equal outputs.
+
+**Goal**: Ensure consistent conversion behavior across all input ranges.
+
+**Mathematical Formula**:
+```
+x < y ⟹ convert(x) ≤ convert(y)
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_conversionWeakMonotonicity() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+
+    uint256 x = 100e18;
+    uint256 y = 200e18;
+
+    uint256 convertX = x.mulDivDown(ONE_SHARE, rate);
+    uint256 convertY = y.mulDivDown(ONE_SHARE, rate);
+
+    assertTrue(x < y, "Test precondition");
+    assertLe(convertX, convertY, "Invariant 43: Conversion weak monotonicity");
+}
+```
+
+---
+
+### Rule 44: conversionWeakIntegrity
+
+**Description**: Round-trip conversions (assets→shares→assets) never create value.
+
+**Goal**: Ensure round-trip conversions never create value.
+
+**Mathematical Formula**:
+```
+convertBack(convert(x)) ≤ x
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_conversionWeakIntegrity() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+
+    uint256 originalAssets = 100e18;
+
+    uint256 shares = originalAssets.mulDivDown(ONE_SHARE, rate);
+    uint256 recoveredAssets = shares.mulDivDown(rate, ONE_SHARE);
+
+    assertLe(recoveredAssets, originalAssets, "Invariant 44: Round trip should not create value");
+}
+```
+
+---
+
+### Rule 45: zeroAllowanceOnAssets
+
+**Description**: After operations complete, the Teller should not have residual spending allowance on user assets.
+
+**Note**: Allowance is given to the vault, not the teller. Some unused allowance may remain after deposits, which is acceptable.
+
+**Goal**: Ensure the Teller does not have residual spending power over user funds.
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_zeroAllowanceOnAssets() public view {
+    for (uint256 i = 0; i < actors.length; i++) {
+        address actor = actors[i];
+        
+        uint256 tellerAllowance = baseAsset.allowance(actor, address(_teller()));
+        assertEq(
+            tellerAllowance,
+            0,
+            "Invariant 45: Users should not give allowance to teller"
+        );
+    }
+}
+```
+
+---
+
+### Rule 46: conversionOfZero
+
+**Description**: Converting zero should always return zero.
+
+**Goal**: Ensure zero-value inputs always result in zero-value outputs.
+
+**Mathematical Formula**:
+```
+convert(0) == 0
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_conversionOfZero() public view {
+    if (_isAccountantPaused()) return;
+    
+    uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+    if (rate == 0) return;
+
+    uint256 zeroAssets = 0;
+    uint256 zeroShares = zeroAssets.mulDivDown(ONE_SHARE, rate);
+    
+    assertEq(zeroShares, 0, "Invariant 46: convert(0) should equal 0");
+}
+```
+
+---
+
+### Rule 47: totalSupplyLEqCap
+
+**Description**: The deposit cap limits NEW deposits, not existing supply. An admin can lower the cap below current supply at any time. This invariant verifies that deposits are rejected when they would exceed the cap.
+
+**Goal**: Enforce the global deposit limit.
+
+**Mathematical Formula**:
+```
+isDepositOp ∧ supplyIncreased ⟹ postSupply ≤ depositCap
+```
+
+**Source Contract Code** (`TellerWithMultiAssetSupport.sol`):
+```solidity
+// Line 594-596: Cap check in _erc20Deposit
+if (cap != type(uint112).max) {
+    if (shares + vault.totalSupply() > cap) revert TellerWithMultiAssetSupport__DepositExceedsCap();
+}
+
+// Line 365-368: Admin can set any cap value
+function setDepositCap(uint112 cap) external requiresAuth {
+    depositCap = cap;
+    emit DepositCapSet(cap);
+}
+```
+
+**Invariant Test Code** (in `BaseInvariants.sol`):
+```solidity
+function invariant_totalSupplyLEqCap() public view {
+    TellerHandler.TellerState memory pre = _getTellerPreState();
+    TellerHandler.TellerState memory post = _getTellerPostState();
+    bytes4 selector = _tellerHandler().lastSelector();
+    
+    bool isDepositOp = selector == TellerWithMultiAssetSupport.deposit.selector ||
+                       selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+    
+    if (!isDepositOp) return;
+    
+    if (post.vaultTotalSupply > pre.vaultTotalSupply) {
+        assertLe(
+            post.vaultTotalSupply,
+            pre.depositCap,
+            "Invariant 47: Deposit should respect deposit cap"
+        );
+    }
+}
+```
+
+---
+
+---
+
+## Summary
+
+This invariant suite provides comprehensive coverage of the BoringVault ecosystem through **47 distinct rules** organized into four groups:
+
+1. **Accountant Common Logic (Rules 1-7)**: 7 invariants verifying basic accounting properties like token handling, paused state behavior, fee mechanics, and timestamp progression. Implemented in `BaseInvariants.sol`.
+
+2. **Accountant Yield Specific (Rules 8-19, 32-38)**: 19 invariants ensuring yield streaming mechanics work correctly, including share price calculations, vesting state integrity, virtual price consistency, and solvency during active vesting. Implemented in `YSOnlyInvariants.sol`.
+
+3. **Teller & Vault Integrity (Rules 20-31, 33-37)**: 17 invariants validating deposit/withdraw operations, access control, deny list functionality, and token pass-through behavior. Implemented in `BaseInvariants.sol`.
+
+4. **Math & Solvency (Rules 38-47)**: 10 invariants mathematically verifying solvency conditions, conversion function properties, and cap enforcement. Implemented in `BaseInvariants.sol`.
+
+### Findings Discovered
+
+The fuzzing suite discovered two edge cases documented in `FINDINGS.md`:
+
+1. **Finding 1** (`setFirstDepositTimestamp` Bug): A combination of stale `vestingGains` and incomplete timestamp reset creates invalid vesting state. Handler workaround applied.
+
+2. **Finding 2** (`uint128` Truncation): When `lastVirtualSharePrice` exceeds ~3.4e56, the `uint128` cast silently truncates, causing `lastSharePrice` to diverge. Invariant skip applied for edge case.
+
+### Key Implementation Notes
+
+- **Modular Architecture**: Uses inheritance-based design with abstract base contracts (`BaseInvariants`, `YSOnlyInvariants`) and concrete test contracts (`InvariantTestRP`, `InvariantTestYS`)
+- **Separate Vaults**: Each system (RP and YS) has its own dedicated vault instance to prevent cross-contamination during fuzzing
+- **N-Asset Support**: The RP system supports 5 alternative assets (configurable via `NUM_ALT_ASSETS`), each with its own rate provider. Handler functions are parameterized by asset index.
+- **Decimal Diversity**: Alternative assets use varying decimals (18, 6, 6, 8, 11) to simulate real-world tokens (WETH, USDC, USDT, WBTC, edge cases). See `ALT_ASSET_DECIMALS` in `BaseSetup.sol`.
+- **Minimum Withdrawal Requirements**: All withdrawal handlers enforce `minAssets >= 1` to prevent 0-asset withdrawals. For low-decimal assets, minimum share amounts are scaled accordingly (e.g., `1e12` shares for 6-decimal assets).
+- **DUST_THRESHOLD**: Set to `1e12` in withdrawal invariants to account for decimal diversity. This represents 1 token in 6-decimal terms when converted to 18-decimal shares.
+- **Ghost State Tracking**: Handlers capture pre/post operation snapshots for transition invariants
+- **Rounding Awareness**: Accounts for `mulDivDown`/`mulDivUp` rounding behavior
+- **Edge Case Handling**: Handles extreme time warps, tiny amounts, and multi-asset scenarios
+- **Proper Rate Usage**: Distinguishes between `getRate()` (includes vesting) and `lastSharePrice` for YS
+- **Fee Accounting**: Includes `feesOwedInBase` in solvency calculations
+- **Share-Based Solvency**: Multi-asset solvency uses share-term calculations (not base-asset terms) to correctly handle decimal diversity
+
+### Multi-Asset Considerations (N-Asset Support)
+
+The RP system supports **N alternative assets** (default: 5) with **decimal diversity**:
+
+| Index | Decimals | Simulates | Min Shares for 1 Token |
+|-------|----------|-----------|------------------------|
+| 0 | 18 | WETH, DAI | 1 |
+| 1 | 6 | USDC | 1e12 |
+| 2 | 6 | USDT | 1e12 |
+| 3 | 8 | WBTC | 1e10 |
+| 4 | 11 | Edge case | 1e7 |
+
+Several invariants handle multi-asset scenarios:
+
+| Invariant | Behavior | Notes |
+|-----------|----------|-------|
+| **Rule 1** (accountantDoesntHoldTokens) | Iterates over all N alt assets | Checks `balanceOf(accountant, altAssets[i]) == 0` for each |
+| **Rule 27** (tellerDoesntHoldTokens) | Iterates over all N alt assets | Checks `balanceOf(teller, altAssets[i]) == 0` for each |
+| **Rule 39** (vaultSolvencyMulti) | Sums value in share terms | Uses `getRateInQuoteSafe()` which handles decimal conversion |
+| **Rule 40** (vaultSolvency_1Asset) | Skips if ANY alt asset > 0 | Only applies to pure single-asset scenarios |
+
+**Single-asset invariants** are skipped when alternative assets are deposited:
+
+| Invariant | Skip Condition | Reason |
+|-----------|---------------|--------|
+| **Rule 13** (totalAssetsCovered) | Any `altBalance > 0` | `totalAssets()` calculation differs in multi-asset scenarios |
+| **Rule 19** (vaultSolvency_1Asset_Vesting) | Any `altBalance > 0` | Single-asset formula doesn't account for alternative asset value |
+| **Rule 39** (vaultSolvencyMulti) | `selector == setAltAssetRate` | Rate changes can make existing deposits "underwater" (expected) |
+| **Rule 40** (vaultSolvency_1Asset) | Any `altBalance > 0` | Single-asset formula doesn't apply to multi-asset backing |
+
+### Relaxed Invariants
+
+**Rule 12** (sharePriceMoreThanOne) was relaxed to only check `rate > 0` because `postLoss` can legitimately reduce the share price below any specific floor (e.g., 0.5e18). Multiple loss events can drive the rate arbitrarily low, which is expected protocol behavior.
+
+### Notes on Expected Behaviors
+
+See `test/fuzzing/FUZZING_NOTES.md` for documented findings discovered during fuzzing.
+
+- **Finding #1**: `invariant_exchangeRateLEhighwaterMark_unlessPaused` - Rate/HWM desync after pause/unpause cycle is **confirmed expected behavior**. The invariant explicitly allows `rate > hwm` when paused: `!isPaused => (exchangeRate <= highwaterMark)`

--- a/test/fuzzing/InvariantTestRP.sol
+++ b/test/fuzzing/InvariantTestRP.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test, console} from "@forge-std/Test.sol";
+import {StdInvariant} from "@forge-std/StdInvariant.sol";
+
+import {BaseInvariants} from "./invariants/BaseInvariants.sol";
+import {AccountantHandler} from "./handlers/AccountantHandler.sol";
+import {TellerHandler} from "./handlers/TellerHandler.sol";
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+
+/**
+ * @title InvariantTestRP
+ * @notice Invariant test suite for the RATE PROVIDER system
+ * @dev Inherits from BaseInvariants and implements abstract getters for RP system
+ * 
+ * SYSTEM: AccountantWithRateProviders + TellerWithMultiAssetSupport + vaultRP
+ * 
+ * INVARIANTS TESTED (via BaseInvariants inheritance):
+ * - Group 1: Accountant Common (1-7)
+ * - Group 3: Teller & Vault Integrity (20-31)
+ * - Group 4: Math & Solvency (33, 36-48)
+ * 
+ * TOTAL: All shared invariants, focused on RP system only
+ * Each fuzz run operates exclusively on the RP vault and contracts.
+ */
+contract InvariantTestRP is BaseInvariants {
+    // ============================================
+    // HANDLER INSTANCES
+    // ============================================
+    AccountantHandler public accountantHandler;
+    TellerHandler public tellerHandler;
+
+    // ============================================
+    // SETUP
+    // ============================================
+    function setUp() public override {
+        // Deploy base infrastructure (from BaseSetup)
+        _setupActors();
+        _deployMocks();
+        _deployRPSystem();
+        _deployYSSystem();
+        _setupRoles();
+        _configureAssets();
+        _fundActors();
+        
+        // Prepare alternative assets arrays for handler constructors
+        address[] memory altAssetAddresses = new address[](NUM_ALT_ASSETS);
+        address[] memory altRateProviderAddresses = new address[](NUM_ALT_ASSETS);
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            altAssetAddresses[i] = address(alternativeAssets[i]);
+            altRateProviderAddresses[i] = address(altAssetRateProviders[i]);
+        }
+        
+        // Deploy handlers with N-asset support
+        accountantHandler = new AccountantHandler(
+            address(accountantRP),
+            address(accountantYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            altRateProviderAddresses,
+            owner,
+            strategist,
+            payoutAddress
+        );
+        
+        tellerHandler = new TellerHandler(
+            address(tellerMAS),
+            address(tellerYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            owner,
+            solver,
+            deniedUser,
+            actors
+        );
+        
+        // Wire up handlers
+        tellerHandler.setAccountantHandler(address(accountantHandler));
+        
+        // Fund handlers with base asset
+        deal(address(baseAsset), address(accountantHandler), 10_000_000e18);
+        deal(address(baseAsset), address(tellerHandler), 10_000_000e18);
+        
+        // Fund handlers with ALL alternative assets (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            deal(address(alternativeAssets[i]), address(accountantHandler), 10_000_000e18);
+            deal(address(alternativeAssets[i]), address(tellerHandler), 10_000_000e18);
+        }
+        
+        // ============================================
+        // TARGET ONLY RP SYSTEM FUNCTIONS
+        // ============================================
+        
+        // Accountant RP functions (N-asset support)
+        bytes4[] memory accountantRPSelectors = new bytes4[](13);
+        accountantRPSelectors[0] = AccountantHandler.updateExchangeRateRP.selector;
+        accountantRPSelectors[1] = AccountantHandler.claimFeesRP.selector;
+        accountantRPSelectors[2] = AccountantHandler.pauseRP.selector;
+        accountantRPSelectors[3] = AccountantHandler.unpauseRP.selector;
+        accountantRPSelectors[4] = AccountantHandler.resetHighwaterMarkRP.selector;
+        accountantRPSelectors[5] = bytes4(keccak256("setAltAssetRate(uint256,uint256)"));
+        accountantRPSelectors[6] = AccountantHandler.updatePlatformFeeRP.selector;
+        accountantRPSelectors[7] = AccountantHandler.updatePerformanceFeeRP.selector;
+        accountantRPSelectors[8] = AccountantHandler.updateBoundsRP.selector;
+        accountantRPSelectors[9] = AccountantHandler.updateDelayRP.selector;
+        accountantRPSelectors[10] = AccountantHandler.setRateProviderDataRP.selector;
+        accountantRPSelectors[11] = AccountantHandler.updatePayoutAddressRP.selector;
+        accountantRPSelectors[12] = AccountantHandler.warpTime.selector;
+        
+        // Teller MAS functions (N-asset support)
+        // Note: depositAltMAS and withdrawAltMAS are now parameterized by asset index
+        // Note: warpTime is handled by AccountantHandler only
+        bytes4[] memory tellerMASSelectors = new bytes4[](30);
+        tellerMASSelectors[0] = TellerHandler.depositMAS.selector;
+        tellerMASSelectors[1] = TellerHandler.withdrawMAS.selector;
+        tellerMASSelectors[2] = TellerHandler.bulkDepositMAS.selector;
+        tellerMASSelectors[3] = TellerHandler.bulkWithdrawMAS.selector;
+        tellerMASSelectors[4] = bytes4(keccak256("depositAltMAS(uint256,uint256,uint256,uint256)")); // Parameterized by asset index
+        tellerMASSelectors[5] = bytes4(keccak256("withdrawAltMAS(uint256,uint256,uint256,uint256,uint256)")); // Parameterized by asset index
+        tellerMASSelectors[6] = TellerHandler.pauseMAS.selector;
+        tellerMASSelectors[7] = TellerHandler.unpauseMAS.selector;
+        tellerMASSelectors[8] = TellerHandler.denyUserMAS.selector;
+        tellerMASSelectors[9] = TellerHandler.allowUserMAS.selector;
+        tellerMASSelectors[10] = TellerHandler.setShareLockPeriodMAS.selector;
+        tellerMASSelectors[11] = TellerHandler.setDepositCapMAS.selector;
+        // Granular deny/allow controls
+        tellerMASSelectors[12] = TellerHandler.denyFromMAS.selector;
+        tellerMASSelectors[13] = TellerHandler.denyToMAS.selector;
+        tellerMASSelectors[14] = TellerHandler.allowFromMAS.selector;
+        tellerMASSelectors[15] = TellerHandler.allowToMAS.selector;
+        tellerMASSelectors[16] = TellerHandler.denyOperatorMAS.selector;
+        tellerMASSelectors[17] = TellerHandler.allowOperatorMAS.selector;
+        // Permissioned transfer controls
+        tellerMASSelectors[18] = TellerHandler.setPermissionedTransfersMAS.selector;
+        tellerMASSelectors[19] = TellerHandler.allowPermissionedOperatorMAS.selector;
+        tellerMASSelectors[20] = TellerHandler.denyPermissionedOperatorMAS.selector;
+        // Deposit cap boundary testing
+        tellerMASSelectors[21] = TellerHandler.depositNearCapMAS.selector;
+        tellerMASSelectors[22] = TellerHandler.setDepositCapNearSupplyMAS.selector;
+        // Edge case testing
+        tellerMASSelectors[23] = TellerHandler.updateAssetDataMAS.selector;
+        tellerMASSelectors[24] = TellerHandler.depositTinyMAS.selector;
+        tellerMASSelectors[25] = TellerHandler.withdrawLockedMAS.selector;
+        tellerMASSelectors[26] = TellerHandler.withdrawZeroMinMAS.selector;
+        // Refund and denied user testing (critical for invariant coverage)
+        tellerMASSelectors[27] = TellerHandler.refundDepositMAS.selector;
+        tellerMASSelectors[28] = TellerHandler.depositAsDeniedUser.selector;
+        tellerMASSelectors[29] = TellerHandler.transferFromDeniedUser.selector;
+        
+        // ============================================
+        // TARGETING: ONLY HANDLERS
+        // ============================================
+        // Use targetContract to ONLY target handlers - this prevents the fuzzer
+        // from calling functions directly on MockRateProvider, BoringVault, etc.
+        targetContract(address(accountantHandler));
+        targetContract(address(tellerHandler));
+        
+        // Target specific selectors on handlers
+        targetSelector(FuzzSelector({addr: address(accountantHandler), selectors: accountantRPSelectors}));
+        targetSelector(FuzzSelector({addr: address(tellerHandler), selectors: tellerMASSelectors}));
+        
+        // Exclude senders that shouldn't be used by fuzzer
+        excludeSender(owner);
+        excludeSender(strategist);
+        excludeSender(payoutAddress);
+        excludeSender(address(vaultRP));
+        excludeSender(address(accountantRP));
+        excludeSender(address(tellerMAS));
+        excludeSender(address(accountantHandler));
+        excludeSender(address(tellerHandler));
+        
+        // Exclude mock contracts from being targeted directly
+        excludeContract(address(baseAsset));
+        excludeContract(address(vaultRP));
+        excludeContract(address(vaultYS));
+        excludeContract(address(accountantRP));
+        excludeContract(address(accountantYS));
+        excludeContract(address(tellerMAS));
+        excludeContract(address(tellerYS));
+        excludeContract(address(rolesAuthorityRP));
+        excludeContract(address(rolesAuthorityYS));
+        
+        // Exclude ALL alternative assets and rate providers (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            excludeContract(address(alternativeAssets[i]));
+            excludeContract(address(altAssetRateProviders[i]));
+        }
+    }
+
+    // ============================================
+    // ABSTRACT GETTER IMPLEMENTATIONS
+    // ============================================
+    
+    function _accountant() internal view override returns (AccountantWithRateProviders) {
+        return accountantRP;
+    }
+    
+    function _teller() internal view override returns (TellerWithMultiAssetSupport) {
+        return tellerMAS;
+    }
+    
+    function _vault() internal view override returns (BoringVault) {
+        return vaultRP;
+    }
+    
+    function _accountantHandler() internal view override returns (AccountantHandler) {
+        return accountantHandler;
+    }
+    
+    function _tellerHandler() internal view override returns (TellerHandler) {
+        return tellerHandler;
+    }
+    
+    function _getPreState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPreRP();
+    }
+    
+    function _getPostState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPostRP();
+    }
+    
+    function _getTellerPreState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPreMAS();
+    }
+    
+    function _getTellerPostState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPostMAS();
+    }
+}

--- a/test/fuzzing/InvariantTestYS.sol
+++ b/test/fuzzing/InvariantTestYS.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test, console} from "@forge-std/Test.sol";
+import {StdInvariant} from "@forge-std/StdInvariant.sol";
+
+import {YSOnlyInvariants} from "./invariants/YSOnlyInvariants.sol";
+import {AccountantHandler} from "./handlers/AccountantHandler.sol";
+import {TellerHandler} from "./handlers/TellerHandler.sol";
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+
+/**
+ * @title InvariantTestYS
+ * @notice Invariant test suite for the YIELD STREAMING system
+ * @dev Inherits from YSOnlyInvariants (which inherits from BaseInvariants)
+ * 
+ * SYSTEM: AccountantWithYieldStreaming + TellerWithYieldStreaming + vaultYS
+ * 
+ * INVARIANTS TESTED:
+ * - Group 1: Accountant Common (1-7) - via BaseInvariants
+ * - Group 2: YS-Specific (8-19, 32, 34, 35) - via YSOnlyInvariants
+ * - Group 3: Teller & Vault Integrity (20-31) - via BaseInvariants
+ * - Group 4: Math & Solvency (33, 36-48) - via BaseInvariants
+ * 
+ * TOTAL: All shared invariants + YS-specific invariants
+ * Each fuzz run operates exclusively on the YS vault and contracts.
+ */
+contract InvariantTestYS is YSOnlyInvariants {
+    // ============================================
+    // HANDLER INSTANCES
+    // ============================================
+    AccountantHandler public accountantHandler;
+    TellerHandler public tellerHandler;
+
+    // ============================================
+    // SETUP
+    // ============================================
+    function setUp() public override {
+        // Deploy base infrastructure (from BaseSetup)
+        _setupActors();
+        _deployMocks();
+        _deployRPSystem();
+        _deployYSSystem();
+        _setupRoles();
+        _configureAssets();
+        _fundActors();
+        
+        // Prepare alternative assets arrays for handler constructors
+        // Note: YS only uses base asset, but handlers need alt assets for RP compatibility
+        address[] memory altAssetAddresses = new address[](NUM_ALT_ASSETS);
+        address[] memory altRateProviderAddresses = new address[](NUM_ALT_ASSETS);
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            altAssetAddresses[i] = address(alternativeAssets[i]);
+            altRateProviderAddresses[i] = address(altAssetRateProviders[i]);
+        }
+        
+        // Deploy handlers with N-asset support
+        accountantHandler = new AccountantHandler(
+            address(accountantRP),
+            address(accountantYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            altRateProviderAddresses,
+            owner,
+            strategist,
+            payoutAddress
+        );
+        
+        tellerHandler = new TellerHandler(
+            address(tellerMAS),
+            address(tellerYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            owner,
+            solver,
+            deniedUser,
+            actors
+        );
+        
+        // Wire up handlers
+        tellerHandler.setAccountantHandler(address(accountantHandler));
+        
+        // Fund handlers with base asset (YS only uses base asset)
+        deal(address(baseAsset), address(accountantHandler), 10_000_000e18);
+        deal(address(baseAsset), address(tellerHandler), 10_000_000e18);
+        
+        // Fund handlers with all alternative assets (for handler compatibility)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            deal(address(alternativeAssets[i]), address(accountantHandler), 10_000_000e18);
+            deal(address(alternativeAssets[i]), address(tellerHandler), 10_000_000e18);
+        }
+        
+        // ============================================
+        // TARGET ONLY YS SYSTEM FUNCTIONS
+        // ============================================
+        
+        // Accountant YS functions
+        bytes4[] memory accountantYSSelectors = new bytes4[](9);
+        accountantYSSelectors[0] = AccountantHandler.vestYield.selector;
+        accountantYSSelectors[1] = AccountantHandler.postLoss.selector;
+        accountantYSSelectors[2] = AccountantHandler.updateExchangeRateYS.selector;
+        accountantYSSelectors[3] = AccountantHandler.claimFeesYS.selector;
+        accountantYSSelectors[4] = AccountantHandler.pauseYS.selector;
+        accountantYSSelectors[5] = AccountantHandler.unpauseYS.selector;
+        accountantYSSelectors[6] = AccountantHandler.resetHighwaterMarkYS.selector;
+        accountantYSSelectors[7] = AccountantHandler.warpTime.selector;
+        accountantYSSelectors[8] = AccountantHandler.updateVestingParams.selector;
+        
+        // Teller YS functions (warpTime handled by AccountantHandler)
+        bytes4[] memory tellerYSSelectors = new bytes4[](6);
+        tellerYSSelectors[0] = TellerHandler.depositYS.selector;
+        tellerYSSelectors[1] = TellerHandler.withdrawYS.selector;
+        tellerYSSelectors[2] = TellerHandler.bulkDepositYS.selector;
+        tellerYSSelectors[3] = TellerHandler.bulkWithdrawYS.selector;
+        tellerYSSelectors[4] = TellerHandler.pauseYS.selector;
+        tellerYSSelectors[5] = TellerHandler.unpauseYS.selector;
+        
+        // ============================================
+        // TARGETING: ONLY HANDLERS
+        // ============================================
+        // Use targetContract to ONLY target handlers - this prevents the fuzzer
+        // from calling functions directly on MockRateProvider, BoringVault, etc.
+        targetContract(address(accountantHandler));
+        targetContract(address(tellerHandler));
+        
+        // Target specific selectors on handlers
+        targetSelector(FuzzSelector({addr: address(accountantHandler), selectors: accountantYSSelectors}));
+        targetSelector(FuzzSelector({addr: address(tellerHandler), selectors: tellerYSSelectors}));
+        
+        // Exclude senders that shouldn't be used by fuzzer
+        excludeSender(owner);
+        excludeSender(strategist);
+        excludeSender(payoutAddress);
+        excludeSender(address(vaultYS));
+        excludeSender(address(accountantYS));
+        excludeSender(address(tellerYS));
+        excludeSender(address(accountantHandler));
+        excludeSender(address(tellerHandler));
+        
+        // Exclude mock contracts from being targeted directly
+        excludeContract(address(baseAsset));
+        excludeContract(address(vaultRP));
+        excludeContract(address(vaultYS));
+        excludeContract(address(accountantRP));
+        excludeContract(address(accountantYS));
+        excludeContract(address(tellerMAS));
+        excludeContract(address(tellerYS));
+        excludeContract(address(rolesAuthorityRP));
+        excludeContract(address(rolesAuthorityYS));
+        
+        // Exclude ALL alternative assets and rate providers (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            excludeContract(address(alternativeAssets[i]));
+            excludeContract(address(altAssetRateProviders[i]));
+        }
+    }
+
+    // ============================================
+    // ABSTRACT GETTER IMPLEMENTATIONS (BaseInvariants)
+    // ============================================
+    
+    function _accountant() internal view override returns (AccountantWithRateProviders) {
+        // YS accountant inherits from RP accountant
+        return AccountantWithRateProviders(address(accountantYS));
+    }
+    
+    function _teller() internal view override returns (TellerWithMultiAssetSupport) {
+        // YS teller inherits from MAS teller
+        return TellerWithMultiAssetSupport(address(tellerYS));
+    }
+    
+    function _vault() internal view override returns (BoringVault) {
+        return vaultYS;
+    }
+    
+    function _accountantHandler() internal view override returns (AccountantHandler) {
+        return accountantHandler;
+    }
+    
+    function _tellerHandler() internal view override returns (TellerHandler) {
+        return tellerHandler;
+    }
+    
+    /// @notice For YS, we use the YSAccountant state (same struct as RPState, but for YS accountant)
+    function _getPreState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPreYSAccountant();
+    }
+    
+    /// @notice For YS, we use the YSAccountant state (same struct as RPState, but for YS accountant)
+    function _getPostState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPostYSAccountant();
+    }
+    
+    function _getTellerPreState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPreYS();
+    }
+    
+    function _getTellerPostState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPostYS();
+    }
+
+    // ============================================
+    // ABSTRACT GETTER IMPLEMENTATIONS (YSOnlyInvariants)
+    // ============================================
+    
+    function _accountantYS() internal view override returns (AccountantWithYieldStreaming) {
+        return accountantYS;
+    }
+    
+    function _getPreYS() internal view override returns (AccountantHandler.YSState memory) {
+        return accountantHandler.getPreYS();
+    }
+    
+    function _getPostYS() internal view override returns (AccountantHandler.YSState memory) {
+        return accountantHandler.getPostYS();
+    }
+}

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -1,0 +1,536 @@
+# BoringVault Fuzzing Suite
+
+Invariant fuzzing test suite for the BoringVault system using **Foundry** and **Medusa**.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Directory Structure](#directory-structure)
+- [Running Foundry Tests](#running-foundry-tests)
+- [Running Medusa Tests](#running-medusa-tests)
+- [Invariants Summary](#invariants-summary)
+- [Known Issues & Workarounds](#known-issues--workarounds)
+- [Assumptions and Simplifications](#assumptions-and-simplifications)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+
+---
+
+## Overview
+
+This suite tests two vault system configurations:
+
+| System | Accountant | Teller | Description |
+|--------|------------|--------|-------------|
+| **RP** | `AccountantWithRateProviders` | `TellerWithMultiAssetSupport` | Multi-asset support with external rate providers |
+| **YS** | `AccountantWithYieldStreaming` | `TellerWithYieldStreaming` | Yield streaming with vesting mechanics |
+
+### Dual Fuzzer Architecture
+
+The suite maintains **two parallel implementations**:
+
+| Fuzzer | Location | Purpose |
+|--------|----------|---------|
+| **Foundry** | `test/fuzzing/` | Primary suite using Foundry's native invariant testing |
+| **Medusa** | `test/fuzzing/medusa/` | Adapted suite for Medusa fuzzer with `require()` assertions |
+
+Key differences between implementations:
+- **Assertions**: Foundry uses `assertEq`/`assertGe`/etc., Medusa uses `require()`
+- **Cheatcodes**: Medusa doesn't support `deal()`, uses `mint()`/`burn()` instead
+- **Setup**: Medusa runs setup in constructor, not `setUp()`
+
+---
+
+## Prerequisites
+
+### Foundry (Required)
+
+```bash
+# Install Foundry
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+
+# Verify installation
+forge --version  # Should be 0.2.0 or higher
+```
+
+### Medusa (Optional - for extended fuzzing)
+
+```bash
+# Install Medusa via Go (recommended)
+go install github.com/crytic/medusa@latest
+
+# Verify installation
+medusa --version
+```
+
+> **Note**: Medusa requires `crytic-compile`. The `medusa.json` is pre-configured to use Foundry's compilation framework (`--compile-force-framework foundry`) to avoid solc-select network issues.
+
+### Dependencies
+
+```bash
+# Install project dependencies
+forge install
+```
+
+If you encounter git submodule issues (e.g., "already exists in the index" or shallow clone errors):
+
+```bash
+# Reset and reinitialize all submodules
+git submodule deinit --all -f
+git submodule update --init --recursive
+
+# If submodules are still broken, remove and re-add
+rm -rf lib/*
+git submodule update --init --recursive --force
+
+# For shallow clone issues specifically
+git submodule foreach 'git fetch --unshallow || true'
+git submodule update --init --recursive
+```
+
+---
+
+## Directory Structure
+
+```
+test/fuzzing/
+├── README.md                       # This file
+├── example-foundry.toml            # Config used during initial fuzzing engagement, copy to root
+├── example-medusa.toml             # Config used during initial fuzzing engagement, copy to root
+├── BaseSetup.sol                   # Shared test infrastructure
+├── InvariantTestRP.sol             # Foundry RP system entry point
+├── InvariantTestYS.sol             # Foundry YS system entry point
+├── handlers/
+│   ├── AccountantHandler.sol       # Foundry accountant handlers
+│   └── TellerHandler.sol           # Teller operation handlers (shared)
+├── invariants/
+│   ├── BaseInvariants.sol          # Foundry shared invariants
+│   └── YSOnlyInvariants.sol        # Foundry YS-specific invariants
+├── mocks/                          # Mock contracts (shared by both suites)
+│   ├── MockERC20Extended.sol       # ERC20 with mint/burn and configurable decimals
+│   ├── MockRateProvider.sol        # Configurable rate provider
+│   └── MockWETH.sol                # WETH mock
+└── medusa/                         # Medusa-specific adaptations
+    ├── MedusaInvariantTestRP.sol   # Medusa RP system entry point
+    ├── MedusaInvariantTestYS.sol   # Medusa YS system entry point
+    ├── handlers/
+    │   └── AccountantHandler.sol   # Medusa accountant handlers (uses mint/burn)
+    └── invariants/
+        ├── BaseInvariants.sol      # Medusa shared invariants (uses require())
+        └── YSOnlyInvariants.sol    # Medusa YS invariants (uses require())
+```
+
+### Why Separate Medusa Folder?
+
+1. **Different assertion styles**: Foundry uses `assertEq()`, Medusa requires `require()`
+2. **Different cheatcode support**: Medusa doesn't support `deal()`, requires `mint()`/`burn()`
+3. **Isolation**: Keeps both suites independently runnable without conflicts
+
+---
+
+## Running Foundry Tests
+
+### Configuration (`foundry.toml`)
+
+```toml
+[invariant]
+runs = 256          # Number of test runs
+depth = 128         # Call depth per run
+fail_on_revert = false
+shrink_run_limit = 5000
+
+# Exclude medusa folder (uses require() instead of assert*())
+no_match_path = "test/fuzzing/medusa/*"
+```
+
+### Commands
+
+```bash
+# Run all invariant tests (both RP and YS systems)
+forge test --match-contract "InvariantTest" -vvv
+
+# Run only RP system tests
+forge test --match-contract "InvariantTestRP" -vvv
+
+# Run only YS system tests
+forge test --match-contract "InvariantTestYS" -vvv
+
+# Run with custom depth/runs
+forge test --match-contract "InvariantTest" -vvv --invariant-depth 256 --invariant-runs 512
+
+# Quick iteration (reduced coverage)
+forge test --match-contract "InvariantTest" --invariant-depth 32 --invariant-runs 64 -vvv
+```
+
+---
+
+## Running Medusa Tests
+
+### Configuration (`medusa.json`)
+
+Key settings:
+
+```json
+{
+  "fuzzing": {
+    "workers": 4,
+    "timeout": 3600,
+    "callSequenceLength": 100,
+    "transactionGasLimit": 100000000,
+    "targetContracts": ["MedusaInvariantTestRP"],
+    "testing": {
+      "propertyTesting": {
+        "enabled": true,
+        "testPrefixes": ["invariant_"]
+      }
+    }
+  },
+  "compilation": {
+    "platform": "crytic-compile",
+    "platformConfig": {
+      "args": ["--foundry-out-directory", "out", "--foundry-compile-all", "--compile-force-framework", "foundry"]
+    }
+  }
+}
+```
+
+### Switching Target Systems
+
+Medusa can only target **one contract at a time** (it mixes state between multiple targets). Edit `medusa.json`:
+
+```json
+// For RP system:
+"targetContracts": ["MedusaInvariantTestRP"]
+
+// For YS system:
+"targetContracts": ["MedusaInvariantTestYS"]
+```
+
+### Commands
+
+```bash
+# Ensure project compiles first
+forge build
+
+# Run Medusa fuzzer (uses medusa.json config)
+medusa fuzz
+
+# Run for specific duration (seconds)
+medusa fuzz --timeout 7200  # 2 hours
+
+# Run with more workers
+medusa fuzz --workers 8
+```
+
+### Generated Files
+
+Medusa generates the following (gitignored):
+
+| Directory/File | Purpose |
+|----------------|---------|
+| `medusa-corpus/` | Saved inputs that increased coverage |
+| `medusa-logs/` | Detailed execution logs |
+| `crytic-export/` | Compilation artifacts |
+
+---
+
+## Invariants Summary
+
+### Group 1: Accountant Properties (Both Systems)
+
+| Rule | Invariant | Description |
+|------|-----------|-------------|
+| 1 | `accountantDoesntHoldTokens` | Accountant never holds tokens |
+| 2 | `accountantPaused_valuesFrozen` | When paused, fees only change via `resetHighwaterMark` |
+| 3 | `feesCanOnlyDecreaseViaClaimFees` | Fees decrease only via `claimFees` |
+| 4 | `highwaterMarkNeverDecreases` | HWM never decreases except via reset |
+| 5 | `lastUpdateTimestampNeverDecreases` | Timestamp monotonically increases |
+| 6 | `allowedExchangeRateChangeBounds` | Rate bounds are valid (upper >= 100%, lower <= 100%) |
+| 7 | `exchangeRateLEhighwaterMark` | After successful update: rate <= HWM |
+
+### Group 2: YS-Specific Properties
+
+| Rule | Invariant | Description |
+|------|-----------|-------------|
+| 8 | `cumulativeSupplyBounded` | Cumulative supply tracking is monotonic |
+| 9 | `exchangeRateEqlastSharePrice` | After sync ops: rate == lastSharePrice |
+| 10-11 | `sharePriceBounded{Upper,Lower}` | Share price within expected bounds |
+| 12 | `sharePriceMoreThanOne` | Rate > 0 when assets exist |
+| 13 | `totalAssetsCovered` | totalAssets <= vaultBalance |
+| 14 | `startVestingTimeLEendVestingTime` | startTime <= endTime (see [Finding 1](#finding-1-setfirstdeposittimestamp-bug-ys-system)) |
+| 15 | `vestingGainsIntegrity` | vestingGains > 0 implies startTime < endTime |
+| 16-17 | `lastVestingUpdate*` | Vesting timestamp monotonicity |
+| 18 | `exchangeRatePostLoss` | After postLoss: rate <= HWM |
+| 19 | `vaultSolvency_1Asset_Vesting` | Solvency with pending vesting gains |
+
+### Group 3: Teller & Vault Properties
+
+| Rule | Invariant | Description |
+|------|-----------|-------------|
+| 20 | `integrityOfDeposit` | Deposit mints shares proportionally |
+| 21 | `integrityOfWithdraw` | Withdraw returns assets |
+| 22 | `noFreeAssets` | Round-trip doesn't create value |
+| 23 | `tellerDoesntHoldTokens` | Teller never holds tokens |
+| 24 | `vaultCannotChange` | Teller.vault is immutable |
+| 25 | `depositNonceNeverGoesDown` | Nonce monotonically increases |
+| 26-27 | `tellerPaused_*` | Paused state behavior |
+| 28 | `dustFavorsTheHouse` | Rounding favors protocol |
+
+### Group 4: Math & Permissions
+
+| Rule | Invariant | Description |
+|------|-----------|-------------|
+| 36-37 | `deniedUsers_balance*` | Deny list enforcement |
+| 38-39 | `vaultSolvency*` | Single and multi-asset solvency |
+| 40-47 | `conversion*` | Math conversion properties |
+
+---
+
+## Known Issues & Workarounds
+
+### Finding 1: `setFirstDepositTimestamp` Bug (YS System)
+
+**Status**: Open (Handler Workaround Applied)  
+**Invariant**: Rule 14 - `startVestingTimeLEendVestingTime`  
+**Severity**: Info
+
+#### Description
+
+A combination of two issues creates an invalid vesting state where `startVestingTime > endVestingTime`:
+
+1. `_updateExchangeRate()` doesn't clear `vestingGains` when `totalSupply == 0`
+2. `setFirstDepositTimestamp()` only updates `startVestingTime`, leaving stale `endVestingTime`
+
+#### Reproduction Sequence
+
+```
+1. depositYS       → creates shares
+2. vestYield       → sets vestingGains, startTime, endTime
+3. warpTime(huge)  → time passes endTime
+4. withdrawYS(all) → totalSupply = 0, vestingGains NOT cleared
+5. warpTime        → more time passes
+6. bulkDepositYS   → triggers setFirstDepositTimestamp
+                     startTime = now (large), endTime = old (small)
+                     Result: startTime > endTime
+```
+
+#### Handler Workaround
+
+The fuzzing handlers work around this bug:
+
+1. **`TellerHandler.depositYS()`**: Tracks if vault was empty before deposit
+2. **`AccountantHandler.fixVestingStateAfterFirstDeposit()`**: Called after deposit to empty vault, performs a minimal `vestYield` to reset timestamps
+
+```solidity
+// In TellerHandler.depositYS():
+bool vaultWasEmpty = vaultYS.totalSupply() == 0;
+// ... deposit ...
+if (vaultWasEmpty && succeeded) {
+    accountantHandler.fixVestingStateAfterFirstDeposit();
+}
+```
+
+#### Suggested Source Contract Fix
+
+```solidity
+function setFirstDepositTimestamp() external requiresAuth {
+    vestingState.startVestingTime = uint64(block.timestamp);
+    if (vestingState.endVestingTime < block.timestamp) {
+        vestingState.endVestingTime = uint64(block.timestamp);
+        vestingState.vestingGains = 0;  // Clear stale gains
+    }
+}
+```
+
+### Finding 2: `uint128` Truncation in Virtual Share Price (YS System)
+
+**Status**: Open (Invariant Skip Applied)  
+**Invariant**: Rule 36 - `virtualPriceUpperBound`  
+**Severity**: Info (Edge Case)
+
+#### Description
+
+When `lastVirtualSharePrice` becomes extremely large (after vesting large yields with very few shares), the `uint128` cast in `_calculateSharePriceFromVirtual()` silently truncates the value, causing `lastSharePrice` to diverge from the true converted virtual price.
+
+#### Impact
+
+- Edge case only: Requires extreme conditions (very large yield, very few shares)
+- Silent truncation can cause ~500x difference between values
+- Unlikely in production but could affect accounting precision
+
+#### Invariant Skip
+
+The virtual price invariants (Rules 36-37) now skip when `convertedPrice > type(uint128).max`:
+
+```solidity
+uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+if (convertedPrice > type(uint128).max) return true;
+```
+
+See `FINDINGS.md` for full details.
+
+---
+
+## Assumptions and Simplifications
+
+### System Configuration
+- One Teller per Vault (multiple Tellers not tested)
+- `BoringVault.manage()` is never called (strategist operations excluded)
+- Roles (`owner`, `strategist`, `solver`) are pre-configured and immutable
+
+### Asset Configuration
+- Base asset: 18 decimals
+- Alternative assets: varying decimals (6, 8, 11, 18) to test decimal diversity
+- Mock contracts used for assets and rate providers
+- **Rate provider rates bounded: 50% to 200% of base rate** (realistic range to avoid rounding edge cases)
+
+### Bounds
+- Deposit/withdrawal amounts: 1 wei to 100,000 tokens
+- Exchange rates: 0.001 to 1000 tokens per share
+- Time warps: 1 second to 365 days
+- Vesting durations: 1 hour to 90 days
+
+### Contract Linking
+```
+Teller.vault        == BoringVault
+BoringVault.hook    == Teller
+Teller.accountant   == Accountant
+Accountant.vault    == BoringVault
+```
+
+---
+
+## Troubleshooting
+
+### Foundry Issues
+
+**Tests timeout with no output**
+```bash
+# Reduce depth and runs for faster iteration
+forge test --match-contract "InvariantTest" --invariant-depth 32 --invariant-runs 64 -vvv
+```
+
+**Stack too deep errors**
+- The handlers use minimal state structs to avoid this
+- If modifying, keep snapshot functions simple
+
+### Medusa Issues
+
+**solc-select HTTP 403 error**
+```
+error while executing `solc-select install`:
+urllib.error.HTTPError: HTTP Error 403: Forbidden
+```
+
+This is a known issue with solc-select's network calls. The `medusa.json` is already configured to bypass this using `--compile-force-framework foundry`. If you still encounter it:
+
+```bash
+# Ensure Foundry compiles successfully first
+forge build
+
+# Clear any stale Medusa artifacts
+rm -rf medusa-corpus medusa-logs crytic-export
+
+# Re-run Medusa
+medusa fuzz
+```
+
+**Invariants all reverting with `address(0)` calls**
+
+This indicates the constructor setup didn't run. Ensure:
+1. Target contract has setup logic in `constructor()` (not just `setUp()`)
+2. `medusa.json` targets the correct contract name (e.g., `MedusaInvariantTestRP`)
+3. Run `forge build` before `medusa fuzz`
+
+**State mixing between RP and YS tests**
+
+Medusa doesn't isolate state between multiple target contracts. Always target **one contract at a time**:
+
+```json
+// CORRECT - single target
+"targetContracts": ["MedusaInvariantTestRP"]
+
+// INCORRECT - will cause state mixing
+"targetContracts": ["MedusaInvariantTestRP", "MedusaInvariantTestYS"]
+```
+
+### Debug a Failing Sequence
+
+```bash
+# Foundry - verbose output
+forge test --match-contract "InvariantTestYS" -vvvvv
+
+# Medusa - check logs
+tail -100 medusa-logs/log-*.log
+```
+
+---
+
+## Contributing
+
+### Adding New Invariants
+
+1. Add the invariant function to appropriate file:
+   - `invariants/BaseInvariants.sol` for shared invariants
+   - `invariants/YSOnlyInvariants.sol` for YS-specific invariants
+2. If adding Medusa support, also update:
+   - `medusa/invariants/BaseInvariants.sol` (convert `assert*()` to `require()`)
+   - `medusa/invariants/YSOnlyInvariants.sol`
+3. Update this README with invariant documentation
+4. Run full fuzzing suite to verify no regressions
+
+### Adding New Handlers
+
+1. Add handler function to `handlers/AccountantHandler.sol` or `handlers/TellerHandler.sol`
+2. Register the handler in `InvariantTestRP.sol` / `InvariantTestYS.sol`
+3. If Medusa support needed:
+   - Update `medusa/handlers/AccountantHandler.sol` (replace `deal()` with `mint()`/`burn()`)
+   - The `TellerHandler.sol` is shared (no Medusa-specific version needed)
+
+### Handler Selectors
+
+**RP System (31 selectors)**:
+- Deposits: `depositMAS`, `bulkDepositMAS`, `depositAltMAS`, `depositTinyMAS`, `depositNearCapMAS`
+- Withdrawals: `withdrawMAS`, `bulkWithdrawMAS`, `withdrawAltMAS`, `withdrawLockedMAS`, `withdrawZeroMinMAS`
+- Admin: `pauseMAS`, `unpauseMAS`, `setShareLockPeriodMAS`, `setDepositCapMAS`, `updateAssetDataMAS`
+- Deny List: `denyUserMAS`, `allowUserMAS`, `denyFromMAS`, `denyToMAS`, `allowFromMAS`, `allowToMAS`
+- Accountant: `updateExchangeRateRP`, `claimFeesRP`, `pauseRP`, `unpauseRP`, `setAltAssetRate`
+
+**YS System (16 selectors)**:
+- Deposits: `depositYS`, `bulkDepositYS`
+- Withdrawals: `withdrawYS`, `bulkWithdrawYS`
+- Admin: `pauseYS`, `unpauseYS`
+- Yield: `vestYield`, `postLoss`, `updateExchangeRateYS`, `updateVestingParams`
+- Time: `warpTime`
+- Accountant: `claimFeesYS`, `resetHighwaterMarkYS`
+
+---
+
+## Verification Notations
+
+| Status | Meaning |
+|--------|---------|
+| **Fuzz Verified** | Invariant held across all fuzz runs with no violations |
+| **Fuzz Verified (Workaround)** | Invariant held after handler-level workaround for known source bug |
+| **Conditionally Verified** | Invariant holds under documented preconditions |
+| **Violated** | Counter-example found exposing a bug (documented in FINDINGS.md) |
+
+### Conditionally Verified Invariants
+
+| Rule | Condition | Reason |
+|------|-----------|--------|
+| 7 | Only after successful `updateExchangeRate` | Rate/HWM relationship only guaranteed after successful updates |
+| 9 | Only after sync operations | `exchangeRate` and `lastSharePrice` diverge between syncs |
+| 13, 19 | Skip after fee claims | Fee extraction temporarily breaks accounting until next sync |
+| 36-37 | Skip when `convertedPrice > uint128.max` | Protocol truncation causes divergence (see Finding 2) |
+| 38-39 | Skip after fee claims or rate changes | Temporary valuation mismatches |
+
+---
+
+## License
+
+MIT

--- a/test/fuzzing/example-foundry.toml
+++ b/test/fuzzing/example-foundry.toml
@@ -1,0 +1,107 @@
+[profile.default]
+# Sets the concrete solc version to use
+# This overrides the `auto_detect_solc` value
+solc_version = '0.8.21'
+auto_detect_solc = false
+evm_version = 'cancun'
+optimizer = true
+optimizer_runs = 200
+
+fs_permissions = [{ access = "read-write", path = "./" }]
+deny = "never"
+remappings = [
+    "@solmate/=lib/solmate/src/",
+    "@forge-std/=lib/forge-std/src/",
+    "@ds-test/=lib/forge-std/lib/ds-test/src/",
+    "ds-test/=lib/forge-std/lib/ds-test/src/",
+    "@openzeppelin/=lib/openzeppelin-contracts/",
+    "@ccip/=lib/ccip/",
+    "@oapp-auth/=lib/OAppAuth/src/",
+]
+
+# Exclude medusa folder from Foundry tests (medusa uses require() instead of assert*())
+no_match_path = "test/fuzzing/medusa/*"
+
+# Invariant testing configuration
+[invariant]
+runs = 256          # Number of test runs (reduce for faster iteration)
+depth = 128          # Call depth per run
+fail_on_revert = false
+shrink_run_limit = 5000
+
+[fuzz]
+runs = 128
+max_test_rejects = 65536
+
+[rpc_endpoints]
+mainnet = "${MAINNET_RPC_URL}"
+polygon = "${MATIC_RPC_URL}"
+bsc = "${BNB_RPC_URL}"
+avalanche = "${AVALANCHE_RPC_URL}"
+arbitrum = "${ARBITRUM_RPC_URL}"
+optimism = "${OPTIMISM_RPC_URL}"
+base = "${BASE_RPC_URL}"
+zircuit = "${ZIRCUIT_RPC_URL}"
+scroll = "${SCROLL_RPC_URL}"
+linea = "${LINEA_RPC_URL}"
+sonicMainnet = "${SONIC_MAINNET_RPC_URL}"
+sepolia = "${SEPOLIA_RPC_URL}"
+sonicTestnet = "${SONIC_TESTNET_RPC_URL}"
+corn = "${CORN_MAIZENET_RPC_URL}"
+swell = "${SWELL_CHAIN_RPC_URL}"
+bob = "${BOB_RPC_URL}"
+berachainTestnet = "${BERA_TESTNET_RPC_URL}"
+berachain = "${BERA_CHAIN_RPC_URL}"
+bartio = "${BARTIO_RPC_URL}"
+holesky = "${HOLESKY_RPC_URL}"
+unichain = "${UNICHAIN_RPC_URL}"
+hyperEVM = "${HYPER_EVM_RPC_URL}"
+tacTestnet = "${TAC_TESTNET_RPC_URL}"
+flare = "${FLARE_RPC_URL}"
+ink = "${INK_RPC_URL}"
+plume = "${PLUME_RPC_URL}"
+katana = "${KATANA_RPC_URL}"
+tac = "${TAC_RPC_URL}"
+plasma = "${PLASMA_RPC_URL}"
+inkSepolia= "${INK_SEPOLIA_RPC_URL}"
+
+[etherscan]
+#bob = { key = "${BOBSCAN_KEY}", chain = 60808, url = "https://explorer.gobob.xyz/api?"}
+#corn = { key = "${CORNSCAN_KEY}", chain = 21000000, url = "https://api.routescan.io/v2/network/mainnet/evm/21000000/etherscan" }
+#arbitrum = { key = "${ARBISCAN_KEY}" }
+mainnet = { key = "${ETHERSCAN_KEY}", chain = 1, url = "https://api.etherscan.io/v2/api?chainid=1" }
+#polygon = { key = "${POLYGONSCAN_KEY}" }
+#bsc = { key = "${ETHERSCAN_KEY}" }
+#avalanche = { key = "${SNOWTRACE_KEY}" }
+#optimism = { key = "${OPTIMISMSCAN_KEY}" }
+#base = { key = "${BASESCAN_KEY}", chain = 8453, url = " https://api.etherscan.io/v2/api?chainid=8453" }
+#scroll = { key = "${SCROLLSCAN_KEY}", chain = 534352, url = "https://api.etherscan.io/v2/api?chainid=534352"  }
+sonicMainnet = { key = "${ETHERSCAN_KEY}", chain = 146, url = "https://api.etherscan.io/v2/api?chainid=146" }
+#swell = { key = "${SWELLSCAN_KEY}", chain = 1923, url = "https://explorer.swellnetwork.io:443/api/" }
+#sonicMainnet = { key = "${SONICSCAN_KEY}", chain = 146, url = "https://api.sonicscan.org/api" }
+#swell = { key = "${SWELLSCAN_KEY}", chain = 1923, url = "https://explorer.swellnetwork.io:443/api/" }
+#berachainTestnet = { key = "${BERASCAN_TESTNET_KEY}", chain = 80000, url = "https://api.routescan.io/v2/network/testnet/evm/80000/etherscan" }
+# sepolia = { key = "${ETHERSCAN_KEY}" }
+#berachain = { key = "${BERASCAN_KEY}", chain = 80094, url = "https://api.berascan.com/api" }
+#bob = { key = "${BOBSCAN_KEY}", chain = 60808, url = "https://explorer.gobob.xyz/api?"}
+#unichain = { key = "${UNISCAN_KEY}", chain = 130, url = "https://api.uniscan.xyz/api" }
+#flare = {key = "${FLARESCAN_KEY}", chain = 14, url = "https://api.routescan.io/v2/network/mainnet/evm/14/etherscan" }
+#hyperEVM = { key = "${HYPER_EVM_KEY}", chain = 999, url = "https://api.etherscan.io/v2/api?chainid=999" }
+#plume = { key = "${PLUMESCAN_KEY}", chain = 98866, url = "https://explorer-plume-mainnet-1.t.conduit.xyz/api/"}
+#katana = { key = "${KATANASCAN_KEY}", chain = 747474, url = "https://api.etherscan.io/v2/api?chainid=747474" }
+#tac = { key = "${TACSCAN_KEY}", chain = 239, url = "https://explorer.tac.build/api" }
+ink = { key = "${INKSCAN_KEY}", chain = 57073, url = "https://explorer.inkonchain.com/api" }
+#linea = { key = "${LINEASCAN_KEY}", chain = 59144, url = "https://api.etherscan.io/v2/api?chainid=59144" }
+#plasma = { key = "${PLASMASCAN_KEY}", chain = 9745, url = "https://api.routescan.io/v2/network/mainnet/evm/9745/etherscan" }
+
+[fmt]
+FOUNDRY_FMT_LINE_LENGTH = 120
+FOUNDRY_FMT_TAB_WIDTH = 4
+FOUNDRY_FMT_BRACKET_SPACING = true
+FOUNDRY_FMT_INT_TYPES = "long"
+FOUNDRY_FMT_MULTILINE_FUNC_HEADER = "attributes_first"
+FOUNDRY_FMT_QUOTE_STYLE = "double"
+FOUNDRY_FMT_NUMBER_UNDERSCORE = "thousands"
+FOUNDRY_FMT_OVERRIDE_SPACING = true
+FOUNDRY_FMT_WRAP_COMMENTS = false
+FOUNDRY_FMT_IGNORE = []

--- a/test/fuzzing/example-medusa.json
+++ b/test/fuzzing/example-medusa.json
@@ -1,0 +1,82 @@
+{
+  "fuzzing": {
+    "workers": 4,
+    "workerResetLimit": 50,
+    "timeout": 3600,
+    "testLimit": 0,
+    "shrinkLimit": 5000,
+    "callSequenceLength": 100,
+    "corpusDirectory": "medusa-corpus",
+    "coverageEnabled": true,
+    "targetContracts": ["MedusaInvariantTestRP"],
+    "predeployedContracts": {},
+    "targetContractsBalances": [],
+    "constructorArgs": {},
+    "deployerAddress": "0x30000",
+    "senderAddresses": [
+      "0x10000"
+    ],
+    "blockNumberDelayMax": 60480,
+    "blockTimestampDelayMax": 604800,
+    "blockGasLimit": 125000000,
+    "transactionGasLimit": 100000000,
+    "testing": {
+      "stopOnFailedTest": false,
+      "stopOnFailedContractMatching": false,
+      "stopOnNoTests": true,
+      "testAllContracts": false,
+      "traceAll": false,
+      "assertionTesting": {
+        "enabled": true,
+        "testViewMethods": true,
+        "panicCodeConfig": {
+          "failOnCompilerInsertedPanic": false,
+          "failOnAssertion": true,
+          "failOnArithmeticUnderflow": true,
+          "failOnDivideByZero": true,
+          "failOnEnumCastOutOfBounds": false,
+          "failOnIncorrectStorageAccess": false,
+          "failOnPopEmptyArray": false,
+          "failOnOutOfBoundsArrayAccess": false,
+          "failOnAllocateTooMuchMemory": false,
+          "failOnCallUninitializedVariable": false
+        }
+      },
+      "propertyTesting": {
+        "enabled": true,
+        "testPrefixes": [
+          "invariant_"
+        ]
+      },
+      "optimizationTesting": {
+        "enabled": false,
+        "testPrefixes": [
+          "optimize_"
+        ]
+      },
+      "targetFunctionSignatures": [],
+      "excludeFunctionSignatures": []
+    },
+    "chainConfig": {
+      "codeSizeCheckDisabled": true,
+      "cheatCodes": {
+        "cheatCodesEnabled": true,
+        "enableFFI": false
+      }
+    }
+  },
+  "compilation": {
+    "platform": "crytic-compile",
+    "platformConfig": {
+      "target": ".",
+      "solcVersion": "",
+      "exportDirectory": "",
+      "args": ["--foundry-out-directory", "out", "--foundry-compile-all", "--compile-force-framework", "foundry"]
+    }
+  },
+  "logging": {
+    "level": "info",
+    "logDirectory": "medusa-logs",
+    "noColor": false
+  }
+}

--- a/test/fuzzing/handlers/AccountantHandler.sol
+++ b/test/fuzzing/handlers/AccountantHandler.sol
@@ -1,0 +1,889 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+// Test and console unused but keeping for debugging if needed
+import {CommonBase} from "@forge-std/Base.sol";
+import {StdCheats} from "@forge-std/StdCheats.sol";
+import {StdUtils} from "@forge-std/StdUtils.sol";
+
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {MockRateProvider} from "../mocks/MockRateProvider.sol";
+
+/**
+ * @title AccountantHandler
+ * @notice Handler contract for fuzzing accountant operations with ghost state tracking
+ * @dev Tracks pre/post state for invariant verification
+ */
+contract AccountantHandler is CommonBase, StdCheats, StdUtils {
+    using FixedPointMathLib for uint256;
+
+    // ============================================
+    // CONSTANTS
+    // ============================================
+    
+    uint256 public constant ONE_SHARE = 1e18;
+    uint256 public constant NUM_ALT_ASSETS = 5;
+    uint8 public constant BASE_DECIMALS = 18;
+    
+    // Decimals for each alternative asset (must match BaseSetup)
+    // Index 0: 18 decimals (standard ERC20)
+    // Index 1: 6 decimals (USDC-like)
+    // Index 2: 6 decimals (USDT-like)
+    // Index 3: 8 decimals (WBTC-like)
+    // Index 4: 11 decimals (unusual, edge case)
+    uint8[5] public ALT_ASSET_DECIMALS = [18, 6, 6, 8, 11];
+
+    // ============================================
+    // CONTRACTS
+    // ============================================
+    
+    AccountantWithRateProviders public accountantRP;
+    AccountantWithYieldStreaming public accountantYS;
+    BoringVault public vaultRP;  // Vault for RP system
+    BoringVault public vaultYS;  // Vault for YS system
+    ERC20 public baseAsset;
+    
+    // Multiple alternative assets for RP multi-asset testing
+    ERC20[] public alternativeAssets;
+    MockRateProvider[] public altAssetRateProviders;
+    
+    address public owner;
+    address public strategist;
+    address public payoutAddress;
+    
+    // ============================================
+    // GHOST STATE - Pre-call snapshots (only fields used by invariants)
+    // ============================================
+    
+    // Rate Provider Accountant ghost state - minimal for invariants
+    struct RPState {
+        uint96 highwaterMark;
+        uint128 feesOwedInBase;
+        uint64 lastUpdateTimestamp;
+        bool isPaused;
+    }
+    
+    // Yield Streaming Accountant ghost state - minimal for invariants
+    struct YSState {
+        uint128 lastSharePrice;
+        uint128 lastVestingUpdate;
+        uint128 vestingGains;      // Total vesting gains pool
+        uint256 pendingGains;      // Amount that has vested (claimable)
+        uint256 totalSupply;       // Vault total supply at snapshot time
+    }
+    
+    RPState public preRP;
+    RPState public postRP;
+    YSState public preYS;
+    YSState public postYS;
+    
+    // YS Accountant state (same fields as RP for shared invariants)
+    RPState public preYSAccountant;
+    RPState public postYSAccountant;
+    
+    // ============================================
+    // TRACKING VARIABLES
+    // ============================================
+    
+    // Track the last selector called
+    bytes4 public lastSelector;
+    
+    // Track if the last call succeeded (for selector-based invariants)
+    bool public lastCallSucceeded;
+    
+    // External call tracking (always false - no unauthorized calls in handlers)
+    bool public constant callMade = false;
+    bool public constant delegatecallMade = false;
+    
+    // Track if fees were recently claimed (solvency invariants should skip)
+    bool public feesRecentlyClaimed;
+    
+    // Flag to track if ANY alternative asset rate was changed (oracle simulation)
+    bool public altAssetRateChanged;
+    
+    // Vesting simulation tracking - cumulative vested assets released to vault
+    uint256 public cumulativeVestedAssetsReleased;
+    
+    
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+    
+    constructor(
+        address _accountantRP,
+        address _accountantYS,
+        address _vaultRP,
+        address _vaultYS,
+        address _baseAsset,
+        address[] memory _alternativeAssets,
+        address[] memory _altAssetRateProviders,
+        address _owner,
+        address _strategist,
+        address _payoutAddress
+    ) {
+        require(_alternativeAssets.length == NUM_ALT_ASSETS, "Must provide NUM_ALT_ASSETS alternative assets");
+        require(_altAssetRateProviders.length == NUM_ALT_ASSETS, "Must provide NUM_ALT_ASSETS rate providers");
+        
+        accountantRP = AccountantWithRateProviders(_accountantRP);
+        accountantYS = AccountantWithYieldStreaming(_accountantYS);
+        vaultRP = BoringVault(payable(_vaultRP));
+        vaultYS = BoringVault(payable(_vaultYS));
+        baseAsset = ERC20(_baseAsset);
+        
+        // Initialize alternative assets arrays
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            alternativeAssets.push(ERC20(_alternativeAssets[i]));
+            altAssetRateProviders.push(MockRateProvider(_altAssetRateProviders[i]));
+        }
+        
+        owner = _owner;
+        strategist = _strategist;
+        payoutAddress = _payoutAddress;
+    }
+    
+    // ============================================
+    // SNAPSHOT FUNCTIONS - Minimal to avoid stack-too-deep
+    // ============================================
+    
+    function _snapshotRPState() internal view returns (RPState memory state) {
+        // Only read the fields we actually need for invariants
+        (
+            ,              // payout
+            uint96 hwm,
+            uint128 fees,
+            ,              // shares
+            ,              // rate
+            ,              // upper
+            ,              // lower
+            uint64 timestamp,
+            bool paused,
+            ,              // delay
+            ,              // platformFee
+                           // performanceFee (last)
+        ) = accountantRP.accountantState();
+        
+        state.highwaterMark = hwm;
+        state.feesOwedInBase = fees;
+        state.lastUpdateTimestamp = timestamp;
+        state.isPaused = paused;
+    }
+    
+    function _snapshotYSAccountantState() internal view returns (RPState memory state) {
+        // Read accountantState for YS accountant (same fields as RP for shared invariants)
+        (
+            ,              // payout
+            uint96 hwm,
+            uint128 fees,
+            ,              // shares
+            ,              // rate
+            ,              // upper
+            ,              // lower
+            uint64 timestamp,
+            bool paused,
+            ,              // delay
+            ,              // platformFee
+                           // performanceFee (last)
+        ) = accountantYS.accountantState();
+        
+        state.highwaterMark = hwm;
+        state.feesOwedInBase = fees;
+        state.lastUpdateTimestamp = timestamp;
+        state.isPaused = paused;
+    }
+    
+    function _snapshotYSState() internal view returns (YSState memory state) {
+        // Read vestingState for lastSharePrice, vestingGains, and lastVestingUpdate
+        (
+            uint128 lastSharePrice,
+            uint128 vestingGains,
+            uint128 lastVestingUpdate,
+            ,                        // startVestingTime
+                                     // endVestingTime (last)
+        ) = accountantYS.vestingState();
+        
+        state.lastSharePrice = lastSharePrice;
+        state.lastVestingUpdate = lastVestingUpdate;
+        state.vestingGains = vestingGains;
+        state.pendingGains = accountantYS.getPendingVestingGains();
+        state.totalSupply = vaultYS.totalSupply();
+    }
+    
+    /// @notice Setup call metadata without capturing state (for handlers that need time warps first)
+    function _setupCall(bytes4 selector) internal {
+        lastSelector = selector;
+        lastCallSucceeded = false;
+    }
+    
+    /// @notice Capture pre-state snapshots - call this AFTER any time warps but BEFORE the actual call
+    function _capturePreState() internal {
+        preRP = _snapshotRPState();
+        preYS = _snapshotYSState();
+        preYSAccountant = _snapshotYSAccountantState();
+    }
+    
+    /// @notice Combined setup + capture for handlers without time warps (backwards compatible)
+    function _beforeCall(bytes4 selector) internal {
+        _setupCall(selector);
+        _capturePreState();
+    }
+    
+    function _afterCall() internal {
+        postRP = _snapshotRPState();
+        postYS = _snapshotYSState();
+        postYSAccountant = _snapshotYSAccountantState();
+    }
+    
+    // ============================================
+    // RATE PROVIDER ACCOUNTANT HANDLERS
+    // ============================================
+    
+    /**
+     * @notice Update exchange rate on AccountantWithRateProviders
+     * @param newRate The new exchange rate to set
+     * @param timeDelta Time to warp forward before calling (set to 0 to test timing constraints)
+     */
+    function updateExchangeRateRP(uint96 newRate, uint256 timeDelta) external {
+        _beforeCall(AccountantWithRateProviders.updateExchangeRate.selector);
+        
+        // Bound timeDelta - allows testing both normal updates and timing edge cases
+        vm.warp(block.timestamp + bound(timeDelta, 0, 30 days));
+        syncVestedAssets();
+        
+        uint256 totalSupply = vaultRP.totalSupply();
+        if (totalSupply == 0) {
+            _afterCall();
+            return;
+        }
+        
+        // Calculate bounds and new rate (uses helper functions to avoid stack-too-deep)
+        (uint256 minRate, uint256 maxRate) = _calculateRPRateBounds(totalSupply);
+        
+        // If no valid range exists, skip - system is in an extreme state
+        if (minRate > maxRate) {
+            _afterCall();
+            return;
+        }
+        
+        newRate = uint96(bound(newRate, minRate, maxRate));
+        
+        vm.prank(owner);
+        try accountantRP.updateExchangeRate(newRate) {
+            lastCallSucceeded = true;
+            feesRecentlyClaimed = false;
+            altAssetRateChanged = false;
+        } catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Helper to calculate rate bounds for RP system
+     * @dev Intersects solvency-based bounds with contract's allowed rate change bounds.
+     *      This ensures updateExchangeRate never triggers auto-pause from exceeding bounds.
+     */
+    function _calculateRPRateBounds(uint256 totalSupply) internal view returns (uint256 minRate, uint256 maxRate) {
+        // Calculate solvency-based bounds (0.99x to 1.01x of NAV/supply)
+        (uint256 minSolvencyRate, uint256 maxSolvencyRate) = _getSolvencyRateBoundsRP(totalSupply);
+        
+        // Get contract's allowed rate change bounds
+        (uint256 contractMinRate, uint256 contractMaxRate) = _getContractRateBoundsRP();
+        
+        // Intersect solvency bounds with contract bounds
+        minRate = minSolvencyRate > contractMinRate ? minSolvencyRate : contractMinRate;
+        maxRate = maxSolvencyRate < contractMaxRate ? maxSolvencyRate : contractMaxRate;
+    }
+    
+    function _getSolvencyRateBoundsRP(uint256 totalSupply) internal view returns (uint256 minRate, uint256 maxRate) {
+        uint256 baseRate = accountantRP.getRateInQuoteSafe(baseAsset);
+        
+        if (baseRate == 0) {
+            // Cannot calculate solvency without a valid base rate
+            return (1, type(uint96).max);
+        }
+        
+        // Calculate total value in share terms using the accountant's rate calculations
+        // This matches how Teller computes shares: shares = amount * ONE_SHARE / rateInQuote
+        uint256 totalValueInShares = 0;
+        
+        // Base asset value
+        uint256 baseBalance = baseAsset.balanceOf(address(vaultRP));
+        if (baseBalance > 0) {
+            totalValueInShares += baseBalance * ONE_SHARE / baseRate;
+        }
+        
+        // Alternative assets value
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            uint256 altBalance = alternativeAssets[i].balanceOf(address(vaultRP));
+            if (altBalance > 0) {
+                try accountantRP.getRateInQuoteSafe(alternativeAssets[i]) returns (uint256 altRate) {
+                    if (altRate > 0) {
+                        totalValueInShares += altBalance * ONE_SHARE / altRate;
+                    }
+                } catch {
+                    // Asset not configured, skip
+                }
+            }
+        }
+        
+        // Calculate the rate that would make the vault solvent
+        uint256 solvencyRate = totalValueInShares * baseRate / totalSupply;
+        
+        // Use 0.05% buffer (tighter than invariant's 0.1% tolerance)
+        minRate = solvencyRate * 9995 / 10000;  // 99.95%
+        maxRate = solvencyRate * 10005 / 10000; // 100.05%
+        
+        // Enforce absolute bounds to prevent extreme rates
+        uint256 ABSOLUTE_MIN_RATE = 1e15;  // 0.001 tokens per share
+        uint256 ABSOLUTE_MAX_RATE = 1e21;  // 1000 tokens per share
+        
+        if (minRate < ABSOLUTE_MIN_RATE) minRate = ABSOLUTE_MIN_RATE;
+        if (maxRate > ABSOLUTE_MAX_RATE) maxRate = ABSOLUTE_MAX_RATE;
+        if (maxRate > type(uint96).max) maxRate = type(uint96).max;
+    }
+    
+    function _getContractRateBoundsRP() internal view returns (uint256 minRate, uint256 maxRate) {
+        (, , , , uint96 currentRate, uint16 upper, uint16 lower, , , , , ) = accountantRP.accountantState();
+        minRate = uint256(currentRate) * lower / 10000;
+        maxRate = uint256(currentRate) * upper / 10000;
+        if (minRate == 0) minRate = 1;
+        if (maxRate > type(uint96).max) maxRate = type(uint96).max;
+    }
+    
+    /**
+     * @notice Pause AccountantWithRateProviders
+     */
+    function pauseRP() external {
+        _beforeCall(AccountantWithRateProviders.pause.selector);
+        
+        vm.prank(owner);
+        try accountantRP.pause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Unpause AccountantWithRateProviders
+     */
+    function unpauseRP() external {
+        _beforeCall(AccountantWithRateProviders.unpause.selector);
+        
+        vm.prank(owner);
+        try accountantRP.unpause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Reset highwater mark on AccountantWithRateProviders
+     */
+    function resetHighwaterMarkRP() external {
+        _beforeCall(AccountantWithRateProviders.resetHighwaterMark.selector);
+        
+        vm.prank(owner);
+        try accountantRP.resetHighwaterMark() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update platform fee
+     */
+    function updatePlatformFeeRP(uint16 fee) external {
+        _beforeCall(AccountantWithRateProviders.updatePlatformFee.selector);
+        
+        fee = uint16(bound(fee, 0, 2000)); // Max 20%
+        
+        vm.prank(owner);
+        try accountantRP.updatePlatformFee(fee) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update performance fee
+     */
+    function updatePerformanceFeeRP(uint16 fee) external {
+        _beforeCall(AccountantWithRateProviders.updatePerformanceFee.selector);
+        
+        fee = uint16(bound(fee, 0, 5000)); // Max 50%
+        
+        vm.prank(owner);
+        try accountantRP.updatePerformanceFee(fee) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update exchange rate bounds
+     * @dev Covers both normal and edge case ranges:
+     *      - upper: 100% to 200% (allows testing normal 1-5% and extreme 50%+ changes)
+     *      - lower: 50% to 100% (allows testing normal 1-5% and extreme 50% drops)
+     */
+    function updateBoundsRP(uint16 upper, uint16 lower) external {
+        _beforeCall(AccountantWithRateProviders.updateUpper.selector);
+        
+        upper = uint16(bound(upper, 10000, 20000)); // 100% to 200%
+        lower = uint16(bound(lower, 5000, 10000));  // 50% to 100%
+        
+        vm.startPrank(owner);
+        try accountantRP.updateUpper(upper) {} catch {}
+        try accountantRP.updateLower(lower) {} catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update minimum delay
+     */
+    function updateDelayRP(uint24 delay) external {
+        _beforeCall(AccountantWithRateProviders.updateDelay.selector);
+        
+        delay = uint24(bound(delay, 0, 14 days));
+        
+        vm.prank(owner);
+        try accountantRP.updateDelay(delay) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Claim fees from AccountantWithRateProviders
+     * @dev After claiming fees, solvency invariants skip until rate is updated.
+     */
+    function claimFeesRP() external {
+        _beforeCall(AccountantWithRateProviders.claimFees.selector);
+        
+        vm.startPrank(address(vaultRP));
+        baseAsset.approve(address(accountantRP), type(uint256).max);
+        try accountantRP.claimFees(baseAsset) {
+            feesRecentlyClaimed = true;
+        } catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    
+    /**
+     * @notice Set rate provider data for an asset
+     * @dev Tests dynamic rate provider configuration changes.
+     * @param assetIndex The alternative asset index (0 to NUM_ALT_ASSETS-1)
+     * @param isPeggedToBase Whether the asset is pegged 1:1 to base
+     */
+    function setRateProviderDataRP(uint256 assetIndex, bool isPeggedToBase) external {
+        _beforeCall(AccountantWithRateProviders.setRateProviderData.selector);
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS - 1);
+        
+        ERC20 asset = alternativeAssets[assetIndex];
+        address rateProvider = isPeggedToBase ? address(0) : address(altAssetRateProviders[assetIndex]);
+        
+        vm.prank(owner);
+        try accountantRP.setRateProviderData(asset, isPeggedToBase, rateProvider) {
+            // Rate provider config changed - set flag so solvency invariants skip
+            // In production, strategist would update rate after this
+            altAssetRateChanged = true;
+        } catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update payout address
+     */
+    function updatePayoutAddressRP(address newPayout) external {
+        _beforeCall(AccountantWithRateProviders.updatePayoutAddress.selector);
+        
+        vm.prank(owner);
+        try accountantRP.updatePayoutAddress(newPayout) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Change the alternative asset rate provider rate (parameterized by asset index)
+     * @dev Tests multi-asset solvency across different rate scenarios.
+     *      Rates must be in the QUOTE TOKEN's decimals, not 18 decimals.
+     *      Bounds are realistic oracle movements (50% to 200%) to avoid extreme
+     *      rounding scenarios that mask real bugs.
+     * @param assetIndex The index of the alternative asset (0 to NUM_ALT_ASSETS-1)
+     * @param newRate The new rate to set (bounded to realistic oracle movement)
+     */
+    function setAltAssetRate(uint256 assetIndex, uint256 newRate) external {
+        _beforeCall(bytes4(keccak256("setAltAssetRate(uint256,uint256)")));
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS - 1);
+        
+        uint8 assetDecimals = ALT_ASSET_DECIMALS[assetIndex];
+        uint256 oneUnit = 10 ** assetDecimals;
+        
+        // Bound rate: 50% to 200% of unit rate (realistic oracle movement)
+        // This avoids extreme rounding-to-zero scenarios while still testing
+        // meaningful rate fluctuations that could expose real bugs
+        newRate = bound(newRate, oneUnit / 2, oneUnit * 2);
+        
+        altAssetRateProviders[assetIndex].setRate(newRate);
+        altAssetRateChanged = true;
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // YIELD STREAMING ACCOUNTANT HANDLERS
+    // ============================================
+    
+    /**
+     * @notice Sync vault balance with vested yield
+     * @dev In production, yield assets flow into the vault as they vest.
+     *      This helper calculates how much has vested and mints that amount.
+     *      Called after any time-advancing operation to maintain solvency.
+     *      Made public so TellerHandler can also sync after time warps.
+     *
+     *      Important: getPendingVestingGains() can DECREASE when _updateExchangeRate()
+     *      is called (by vestYield, postLoss, updateExchangeRate). This "realizes" the
+     *      vested gains by moving them from vestingGains to lastSharePrice. When this
+     *      happens, we need to reset our tracking to match the new state.
+     */
+    function syncVestedAssets() public {
+        // Get current pending vesting gains (how much has vested so far but not yet realized)
+        uint256 currentVested = accountantYS.getPendingVestingGains();
+        
+        if (currentVested > cumulativeVestedAssetsReleased) {
+            // New vesting has occurred - mint the difference to YS vault
+            uint256 newlyVested = currentVested - cumulativeVestedAssetsReleased;
+            deal(address(baseAsset), address(vaultYS), baseAsset.balanceOf(address(vaultYS)) + newlyVested);
+            cumulativeVestedAssetsReleased = currentVested;
+        } else if (currentVested < cumulativeVestedAssetsReleased) {
+            // Gains were "realized" by _updateExchangeRate() being called
+            // (vestYield, postLoss, or updateExchangeRate)
+            // Reset tracking to match new state - no minting needed since
+            // we already minted for those gains before they were realized
+            cumulativeVestedAssetsReleased = currentVested;
+        }
+        // If equal, do nothing
+    }
+    
+    /**
+     * @notice Fix vesting state after a deposit to an empty vault created invalid state
+     * @dev Called by TellerHandler after depositYS/bulkDepositYS when vault was empty
+     *      This corrects the startVestingTime > endVestingTime condition by doing a minimal vestYield
+     */
+    function fixVestingStateAfterFirstDeposit() external {
+        // Check if vesting state is invalid
+        (, , , uint64 startTime, uint64 endTime) = accountantYS.vestingState();
+        
+        // Only fix if we have an invalid state: startVestingTime > endVestingTime
+        // and there are shares (deposit succeeded)
+        if (startTime <= endTime || vaultYS.totalSupply() == 0) return;
+        
+        // Reset vesting state by doing a minimal vestYield call
+        syncVestedAssets();
+        
+        // Get min vesting duration
+        uint64 minVest = accountantYS.minimumVestingTime();
+        uint64 maxVest = accountantYS.maximumVestingTime();
+        uint256 duration = minVest > 0 ? minVest : 1 days;
+        if (duration > maxVest && maxVest > 0) duration = maxVest;
+        
+        // Calculate safe yield amount that will pass the daily yield check:
+        // dailyYieldBps = (yieldAmount * 1 day / duration) * 10000 / totalAssets
+        // For it to pass: dailyYieldBps <= maxDeviationYield
+        // Therefore: yieldAmount <= totalAssets * maxDeviationYield * duration / (10000 * 1 day)
+        uint256 totalAssets = accountantYS.totalAssets();
+        uint32 maxDeviation = accountantYS.maxDeviationYield();
+        
+        // Calculate max safe yield - use 1% of max deviation to be safe
+        // yieldAmount = totalAssets * maxDeviation * duration / (10000 * 1 days * 100)
+        uint256 yieldAmount;
+        if (totalAssets > 0) {
+            yieldAmount = totalAssets.mulDivDown(maxDeviation, 10000);
+            yieldAmount = yieldAmount.mulDivDown(duration, 1 days);
+            yieldAmount = yieldAmount / 100; // Use 1% of max to be very safe
+            if (yieldAmount == 0) yieldAmount = 1;
+        } else {
+            yieldAmount = 1;
+        }
+        
+        // Ensure vault has enough assets for the yield
+        uint256 vaultBal = baseAsset.balanceOf(address(vaultYS));
+        if (vaultBal < totalAssets + yieldAmount) {
+            deal(address(baseAsset), address(vaultYS), totalAssets + yieldAmount);
+        }
+        
+        vm.prank(strategist);
+        try accountantYS.vestYield(yieldAmount, duration) {
+            // Success - vesting state is now valid
+            cumulativeVestedAssetsReleased = 0; // Reset tracking for new vest
+        } catch {
+            // If vestYield fails, the invariant will catch the invalid state
+            // This is expected if the contract has checks we can't bypass
+        }
+    }
+    
+    /**
+     * @notice Vest yield on AccountantWithYieldStreaming
+     * @param yieldAmount The amount of yield to vest (bounded dynamically based on totalAssets)
+     * @param duration The vesting duration
+     * @param timeDelta Time to warp forward before calling
+     * @dev Simulates yield vesting by tracking progress and minting proportionally.
+     *      Yield is bounded to 0.01%-50% of totalAssets to test both normal and edge cases.
+     */
+    function vestYield(uint256 yieldAmount, uint256 duration, uint256 timeDelta) external {
+        _setupCall(AccountantWithYieldStreaming.vestYield.selector);
+        
+        // Cannot vest yield if vault has no shares
+        if (vaultYS.totalSupply() == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        syncVestedAssets();
+        vm.warp(block.timestamp + bound(timeDelta, 0, 90 days));
+        syncVestedAssets();
+        
+        // Calculate yield bounds based on totalAssets for realistic testing
+        uint256 totalAssets = accountantYS.totalAssets();
+        uint256 minYield = totalAssets > 10000 ? totalAssets / 10000 : 1;  // 0.01%
+        uint256 maxYield = totalAssets > 2 ? totalAssets / 2 : 100_000e18; // 50%
+        
+        yieldAmount = bound(yieldAmount, minYield, maxYield);
+        duration = bound(duration, 1 hours, 30 days);
+        
+        _capturePreState();
+        
+        vm.prank(strategist);
+        try accountantYS.vestYield(yieldAmount, duration) {} catch {}
+        
+        syncVestedAssets();
+        _afterCall();
+    }
+    
+    /**
+     * @notice Post loss on AccountantWithYieldStreaming
+     * @param lossAmount The amount of loss to post (max 10% of total assets)
+     * @param timeDelta Time to warp forward before calling
+     * @dev Loss can be absorbed by unvested gains or reduce principal.
+     */
+    function postLoss(uint256 lossAmount, uint256 timeDelta) external {
+        _setupCall(AccountantWithYieldStreaming.postLoss.selector);
+        
+        if (vaultYS.totalSupply() == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        uint256 totalAssets = accountantYS.totalAssets();
+        uint256 maxLoss = totalAssets / 10;
+        if (maxLoss == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        lossAmount = bound(lossAmount, 1, maxLoss);
+        
+        vm.warp(block.timestamp + bound(timeDelta, 0, 90 days));
+        syncVestedAssets();
+        _capturePreState();
+        
+        // Get unvested gains to calculate principal loss
+        (, uint128 vestingGains, , , ) = accountantYS.vestingState();
+        uint256 pendingVested = accountantYS.getPendingVestingGains();
+        uint256 unvestedGains = vestingGains > pendingVested ? vestingGains - pendingVested : 0;
+        
+        vm.prank(strategist);
+        try accountantYS.postLoss(lossAmount) {
+            lastCallSucceeded = true;
+            
+            // Remove assets for principal loss (portion not absorbed by unvested gains)
+            if (lossAmount > unvestedGains) {
+                uint256 principalLoss = lossAmount - unvestedGains;
+                uint256 vaultBal = baseAsset.balanceOf(address(vaultYS));
+                deal(address(baseAsset), address(vaultYS), vaultBal > principalLoss ? vaultBal - principalLoss : 0);
+            }
+        } catch {}
+        
+        syncVestedAssets();
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update exchange rate on AccountantWithYieldStreaming (no-arg version)
+     * @param timeDelta Time to warp forward before calling
+     * @dev Realizes vested gains by calling _updateExchangeRate() internally.
+     */
+    function updateExchangeRateYS(uint256 timeDelta) external {
+        _setupCall(bytes4(keccak256("updateExchangeRate()")));
+        
+        if (vaultYS.totalSupply() == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        vm.warp(block.timestamp + bound(timeDelta, 0, 30 days));
+        syncVestedAssets();
+        _capturePreState();
+        
+        vm.prank(strategist);
+        try accountantYS.updateExchangeRate() {} catch {}
+        
+        syncVestedAssets();
+        _afterCall();
+    }
+    
+    /**
+     * @notice Pause AccountantWithYieldStreaming
+     */
+    function pauseYS() external {
+        _beforeCall(AccountantWithRateProviders.pause.selector);
+        
+        vm.prank(owner);
+        try accountantYS.pause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Unpause AccountantWithYieldStreaming
+     */
+    function unpauseYS() external {
+        _beforeCall(AccountantWithRateProviders.unpause.selector);
+        
+        vm.prank(owner);
+        try accountantYS.unpause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Reset highwater mark on AccountantWithYieldStreaming
+     */
+    function resetHighwaterMarkYS() external {
+        _beforeCall(AccountantWithRateProviders.resetHighwaterMark.selector);
+        
+        vm.prank(owner);
+        try accountantYS.resetHighwaterMark() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update vesting parameters
+     * @dev Covers both normal and edge case ranges with proper min <= max enforcement.
+     *      Duration: 1 hour to 90 days, Deviations: 0.1% to 50%
+     */
+    function updateVestingParams(uint64 minVest, uint64 maxVest, uint32 maxYield, uint32 maxLoss) external {
+        _beforeCall(AccountantWithYieldStreaming.updateMaximumVestDuration.selector);
+        
+        // Wide ranges covering both normal and edge cases
+        minVest = uint64(bound(minVest, 1 hours, 30 days));
+        maxVest = uint64(bound(maxVest, 1 hours, 90 days));
+        
+        // Ensure minVest <= maxVest
+        if (minVest > maxVest) {
+            (minVest, maxVest) = (maxVest, minVest);
+        }
+        
+        maxYield = uint32(bound(maxYield, 10, 5000)); // 0.1% to 50%
+        maxLoss = uint32(bound(maxLoss, 10, 5000));   // 0.1% to 50%
+        
+        vm.startPrank(owner);
+        // Set maxVest FIRST to avoid intermediate invalid state
+        try accountantYS.updateMaximumVestDuration(maxVest) {} catch {}
+        try accountantYS.updateMinimumVestDuration(minVest) {} catch {}
+        try accountantYS.updateMaximumDeviationYield(maxYield) {} catch {}
+        try accountantYS.updateMaximumDeviationLoss(maxLoss) {} catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Claim fees from AccountantWithYieldStreaming
+     */
+    function claimFeesYS() external {
+        _beforeCall(AccountantWithRateProviders.claimFees.selector);
+        
+        vm.startPrank(address(vaultYS));
+        baseAsset.approve(address(accountantYS), type(uint256).max);
+        try accountantYS.claimFees(baseAsset) {
+            feesRecentlyClaimed = true;
+        } catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // TIME PASSAGE HANDLER
+    // ============================================
+    
+    /**
+     * @notice Warp time forward to simulate long-duration vesting
+     * @dev Also syncs vested assets to simulate production yield flow
+     */
+    function warpTime(uint256 timeDelta) external {
+        timeDelta = bound(timeDelta, 1, 365 days);
+        vm.warp(block.timestamp + timeDelta);
+        
+        // After time passes, sync vested assets to vault
+        // This simulates production where yield flows into vault as it vests
+        syncVestedAssets();
+    }
+    
+    // ============================================
+    // EXTERNAL STATE CAPTURE (for TellerHandler to use)
+    // ============================================
+    
+    /// @notice Begin a YS operation from TellerHandler - captures pre-state
+    /// @param selector The selector of the operation (for invariant checking)
+    function beginYSOperation(bytes4 selector) external {
+        _setupCall(selector);
+        _capturePreState();
+    }
+    
+    /// @notice End a YS operation from TellerHandler - captures post-state
+    /// @param succeeded Whether the operation succeeded
+    function endYSOperation(bool succeeded) external {
+        lastCallSucceeded = succeeded;
+        _afterCall();
+    }
+    
+    // ============================================
+    // STRUCT GETTERS (needed because public structs return tuples)
+    // ============================================
+    
+    function getPreRP() external view returns (RPState memory) {
+        return preRP;
+    }
+    
+    function getPostRP() external view returns (RPState memory) {
+        return postRP;
+    }
+    
+    function getPreYS() external view returns (YSState memory) {
+        return preYS;
+    }
+    
+    function getPostYS() external view returns (YSState memory) {
+        return postYS;
+    }
+    
+    function getPreYSAccountant() external view returns (RPState memory) {
+        return preYSAccountant;
+    }
+    
+    function getPostYSAccountant() external view returns (RPState memory) {
+        return postYSAccountant;
+    }
+    
+}
+

--- a/test/fuzzing/handlers/TellerHandler.sol
+++ b/test/fuzzing/handlers/TellerHandler.sol
@@ -1,0 +1,1146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+// Test and console unused but keeping for debugging if needed
+import {CommonBase} from "@forge-std/Base.sol";
+import {StdCheats} from "@forge-std/StdCheats.sol";
+import {StdUtils} from "@forge-std/StdUtils.sol";
+
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {AccountantHandler} from "./AccountantHandler.sol";
+
+/**
+ * @title TellerHandler
+ * @notice Handler contract for fuzzing teller operations with ghost state tracking
+ * @dev Tracks pre/post state for invariant verification
+ */
+contract TellerHandler is CommonBase, StdCheats, StdUtils {
+    using FixedPointMathLib for uint256;
+
+    // ============================================
+    // CONSTANTS
+    // ============================================
+    
+    uint256 public constant NUM_ALT_ASSETS = 5;
+    
+    // Decimals for each alternative asset (must match BaseSetup)
+    // Index 0: 18 decimals (standard ERC20)
+    // Index 1: 6 decimals (USDC-like)
+    // Index 2: 6 decimals (USDT-like)
+    // Index 3: 8 decimals (WBTC-like)
+    // Index 4: 11 decimals (unusual, edge case)
+    uint8[5] public ALT_ASSET_DECIMALS = [18, 6, 6, 8, 11];
+
+    // ============================================
+    // CONTRACTS
+    // ============================================
+    
+    TellerWithMultiAssetSupport public tellerMAS;
+    TellerWithYieldStreaming public tellerYS;
+    BoringVault public vaultRP;  // Vault for RP system (MAS teller)
+    BoringVault public vaultYS;  // Vault for YS system (YS teller)
+    ERC20 public baseAsset;
+    
+    // Multiple alternative assets for RP multi-asset testing
+    ERC20[] public alternativeAssets;
+    
+    AccountantHandler public accountantHandler;
+    
+    address public owner;
+    address public solver;
+    address public deniedUser;
+    address[] public actors;
+    
+    // ============================================
+    // GHOST STATE - Pre-call snapshots
+    // ============================================
+    
+    struct TellerState {
+        uint64 depositNonce;
+        uint64 shareLockPeriod;
+        bool isPaused;
+        uint112 depositCap;
+        uint256 vaultTotalSupply;
+        uint256 vaultBaseBalance;
+        uint256[5] vaultAltBalances;  // Balances for each alternative asset
+        uint256 tellerBaseBalance;
+        uint256[5] tellerAltBalances; // Balances for each alternative asset
+    }
+    
+    struct UserState {
+        uint256 shares;
+        uint256 baseBalance;
+        uint256 shareUnlockTime;
+        bool denyFrom;
+        bool denyTo;
+        bool denyOperator;
+    }
+    
+    TellerState public preMAS;
+    TellerState public postMAS;
+    TellerState public preYS;
+    TellerState public postYS;
+    
+    mapping(address => UserState) public preUserState;
+    mapping(address => UserState) public postUserState;
+    
+    // Current actor being used in operations
+    address public currentActor;
+    
+    // ============================================
+    // TRACKING VARIABLES
+    // ============================================
+    
+    // Track the last selector called
+    bytes4 public lastSelector;
+    
+    // External call tracking (always false - no unauthorized calls in handlers)
+    bool public constant callMade = false;
+    bool public constant delegatecallMade = false;
+    
+    // Counters for statistics (successful calls)
+    uint256 public depositCalls;
+    uint256 public withdrawCalls;
+    uint256 public bulkDepositCalls;
+    uint256 public bulkWithdrawCalls;
+    
+    // Track deposit history for refund testing
+    struct DepositRecord {
+        address receiver;
+        address depositAsset;
+        uint256 depositAmount;
+        uint256 shareAmount;
+        uint256 timestamp;
+        uint256 shareLockPeriod;
+        address referralAddress;
+        bool refunded;
+    }
+    
+    mapping(uint256 => DepositRecord) public depositHistory;
+    uint256[] public depositNonces;
+    
+    // Round-trip tracking for no-free-assets invariant
+    uint256 public lastDepositAssets;
+    uint256 public lastDepositShares;
+    uint256 public lastWithdrawAssets;
+    uint256 public lastWithdrawShares;
+    
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+    
+    constructor(
+        address _tellerMAS,
+        address _tellerYS,
+        address _vaultRP,
+        address _vaultYS,
+        address _baseAsset,
+        address[] memory _alternativeAssets,
+        address _owner,
+        address _solver,
+        address _deniedUser,
+        address[] memory _actors
+    ) {
+        require(_alternativeAssets.length == NUM_ALT_ASSETS, "Must provide NUM_ALT_ASSETS alternative assets");
+        
+        tellerMAS = TellerWithMultiAssetSupport(_tellerMAS);
+        tellerYS = TellerWithYieldStreaming(_tellerYS);
+        vaultRP = BoringVault(payable(_vaultRP));
+        vaultYS = BoringVault(payable(_vaultYS));
+        baseAsset = ERC20(_baseAsset);
+        
+        // Initialize alternative assets array
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            alternativeAssets.push(ERC20(_alternativeAssets[i]));
+        }
+        
+        owner = _owner;
+        solver = _solver;
+        deniedUser = _deniedUser;
+        actors = _actors;
+    }
+    
+    /**
+     * @notice Set the AccountantHandler reference for vesting sync
+     * @dev Called after construction to link TellerHandler with AccountantHandler
+     */
+    function setAccountantHandler(address _accountantHandler) external {
+        accountantHandler = AccountantHandler(_accountantHandler);
+    }
+    
+    // ============================================
+    // SNAPSHOT FUNCTIONS
+    // ============================================
+    
+    function _snapshotTellerMASState() internal view returns (TellerState memory state) {
+        state.depositNonce = tellerMAS.depositNonce();
+        state.shareLockPeriod = tellerMAS.shareLockPeriod();
+        state.isPaused = tellerMAS.isPaused();
+        state.depositCap = tellerMAS.depositCap();
+        state.vaultTotalSupply = vaultRP.totalSupply();
+        state.vaultBaseBalance = baseAsset.balanceOf(address(vaultRP));
+        state.tellerBaseBalance = baseAsset.balanceOf(address(tellerMAS));
+        
+        // Snapshot all alternative asset balances
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            state.vaultAltBalances[i] = alternativeAssets[i].balanceOf(address(vaultRP));
+            state.tellerAltBalances[i] = alternativeAssets[i].balanceOf(address(tellerMAS));
+        }
+    }
+    
+    function _snapshotTellerYSState() internal view returns (TellerState memory state) {
+        state.depositNonce = tellerYS.depositNonce();
+        state.shareLockPeriod = tellerYS.shareLockPeriod();
+        state.isPaused = tellerYS.isPaused();
+        state.depositCap = tellerYS.depositCap();
+        state.vaultTotalSupply = vaultYS.totalSupply();
+        state.vaultBaseBalance = baseAsset.balanceOf(address(vaultYS));
+        state.tellerBaseBalance = baseAsset.balanceOf(address(tellerYS));
+        
+        // YS only uses base asset, but snapshot alt balances as 0 for consistency
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            state.vaultAltBalances[i] = 0;
+            state.tellerAltBalances[i] = 0;
+        }
+    }
+    
+    function _snapshotUserState(address user) internal view returns (UserState memory state) {
+        // Track shares in both vaults
+        state.shares = vaultRP.balanceOf(user) + vaultYS.balanceOf(user);
+        state.baseBalance = baseAsset.balanceOf(user);
+        
+        (bool denyFrom, bool denyTo, bool denyOperator, , uint256 unlockTime) = tellerMAS.beforeTransferData(user);
+        state.shareUnlockTime = unlockTime;
+        state.denyFrom = denyFrom;
+        state.denyTo = denyTo;
+        state.denyOperator = denyOperator;
+    }
+    
+    function _beforeCall(bytes4 selector, address actor) internal {
+        lastSelector = selector;
+        currentActor = actor;
+        
+        // Reset operation tracking - only set if current call succeeds
+        lastDepositAssets = 0;
+        lastDepositShares = 0;
+        lastWithdrawAssets = 0;
+        lastWithdrawShares = 0;
+        
+        preMAS = _snapshotTellerMASState();
+        preYS = _snapshotTellerYSState();
+        
+        for (uint256 i = 0; i < actors.length; i++) {
+            preUserState[actors[i]] = _snapshotUserState(actors[i]);
+        }
+        preUserState[deniedUser] = _snapshotUserState(deniedUser);
+        preUserState[solver] = _snapshotUserState(solver);
+    }
+    
+    function _afterCall() internal {
+        postMAS = _snapshotTellerMASState();
+        postYS = _snapshotTellerYSState();
+        
+        for (uint256 i = 0; i < actors.length; i++) {
+            postUserState[actors[i]] = _snapshotUserState(actors[i]);
+        }
+        postUserState[deniedUser] = _snapshotUserState(deniedUser);
+        postUserState[solver] = _snapshotUserState(solver);
+    }
+    
+    function _getRandomActor(uint256 seed) internal view returns (address) {
+        return actors[seed % actors.length];
+    }
+    
+    /**
+     * @notice Find an actor with YS vault shares
+     * @param seed Random seed for starting position
+     * @return actor Address with shares, or address(0) if none found
+     */
+    function _getActorWithSharesYS(uint256 seed) internal view returns (address) {
+        uint256 len = actors.length;
+        uint256 startIdx = seed % len;
+        for (uint256 i = 0; i < len; i++) {
+            address candidate = actors[(startIdx + i) % len];
+            if (vaultYS.balanceOf(candidate) > 0) {
+                return candidate;
+            }
+        }
+        return address(0);
+    }
+    
+    // ============================================
+    // MULTI-ASSET SUPPORT TELLER HANDLERS
+    // ============================================
+    
+    /**
+     * @notice Deposit into TellerWithMultiAssetSupport
+     */
+    function depositMAS(uint256 actorSeed, uint256 amount, uint256 minShares) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.deposit.selector, actor);
+        
+        amount = bound(amount, 1, 100_000e18);
+        
+        // Calculate expected shares based on current rate to set realistic minShares
+        uint256 rate = accountantHandler.accountantRP().getRate();
+        uint256 expectedShares = (amount * 1e18) / rate;
+        // Bound minShares to 0-95% of expected to allow some slippage margin
+        minShares = bound(minShares, 0, (expectedShares * 95) / 100);
+        
+        vm.startPrank(actor);
+        baseAsset.approve(address(vaultRP), amount);
+        
+        uint256 shares = tellerMAS.deposit(baseAsset, amount, minShares, address(0));
+        
+        if (shares > 0) {
+            depositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+            
+            uint64 nonce = tellerMAS.depositNonce();
+            depositHistory[nonce] = DepositRecord({
+                receiver: actor,
+                depositAsset: address(baseAsset),
+                depositAmount: amount,
+                shareAmount: shares,
+                timestamp: block.timestamp,
+                shareLockPeriod: tellerMAS.shareLockPeriod(),
+                referralAddress: address(0),
+                refunded: false
+            });
+            depositNonces.push(nonce);
+        }
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Withdraw from TellerWithMultiAssetSupport
+     */
+    function withdrawMAS(uint256 actorSeed, uint256 shareAmount, uint256 minAssets, uint256 timeDelta) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.withdraw.selector, actor);
+        
+        uint256 actorShares = vaultRP.balanceOf(actor);
+        if (actorShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        shareAmount = bound(shareAmount, 1, actorShares);
+        minAssets = bound(minAssets, 0, shareAmount);
+        timeDelta = bound(timeDelta, 0, 7 days);
+        
+        vm.warp(block.timestamp + timeDelta);
+        if (address(accountantHandler) != address(0)) accountantHandler.syncVestedAssets();
+        
+        vm.startPrank(actor);
+        uint256 assets = tellerMAS.withdraw(baseAsset, shareAmount, minAssets, actor);
+        withdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Bulk deposit via solver
+     */
+    function bulkDepositMAS(uint256 amount, uint256 minShares, uint256 actorSeed) external {
+        address recipient = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.bulkDeposit.selector, solver);
+        
+        amount = bound(amount, 1, 100_000e18);
+        
+        // Calculate expected shares based on current rate to set realistic minShares
+        uint256 rate = accountantHandler.accountantRP().getRate();
+        uint256 expectedShares = (amount * 1e18) / rate;
+        // Bound minShares to 0-95% of expected to allow some slippage margin
+        minShares = bound(minShares, 0, (expectedShares * 95) / 100);
+        
+        vm.startPrank(solver);
+        baseAsset.approve(address(vaultRP), amount);
+        
+        uint256 shares = tellerMAS.bulkDeposit(baseAsset, amount, minShares, recipient);
+        if (shares > 0) {
+            bulkDepositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+        }
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Bulk withdraw via solver
+     */
+    function bulkWithdrawMAS(uint256 shareAmount, uint256 minAssets, uint256 actorSeed) external {
+        address recipient = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.bulkWithdraw.selector, solver);
+        
+        uint256 solverShares = vaultRP.balanceOf(solver);
+        if (solverShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        shareAmount = bound(shareAmount, 1, solverShares);
+        minAssets = bound(minAssets, 0, shareAmount);
+        
+        vm.startPrank(solver);
+        uint256 assets = tellerMAS.bulkWithdraw(baseAsset, shareAmount, minAssets, recipient);
+        bulkWithdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Refund a deposit
+     */
+    function refundDepositMAS(uint256 nonceIndex) external {
+        if (depositNonces.length == 0) return;
+        
+        nonceIndex = bound(nonceIndex, 0, depositNonces.length - 1);
+        uint256 nonce = depositNonces[nonceIndex];
+        DepositRecord storage record = depositHistory[nonce];
+        
+        if (record.refunded) return;
+        
+        _beforeCall(TellerWithMultiAssetSupport.refundDeposit.selector, owner);
+        
+        vm.prank(owner);
+        try tellerMAS.refundDeposit(
+            nonce,
+            record.receiver,
+            record.depositAsset,
+            record.depositAmount,
+            record.shareAmount,
+            record.timestamp,
+            record.shareLockPeriod,
+            record.referralAddress
+        ) {
+            record.refunded = true;
+        } catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Pause TellerWithMultiAssetSupport
+     */
+    function pauseMAS() external {
+        _beforeCall(TellerWithMultiAssetSupport.pause.selector, owner);
+        
+        vm.prank(owner);
+        try tellerMAS.pause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Unpause TellerWithMultiAssetSupport
+     */
+    function unpauseMAS() external {
+        _beforeCall(TellerWithMultiAssetSupport.unpause.selector, owner);
+        
+        vm.prank(owner);
+        try tellerMAS.unpause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Deny a user
+     */
+    function denyUserMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.denyAll.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.denyAll(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Allow a user
+     */
+    function allowUserMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.allowAll.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.allowAll(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Set share lock period
+     */
+    function setShareLockPeriodMAS(uint64 period) external {
+        _beforeCall(TellerWithMultiAssetSupport.setShareLockPeriod.selector, owner);
+        
+        period = uint64(bound(period, 0, 3 days));
+        
+        vm.prank(owner);
+        tellerMAS.setShareLockPeriod(period);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Set deposit cap
+     */
+    function setDepositCapMAS(uint112 cap) external {
+        _beforeCall(TellerWithMultiAssetSupport.setDepositCap.selector, owner);
+        
+        cap = uint112(bound(cap, 1, type(uint112).max));
+        
+        vm.prank(owner);
+        tellerMAS.setDepositCap(cap);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update asset data (allowDeposits, allowWithdraws, sharePremium)
+     */
+    function updateAssetDataMAS(uint256 assetIndex, bool allowDeposits, bool allowWithdraws, uint16 sharePremium) external {
+        _beforeCall(TellerWithMultiAssetSupport.updateAssetData.selector, owner);
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS);
+        sharePremium = uint16(bound(sharePremium, 0, 1000));
+        
+        ERC20 asset;
+        if (assetIndex == 0) {
+            asset = baseAsset;
+        } else {
+            asset = alternativeAssets[assetIndex - 1];
+        }
+        
+        vm.prank(owner);
+        tellerMAS.updateAssetData(asset, allowDeposits, allowWithdraws, sharePremium);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Small deposit for edge case testing
+     */
+    function depositTinyMAS(uint256 actorSeed, uint256 amount) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.deposit.selector, actor);
+        
+        amount = bound(amount, 1, 1e18);
+        
+        vm.startPrank(actor);
+        baseAsset.approve(address(vaultRP), amount);
+        
+        uint256 shares = tellerMAS.deposit(baseAsset, amount, 0, address(0));
+        if (shares > 0) {
+            depositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+        }
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Withdraw with zero time delta to test locked shares
+     */
+    function withdrawLockedMAS(uint256 actorSeed, uint256 shareAmount, uint256 minAssets) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.withdraw.selector, actor);
+        
+        uint256 actorShares = vaultRP.balanceOf(actor);
+        if (actorShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        shareAmount = bound(shareAmount, 1, actorShares);
+        minAssets = bound(minAssets, 0, shareAmount);
+        
+        vm.startPrank(actor);
+        uint256 assets = tellerMAS.withdraw(baseAsset, shareAmount, minAssets, actor);
+        withdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Withdraw with minAssets = 0 to test zero-output edge cases
+     */
+    function withdrawZeroMinMAS(uint256 actorSeed, uint256 shareAmount, uint256 timeDelta) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.withdraw.selector, actor);
+        
+        uint256 actorShares = vaultRP.balanceOf(actor);
+        if (actorShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        shareAmount = bound(shareAmount, 1, actorShares);
+        timeDelta = bound(timeDelta, 0, 7 days);
+        
+        vm.warp(block.timestamp + timeDelta);
+        if (address(accountantHandler) != address(0)) accountantHandler.syncVestedAssets();
+        
+        vm.startPrank(actor);
+        uint256 assets = tellerMAS.withdraw(baseAsset, shareAmount, 0, actor);
+        withdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Individual deny control - deny from only
+     */
+    function denyFromMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.denyFrom.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.denyFrom(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Individual deny control - deny to only
+     */
+    function denyToMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.denyTo.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.denyTo(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Individual allow control - allow from only
+     */
+    function allowFromMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.allowFrom.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.allowFrom(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Individual allow control - allow to only
+     */
+    function allowToMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.allowTo.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.allowTo(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Individual deny control - deny operator only
+     */
+    function denyOperatorMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.denyOperator.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.denyOperator(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Individual allow control - allow operator only
+     */
+    function allowOperatorMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.allowOperator.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.allowOperator(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Set permissioned transfers mode
+     */
+    function setPermissionedTransfersMAS(bool enabled) external {
+        _beforeCall(TellerWithMultiAssetSupport.setPermissionedTransfers.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.setPermissionedTransfers(enabled);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Allow a permissioned operator
+     */
+    function allowPermissionedOperatorMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.allowPermissionedOperator.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.allowPermissionedOperator(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Deny a permissioned operator
+     */
+    function denyPermissionedOperatorMAS(uint256 actorSeed) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.denyPermissionedOperator.selector, owner);
+        
+        vm.prank(owner);
+        tellerMAS.denyPermissionedOperator(actor);
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Test deposit near cap boundary
+     */
+    function depositNearCapMAS(uint256 actorSeed, uint256 amount) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.deposit.selector, actor);
+        
+        uint112 cap = tellerMAS.depositCap();
+        uint256 currentSupply = vaultRP.totalSupply();
+        
+        if (cap == type(uint112).max || currentSupply >= cap) {
+            _afterCall();
+            return;
+        }
+        
+        uint256 remainingCap = cap - currentSupply;
+        uint256 minAmount = remainingCap > 100 ? remainingCap - 100 : 1;
+        uint256 maxAmount = remainingCap + 100;
+        amount = bound(amount, minAmount, maxAmount);
+        
+        vm.startPrank(actor);
+        baseAsset.approve(address(vaultRP), amount);
+        
+        uint256 shares = tellerMAS.deposit(baseAsset, amount, 0, address(0));
+        if (shares > 0) {
+            depositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+        }
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Set deposit cap to a specific value near current supply
+     */
+    function setDepositCapNearSupplyMAS(uint256 offset) external {
+        _beforeCall(TellerWithMultiAssetSupport.setDepositCap.selector, owner);
+        
+        uint256 currentSupply = vaultRP.totalSupply();
+        offset = bound(offset, 0, 1000);
+        uint112 cap = uint112(bound(currentSupply + offset, 1, type(uint112).max));
+        
+        vm.prank(owner);
+        tellerMAS.setDepositCap(cap);
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // ALTERNATIVE ASSET HANDLERS (for multi-asset testing)
+    // ============================================
+    
+    /**
+     * @notice Deposit alternative asset into TellerWithMultiAssetSupport
+     */
+    function depositAltMAS(uint256 assetIndex, uint256 actorSeed, uint256 amount, uint256 minShares) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.deposit.selector, actor);
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS - 1);
+        
+        uint8 assetDecimals = ALT_ASSET_DECIMALS[assetIndex];
+        uint256 minAmount = 1;
+        uint256 maxAmount = 100_000 * (10 ** assetDecimals);
+        
+        amount = bound(amount, minAmount, maxAmount);
+        
+        // Calculate expected shares based on current rate to set realistic minShares
+        uint256 rate = accountantHandler.accountantRP().getRate();
+        uint256 amountIn18Dec = assetDecimals < 18 
+            ? amount * (10 ** (18 - assetDecimals))
+            : amount / (10 ** (assetDecimals - 18));
+        uint256 expectedShares = (amountIn18Dec * 1e18) / rate;
+        // Bound minShares to 0-95% of expected to allow some slippage margin
+        minShares = bound(minShares, 0, (expectedShares * 95) / 100);
+        
+        ERC20 altAsset = alternativeAssets[assetIndex];
+        
+        vm.startPrank(actor);
+        altAsset.approve(address(vaultRP), amount);
+        
+        uint256 shares = tellerMAS.deposit(altAsset, amount, minShares, address(0));
+        if (shares > 0) {
+            depositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+        }
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Withdraw alternative asset from TellerWithMultiAssetSupport
+     */
+    function withdrawAltMAS(uint256 assetIndex, uint256 actorSeed, uint256 shareAmount, uint256 minAssets, uint256 timeDelta) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.withdraw.selector, actor);
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS - 1);
+        
+        uint256 actorShares = vaultRP.balanceOf(actor);
+        if (actorShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        shareAmount = bound(shareAmount, 1, actorShares);
+        
+        uint8 assetDecimals = ALT_ASSET_DECIMALS[assetIndex];
+        uint256 shareAmountInAssetDecimals = assetDecimals < 18
+            ? shareAmount / (10 ** (18 - assetDecimals))
+            : shareAmount * (10 ** (assetDecimals - 18));
+        
+        uint256 maxMinAssets = shareAmountInAssetDecimals > 0 ? shareAmountInAssetDecimals : 1;
+        minAssets = bound(minAssets, 0, maxMinAssets);
+        
+        timeDelta = bound(timeDelta, 0, 7 days);
+        
+        vm.warp(block.timestamp + timeDelta);
+        if (address(accountantHandler) != address(0)) accountantHandler.syncVestedAssets();
+        
+        ERC20 altAsset = alternativeAssets[assetIndex];
+        
+        vm.startPrank(actor);
+        uint256 assets = tellerMAS.withdraw(altAsset, shareAmount, minAssets, actor);
+        withdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+
+        _afterCall();
+    }
+    
+    // ============================================
+    // YIELD STREAMING TELLER HANDLERS
+    // ============================================
+    
+    /**
+     * @notice Deposit into TellerWithYieldStreaming
+     */
+    function depositYS(uint256 actorSeed, uint256 amount, uint256 minShares) external {
+        address actor = _getRandomActor(actorSeed);
+        _beforeCall(TellerWithMultiAssetSupport.deposit.selector, actor);
+        
+        amount = bound(amount, 1, 100_000e18);
+        
+        // Calculate expected shares based on current rate to set realistic minShares
+        uint256 rate = accountantHandler.accountantYS().getRate();
+        uint256 expectedShares = (amount * 1e18) / rate;
+        // Bound minShares to 0-95% of expected to allow some slippage margin
+        minShares = bound(minShares, 0, (expectedShares * 95) / 100);
+        
+        // Track if vault was empty before deposit (will trigger setFirstDepositTimestamp)
+        bool vaultWasEmpty = vaultYS.totalSupply() == 0;
+        
+        // Capture YS state in AccountantHandler - deposits realize yield via _updateExchangeRate()
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.beginYSOperation(TellerWithMultiAssetSupport.deposit.selector);
+        }
+        
+        vm.startPrank(actor);
+        baseAsset.approve(address(vaultYS), amount);
+        
+        bool succeeded = false;
+        uint256 shares = tellerYS.deposit(baseAsset, amount, minShares, address(0));
+        if (shares > 0) {
+            depositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+            succeeded = true;
+        }
+        vm.stopPrank();
+        
+        // Fix stale vesting state if deposit to empty vault triggered setFirstDepositTimestamp bug
+        if (vaultWasEmpty && succeeded && address(accountantHandler) != address(0)) {
+            accountantHandler.fixVestingStateAfterFirstDeposit();
+        }
+        
+        // Capture post-state in AccountantHandler
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.endYSOperation(succeeded);
+        }
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Withdraw from TellerWithYieldStreaming
+     */
+    function withdrawYS(uint256 actorSeed, uint256 shareAmount, uint256 minAssets, uint256 timeDelta) external {
+        // Find an actor with shares
+        address actor = _getActorWithSharesYS(actorSeed);
+        if (actor == address(0)) {
+            _afterCall();
+            return;
+        }
+        
+        _beforeCall(TellerWithMultiAssetSupport.withdraw.selector, actor);
+        
+        uint256 actorShares = vaultYS.balanceOf(actor);
+        shareAmount = bound(shareAmount, 1, actorShares);
+        minAssets = bound(minAssets, 0, shareAmount);
+        timeDelta = bound(timeDelta, 0, 7 days);
+        
+        vm.warp(block.timestamp + timeDelta);
+        if (address(accountantHandler) != address(0)) accountantHandler.syncVestedAssets();
+        
+        // Capture YS state in AccountantHandler - withdrawals realize yield via getRateInQuoteSafe -> _updateExchangeRate()
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.beginYSOperation(TellerWithMultiAssetSupport.withdraw.selector);
+        }
+        
+        vm.startPrank(actor);
+        uint256 assets = tellerYS.withdraw(baseAsset, shareAmount, minAssets, actor);
+        withdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+        
+        // Capture post-state in AccountantHandler
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.endYSOperation(true);
+        }
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Bulk deposit via solver for YS teller
+     * @dev Solver deposits assets, solver receives shares (so it can later bulkWithdraw)
+     */
+    function bulkDepositYS(uint256 amount, uint256 minShares) external {
+        _beforeCall(TellerWithMultiAssetSupport.bulkDeposit.selector, solver);
+        
+        amount = bound(amount, 1, 100_000e18);
+        
+        // Calculate expected shares based on current rate to set realistic minShares
+        uint256 rate = accountantHandler.accountantYS().getRate();
+        uint256 expectedShares = (amount * 1e18) / rate;
+        // Bound minShares to 0-95% of expected to allow some slippage margin
+        minShares = bound(minShares, 0, (expectedShares * 95) / 100);
+        
+        // Track if vault was empty before deposit (will trigger setFirstDepositTimestamp)
+        bool vaultWasEmpty = vaultYS.totalSupply() == 0;
+        
+        // Capture YS state in AccountantHandler - deposits realize yield via _updateExchangeRate()
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.beginYSOperation(TellerWithMultiAssetSupport.bulkDeposit.selector);
+        }
+        
+        vm.startPrank(solver);
+        baseAsset.approve(address(vaultYS), amount);
+        
+        bool succeeded = false;
+        // Solver deposits and receives shares itself (can later bulkWithdraw)
+        uint256 shares = tellerYS.bulkDeposit(baseAsset, amount, minShares, solver);
+        if (shares > 0) {
+            bulkDepositCalls++;
+            lastDepositAssets = amount;
+            lastDepositShares = shares;
+            succeeded = true;
+        }
+        vm.stopPrank();
+        
+        // Fix stale vesting state if deposit to empty vault triggered setFirstDepositTimestamp bug
+        if (vaultWasEmpty && succeeded && address(accountantHandler) != address(0)) {
+            accountantHandler.fixVestingStateAfterFirstDeposit();
+        }
+        
+        // Capture post-state in AccountantHandler
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.endYSOperation(succeeded);
+        }
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Bulk withdraw via solver for YS teller
+     * @dev Solver burns its own shares, sends assets to a random actor
+     */
+    function bulkWithdrawYS(uint256 shareAmount, uint256 minAssets, uint256 actorSeed) external {
+        _beforeCall(TellerWithMultiAssetSupport.bulkWithdraw.selector, solver);
+        
+        // Solver needs shares to withdraw (from previous bulkDepositYS calls)
+        uint256 solverShares = vaultYS.balanceOf(solver);
+        if (solverShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        // Solver burns shares, assets go to a random actor
+        address recipient = _getRandomActor(actorSeed);
+        shareAmount = bound(shareAmount, 1, solverShares);
+        minAssets = bound(minAssets, 0, shareAmount);
+        
+        // Capture YS state in AccountantHandler - withdrawals realize yield via getRateInQuoteSafe -> _updateExchangeRate()
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.beginYSOperation(TellerWithMultiAssetSupport.bulkWithdraw.selector);
+        }
+        
+        vm.startPrank(solver);
+        uint256 assets = tellerYS.bulkWithdraw(baseAsset, shareAmount, minAssets, recipient);
+        bulkWithdrawCalls++;
+        lastWithdrawShares = shareAmount;
+        lastWithdrawAssets = assets;
+        vm.stopPrank();
+        
+        // Capture post-state in AccountantHandler
+        if (address(accountantHandler) != address(0)) {
+            accountantHandler.endYSOperation(true);
+        }
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Pause TellerWithYieldStreaming
+     */
+    function pauseYS() external {
+        _beforeCall(TellerWithMultiAssetSupport.pause.selector, owner);
+        
+        vm.prank(owner);
+        try tellerYS.pause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Unpause TellerWithYieldStreaming
+     */
+    function unpauseYS() external {
+        _beforeCall(TellerWithMultiAssetSupport.unpause.selector, owner);
+        
+        vm.prank(owner);
+        try tellerYS.unpause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // DENIED USER OPERATIONS (for testing deny list invariants)
+    // ============================================
+    
+    /**
+     * @notice Attempt deposit with denied user
+     */
+    function depositAsDeniedUser(uint256 amount) external {
+        _beforeCall(TellerWithMultiAssetSupport.deposit.selector, deniedUser);
+        
+        amount = bound(amount, 1e6, 100_000e18);
+        
+        vm.startPrank(deniedUser);
+        baseAsset.approve(address(vaultRP), amount);
+        tellerMAS.deposit(baseAsset, amount, 0, address(0));
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Attempt transfer from denied user (using RP vault where deny is configured)
+     */
+    function transferFromDeniedUser(uint256 amount, uint256 actorSeed) external {
+        address recipient = _getRandomActor(actorSeed);
+        _beforeCall(BoringVault.transfer.selector, deniedUser);
+        
+        uint256 deniedShares = vaultRP.balanceOf(deniedUser);
+        if (deniedShares == 0) {
+            _afterCall();
+            return;
+        }
+        
+        amount = bound(amount, 1, deniedShares);
+        
+        vm.prank(deniedUser);
+        vaultRP.transfer(recipient, amount);
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // STRUCT GETTERS (needed because public structs return tuples)
+    // ============================================
+    
+    function getPreMAS() external view returns (TellerState memory) {
+        return preMAS;
+    }
+    
+    function getPostMAS() external view returns (TellerState memory) {
+        return postMAS;
+    }
+    
+    function getPreYS() external view returns (TellerState memory) {
+        return preYS;
+    }
+    
+    function getPostYS() external view returns (TellerState memory) {
+        return postYS;
+    }
+    
+    function getPreUserState(address user) external view returns (UserState memory) {
+        return preUserState[user];
+    }
+    
+    function getPostUserState(address user) external view returns (UserState memory) {
+        return postUserState[user];
+    }
+    
+}
+

--- a/test/fuzzing/invariants/BaseInvariants.sol
+++ b/test/fuzzing/invariants/BaseInvariants.sol
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "@forge-std/Test.sol";
+import {StdInvariant} from "@forge-std/StdInvariant.sol";
+
+import {BaseSetup} from "../BaseSetup.sol";
+import {AccountantHandler} from "../handlers/AccountantHandler.sol";
+import {TellerHandler} from "../handlers/TellerHandler.sol";
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+
+/**
+ * @title BaseInvariants
+ * @notice Abstract base contract containing all shared invariants for BOTH RP and YS systems
+ */
+abstract contract BaseInvariants is StdInvariant, BaseSetup {
+    using FixedPointMathLib for uint256;
+
+    // ============================================
+    // ABSTRACT GETTERS - Implemented by child contracts
+    // ============================================
+
+    function _accountant() internal view virtual returns (AccountantWithRateProviders);
+    function _teller() internal view virtual returns (TellerWithMultiAssetSupport);
+    function _vault() internal view virtual returns (BoringVault);
+    function _accountantHandler() internal view virtual returns (AccountantHandler);
+    function _tellerHandler() internal view virtual returns (TellerHandler);
+    function _getPreState() internal view virtual returns (AccountantHandler.RPState memory);
+    function _getPostState() internal view virtual returns (AccountantHandler.RPState memory);
+    function _getTellerPreState() internal view virtual returns (TellerHandler.TellerState memory);
+    function _getTellerPostState() internal view virtual returns (TellerHandler.TellerState memory);
+
+    // ============================================
+    // HELPER FUNCTIONS
+    // ============================================
+
+    function _isAccountantPaused() internal view returns (bool) {
+        (,,,,,,,, bool isPaused,,,) = _accountant().accountantState();
+        return isPaused;
+    }
+
+    // ============================================
+    // GROUP 1: ACCOUNTANT INVARIANTS (Rules 1-7)
+    // ============================================
+
+    function invariant_accountantDoesntHoldTokens() public view returns (bool) {
+        address acc = address(_accountant());
+        
+        // Check base asset
+        assertEq(
+            baseAsset.balanceOf(acc),
+            0,
+            "Invariant 1: Accountant should not hold base tokens"
+        );
+        
+        // Check ALL alternative assets (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            assertEq(
+                alternativeAssets[i].balanceOf(acc),
+                0,
+                string(abi.encodePacked("Invariant 1: Accountant should not hold alt tokens (asset ", vm.toString(i), ")"))
+            );
+        }
+
+        (address payout,,,,,,,,,,, ) = _accountant().accountantState();
+        assertTrue(payout != acc, "Invariant 1: Payout should not be Accountant");
+        return true;
+    }
+
+    function invariant_accountantPaused_valuesFrozen() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+
+        if (pre.isPaused && selector != AccountantWithRateProviders.resetHighwaterMark.selector) {
+            assertEq(
+                post.feesOwedInBase,
+                pre.feesOwedInBase,
+                "Invariant 2: Fees should be frozen when paused"
+            );
+        }
+        return true;
+    }
+
+    function invariant_feesCanOnlyDecreaseViaClaimFees() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+
+        if (post.feesOwedInBase < pre.feesOwedInBase) {
+            assertEq(
+                selector,
+                AccountantWithRateProviders.claimFees.selector,
+                "Invariant 3: Fees should only decrease via claimFees"
+            );
+        }
+        return true;
+    }
+
+    function invariant_highwaterMarkNeverDecreases() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+
+        if (selector != AccountantWithRateProviders.resetHighwaterMark.selector) {
+            assertGe(
+                post.highwaterMark,
+                pre.highwaterMark,
+                "Invariant 4: Highwater mark should never decrease"
+            );
+        }
+        return true;
+    }
+
+    function invariant_lastUpdateTimestampNeverDecreases() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+
+        assertGe(
+            post.lastUpdateTimestamp,
+            pre.lastUpdateTimestamp,
+            "Invariant 5: Timestamp should never decrease"
+        );
+        return true;
+    }
+
+    function invariant_allowedExchangeRateChangeBounds() public view returns (bool) {
+        (, , , , , uint16 upper, uint16 lower, , , , , ) = _accountant().accountantState();
+
+        assertGe(upper, 10000, "Invariant 6: Upper bound should be >= 100%");
+        assertLe(lower, 10000, "Invariant 6: Lower bound should be <= 100%");
+        return true;
+    }
+
+    function invariant_exchangeRateLEhighwaterMark() public view returns (bool) {
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        // Only check after updateExchangeRate calls
+        if (selector != AccountantWithRateProviders.updateExchangeRate.selector) {
+            return true;
+        }
+        
+        // Only check if the call actually succeeded
+        if (!_accountantHandler().lastCallSucceeded()) {
+            return true;
+        }
+        
+        (, uint96 hwm, , , uint96 rate, , , , bool paused, , , ) = _accountant().accountantState();
+        
+        if (!paused) {
+            assertLe(rate, hwm, "Invariant 7: Exchange rate should be <= highwater mark when not paused");
+        }
+        return true;
+    }
+
+    // ============================================
+    // GROUP 2: TELLER INVARIANTS (Rules 20-31)
+    // ============================================
+
+    function invariant_integrityOfDeposit() public view returns (bool) {
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        bool isDepositOp = selector == TellerWithMultiAssetSupport.deposit.selector ||
+                           selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+        
+        if (!isDepositOp) return true;
+        
+        uint256 lastDepositAssets = _tellerHandler().lastDepositAssets();
+        uint256 lastDepositShares = _tellerHandler().lastDepositShares();
+        
+        if (lastDepositAssets > 0 && _tellerHandler().depositCalls() > 0) {
+            assertGt(lastDepositShares, 0, "Invariant 20: Deposit should mint shares");
+        }
+        return true;
+    }
+
+    function invariant_integrityOfWithdraw() public view returns (bool) {
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        bool isWithdrawOp = selector == TellerWithMultiAssetSupport.withdraw.selector ||
+                            selector == TellerWithMultiAssetSupport.bulkWithdraw.selector;
+        
+        if (!isWithdrawOp) return true;
+        
+        uint256 lastWithdrawShares = _tellerHandler().lastWithdrawShares();
+        uint256 lastWithdrawAssets = _tellerHandler().lastWithdrawAssets();
+        
+        // DUST_THRESHOLD accounts for lowest decimal asset (6 decimals)
+        uint256 DUST_THRESHOLD = 1e12;
+        if (lastWithdrawShares > DUST_THRESHOLD && _tellerHandler().withdrawCalls() > 0) {
+            assertGt(lastWithdrawAssets, 0, "Invariant 21: Withdraw should produce assets");
+        }
+        return true;
+    }
+
+    function invariant_noFreeAssets() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+        
+        uint256 testAmount = _tellerHandler().lastDepositAssets();
+        if (testAmount == 0) testAmount = 1000e18;
+        
+        uint256 shares = testAmount.mulDivDown(ONE_SHARE, rate);
+        uint256 recoveredAssets = shares.mulDivDown(rate, ONE_SHARE);
+        
+        assertLe(recoveredAssets, testAmount, "Invariant 22: Round-trip should not create free assets");
+        return true;
+    }
+
+    function invariant_tellerDoesntHoldTokens() public view returns (bool) {
+        address teller = address(_teller());
+        
+        // Check base asset
+        assertEq(
+            baseAsset.balanceOf(teller),
+            0,
+            "Invariant 23: Teller should not hold base tokens"
+        );
+        
+        // Check ALL alternative assets
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            assertEq(
+                alternativeAssets[i].balanceOf(teller),
+                0,
+                string(abi.encodePacked("Invariant 23: Teller should not hold alt tokens (asset ", vm.toString(i), ")"))
+            );
+        }
+        return true;
+    }
+
+    function invariant_vaultCannotChange() public view returns (bool) {
+        assertEq(address(_teller().vault()), address(_vault()), "Invariant 24: Teller vault should be immutable");
+        return true;
+    }
+
+    function invariant_depositNonceNeverGoesDown() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+
+        assertGe(post.depositNonce, pre.depositNonce, "Invariant 25: Deposit nonce should never decrease");
+        return true;
+    }
+
+    function invariant_tellerPaused_valuesFrozen() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+        bytes4 selector = _tellerHandler().lastSelector();
+
+        if (pre.isPaused && selector != TellerWithMultiAssetSupport.refundDeposit.selector) {
+            assertEq(post.depositNonce, pre.depositNonce, "Invariant 26: Nonce frozen when paused");
+        }
+        return true;
+    }
+
+    function invariant_tellerPaused_methodsRevert() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        if (pre.isPaused) {
+            bool isPublicDepositWithdraw = 
+                selector == TellerWithMultiAssetSupport.deposit.selector ||
+                selector == TellerWithMultiAssetSupport.withdraw.selector;
+            
+            if (isPublicDepositWithdraw) {
+                assertEq(
+                    post.vaultTotalSupply,
+                    pre.vaultTotalSupply,
+                    "Invariant 27: Paused teller should reject deposits/withdrawals"
+                );
+            }
+        }
+        return true;
+    }
+
+    function invariant_dustFavorsTheHouse() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+        
+        uint256 testAmount = 12345678901234567890;
+        
+        uint256 sharesFromDeposit = testAmount.mulDivDown(ONE_SHARE, rate);
+        uint256 assetsFromWithdraw = sharesFromDeposit.mulDivDown(rate, ONE_SHARE);
+        
+        assertLe(assetsFromWithdraw, testAmount, "Invariant 28: Rounding should favor the vault");
+        return true;
+    }
+
+    function invariant_noDynamicCalls() public view returns (bool) {
+        assertFalse(_tellerHandler().callMade(), "Invariant 29: No unauthorized calls should be made");
+        assertFalse(_tellerHandler().delegatecallMade(), "Invariant 29: No unauthorized delegatecalls should be made");
+        assertFalse(_accountantHandler().callMade(), "Invariant 29: No unauthorized calls should be made");
+        assertFalse(_accountantHandler().delegatecallMade(), "Invariant 29: No unauthorized delegatecalls should be made");
+        return true;
+    }
+
+    function invariant_onlyContributionMethodsReduceAssets() public view returns (bool) {
+        bytes4 selector = _tellerHandler().lastSelector();
+        address actor = _tellerHandler().currentActor();
+
+        if (actor == address(0)) return true;
+
+        TellerHandler.UserState memory preUser = _tellerHandler().getPreUserState(actor);
+        TellerHandler.UserState memory postUser = _tellerHandler().getPostUserState(actor);
+
+        if (postUser.baseBalance < preUser.baseBalance) {
+            bool isDepositMethod = 
+                selector == TellerWithMultiAssetSupport.deposit.selector ||
+                selector == TellerWithMultiAssetSupport.depositWithPermit.selector ||
+                selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+            
+            assertTrue(isDepositMethod, "Invariant 30: Only deposit methods should reduce user assets");
+        }
+        return true;
+    }
+
+    function invariant_withdrawingProducesAssets() public view returns (bool) {
+        uint256 withdrawCalls = _tellerHandler().withdrawCalls();
+        uint256 bulkWithdrawCalls = _tellerHandler().bulkWithdrawCalls();
+        
+        if (withdrawCalls == 0 && bulkWithdrawCalls == 0) {
+            return true;
+        }
+        
+        uint256 sharesWithdrawn = _tellerHandler().lastWithdrawShares();
+        uint256 assetsReceived = _tellerHandler().lastWithdrawAssets();
+
+        // DUST_THRESHOLD accounts for lowest decimal asset (6 decimals)
+        uint256 DUST_THRESHOLD = 1e12;
+        
+        if (sharesWithdrawn > DUST_THRESHOLD) {
+            assertGt(assetsReceived, 0, "Invariant 31: Withdrawing shares should produce assets");
+        }
+        return true;
+    }
+
+    // ============================================
+    // GROUP 3: PERMISSIONS INVARIANTS (Rules 33, 36-37)
+    // ============================================
+
+    function invariant_feesIntegrity() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        if (selector == AccountantWithRateProviders.claimFees.selector) {
+            uint256 claimedAmount = pre.feesOwedInBase > post.feesOwedInBase 
+                ? pre.feesOwedInBase - post.feesOwedInBase 
+                : 0;
+            
+            assertLe(
+                claimedAmount,
+                pre.feesOwedInBase,
+                "feesIntegrity: Claimed fees should not exceed available fees"
+            );
+        }
+        return true;
+    }
+
+    function invariant_deniedUsers_balanceNonDecreasing() public view returns (bool) {
+        TellerHandler.UserState memory preDenied = _tellerHandler().getPreUserState(deniedUser);
+        TellerHandler.UserState memory postDenied = _tellerHandler().getPostUserState(deniedUser);
+
+        if (preDenied.denyFrom) {
+            assertGe(
+                postDenied.shares,
+                preDenied.shares,
+                "Invariant 36: Denied user (denyFrom) shares should not decrease"
+            );
+        }
+        return true;
+    }
+
+    function invariant_deniedUsers_balanceNonIncreasing() public view returns (bool) {
+        TellerHandler.UserState memory preDenied = _tellerHandler().getPreUserState(deniedUser);
+        TellerHandler.UserState memory postDenied = _tellerHandler().getPostUserState(deniedUser);
+
+        if (preDenied.denyTo) {
+            assertLe(
+                postDenied.shares,
+                preDenied.shares,
+                "Invariant 37: Denied user (denyTo) shares should not increase"
+            );
+        }
+        return true;
+    }
+
+    // ============================================
+    // GROUP 4: MATH INVARIANTS (Rules 40-47)
+    // ============================================
+
+    function invariant_convertToAssetsWeakAdditivity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 sharesA = 100e18;
+        uint256 sharesB = 200e18;
+
+        uint256 assetsA = sharesA.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsB = sharesB.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsAB = (sharesA + sharesB).mulDivDown(rate, ONE_SHARE);
+
+        assertLe(assetsA + assetsB, assetsAB + 1, "Invariant 40: Weak additivity for convertToAssets");
+        return true;
+    }
+
+    function invariant_convertToSharesWeakAdditivity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 assetsA = 100e18;
+        uint256 assetsB = 200e18;
+
+        uint256 sharesA = assetsA.mulDivDown(ONE_SHARE, rate);
+        uint256 sharesB = assetsB.mulDivDown(ONE_SHARE, rate);
+        uint256 sharesAB = (assetsA + assetsB).mulDivDown(ONE_SHARE, rate);
+
+        assertLe(sharesA + sharesB, sharesAB + 1, "Invariant 41: Weak additivity for convertToShares");
+        return true;
+    }
+
+    function invariant_conversionWeakMonotonicity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 x = 100e18;
+        uint256 y = 200e18;
+
+        uint256 convertX = x.mulDivDown(ONE_SHARE, rate);
+        uint256 convertY = y.mulDivDown(ONE_SHARE, rate);
+
+        assertTrue(x < y, "Test precondition");
+        assertLe(convertX, convertY, "Invariant 42: Conversion weak monotonicity");
+        return true;
+    }
+
+    function invariant_conversionWeakIntegrity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 originalAssets = 100e18;
+
+        uint256 shares = originalAssets.mulDivDown(ONE_SHARE, rate);
+        uint256 recoveredAssets = shares.mulDivDown(rate, ONE_SHARE);
+
+        assertLe(recoveredAssets, originalAssets, "Invariant 43: Round trip should not create value");
+        return true;
+    }
+
+    function invariant_zeroAllowanceOnAssets() public view returns (bool) {
+        for (uint256 i = 0; i < actors.length; i++) {
+            address actor = actors[i];
+            
+            uint256 tellerAllowance = baseAsset.allowance(actor, address(_teller()));
+            assertEq(
+                tellerAllowance,
+                0,
+                "Invariant 44: Users should not give allowance to teller"
+            );
+        }
+        return true;
+    }
+
+    function invariant_conversionOfZero() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 zeroAssets = 0;
+        uint256 zeroShares = zeroAssets.mulDivDown(ONE_SHARE, rate);
+        
+        assertEq(zeroShares, 0, "Invariant 45: convert(0) should equal 0");
+        return true;
+    }
+
+    function invariant_totalSupplyLEqCap() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        bool isDepositOp = selector == TellerWithMultiAssetSupport.deposit.selector ||
+                           selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+        
+        if (!isDepositOp) return true;
+        
+        if (post.vaultTotalSupply > pre.vaultTotalSupply) {
+            assertLe(
+                post.vaultTotalSupply,
+                pre.depositCap,
+                "Invariant 46: Deposit should respect deposit cap"
+            );
+        }
+        return true;
+    }
+
+    function invariant_weakAdditivityGeneral() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+        
+        uint256 amountA = _tellerHandler().lastDepositAssets();
+        if (amountA == 0) amountA = 50e18;
+        uint256 amountB = amountA * 2;
+        
+        uint256 assetsA = amountA.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsB = amountB.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsAB = (amountA + amountB).mulDivDown(rate, ONE_SHARE);
+        
+        assertLe(
+            assetsA + assetsB,
+            assetsAB + 1,
+            "Invariant 47: Weak additivity should hold for conversions"
+        );
+        return true;
+    }
+
+    // ============================================
+    // GROUP 5: SOLVENCY INVARIANTS (Rules 38-39)
+    // ============================================
+
+    function invariant_vaultSolvencyMulti() public view returns (bool) {
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply == 0) return true;
+        if (_isAccountantPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+        if (_accountantHandler().altAssetRateChanged()) return true;
+
+        address vault = address(_vault());
+        
+        uint256 totalValueInShares = 0;
+        
+        // Base asset value
+        uint256 baseBalance = baseAsset.balanceOf(vault);
+        uint256 baseRate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (baseRate > 0 && baseBalance > 0) {
+            totalValueInShares += baseBalance.mulDivDown(ONE_SHARE, baseRate);
+        }
+        
+        // Alternative assets value
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            uint256 altBalance = alternativeAssets[i].balanceOf(vault);
+            if (altBalance > 0) {
+                try _accountant().getRateInQuoteSafe(ERC20(address(alternativeAssets[i]))) returns (uint256 altRate) {
+                    if (altRate > 0) {
+                        totalValueInShares += altBalance.mulDivDown(ONE_SHARE, altRate);
+                    }
+                } catch {
+                    // Asset not configured in accountant, skip
+                }
+            }
+        }
+        
+        uint256 tolerance = totalSupply / 1000;
+        if (tolerance == 0) tolerance = 1;
+
+        assertGe(totalValueInShares + tolerance, totalSupply, "Invariant 38: Multi-asset solvency check (N assets)");
+        return true;
+    }
+
+    function invariant_vaultSolvency_1Asset() public view returns (bool) {
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply == 0) return true;
+        if (_isAccountantPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+
+        address vault = address(_vault());
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            if (alternativeAssets[i].balanceOf(vault) > 0) return true;
+        }
+
+        uint256 vaultBalance = baseAsset.balanceOf(vault);
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+
+        uint256 lhs = vaultBalance * ONE_SHARE;
+        uint256 rhs = totalSupply * rate;
+
+        uint256 tolerance = rhs / 1000;
+        if (tolerance == 0) tolerance = 1;
+
+        assertGe(lhs + tolerance, rhs, "Invariant 39: Single-asset solvency check");
+        return true;
+    }
+}

--- a/test/fuzzing/invariants/YSOnlyInvariants.sol
+++ b/test/fuzzing/invariants/YSOnlyInvariants.sol
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {BaseInvariants} from "./BaseInvariants.sol";
+import {AccountantHandler} from "../handlers/AccountantHandler.sol";
+
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+
+/**
+ * @title YSOnlyInvariants
+ * @notice Abstract contract containing YS-ONLY invariants
+ */
+abstract contract YSOnlyInvariants is BaseInvariants {
+    using FixedPointMathLib for uint256;
+
+    bytes4 constant YS_UPDATE_EXCHANGE_RATE_SELECTOR = bytes4(keccak256("updateExchangeRate()"));
+
+    function _accountantYS() internal view virtual returns (AccountantWithYieldStreaming);
+    function _getPreYS() internal view virtual returns (AccountantHandler.YSState memory);
+    function _getPostYS() internal view virtual returns (AccountantHandler.YSState memory);
+
+    // ============================================
+    // HELPER FUNCTIONS
+    // ============================================
+
+    function _isAccountantYSPaused() internal view returns (bool) {
+        (,,,,,,,, bool isPaused,,,) = _accountantYS().accountantState();
+        return isPaused;
+    }
+
+    // ============================================
+    // YS-ONLY INVARIANTS (Rules 8-19, 32, 34, 35)
+    // ============================================
+
+    function invariant_cumulativeSupplyBounded() public view returns (bool) {
+        (uint256 cumSupply, uint256 cumSupplyLast, ) = _accountantYS().supplyObservation();
+        
+        assertGe(cumSupply, cumSupplyLast, "Invariant 8: Cumulative supply last should be <= cumulative supply");
+        return true;
+    }
+
+    function invariant_exchangeRateEqlastSharePrice() public view returns (bool) {
+        (, , , , uint96 rate, , , , bool isPaused, , , ) = _accountantYS().accountantState();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+
+        if (isPaused) return true;
+
+        bytes4 selector = _accountantHandler().lastSelector();
+        bool isSyncOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                        selector == AccountantWithYieldStreaming.postLoss.selector ||
+                        selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+        
+        if (!isSyncOp) return true;
+
+        if (lastSharePrice <= type(uint96).max) {
+            assertEq(rate, uint96(lastSharePrice), "Invariant 9: Exchange rate should equal last share price");
+        }
+        return true;
+    }
+
+    function invariant_sharePriceBoundedUpper() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply > 0) {
+            uint256 rate = _accountantYS().getRate();
+            uint256 totalAssets = _accountantYS().totalAssets();
+            
+            uint256 lhs = rate.mulDivUp(totalSupply, ONE_SHARE);
+            assertLe(lhs, totalAssets + 1, "Invariant 10: Share price upper bound violated");
+        }
+        return true;
+    }
+
+    function invariant_sharePriceBoundedLower() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply > 0) {
+            uint256 rate = _accountantYS().getRate();
+            uint256 totalAssets = _accountantYS().totalAssets();
+            
+            uint256 lhs = rate.mulDivDown(totalSupply, ONE_SHARE);
+            
+            uint256 tolerance = totalAssets / 1e6;
+            if (tolerance == 0) tolerance = 1;
+            
+            assertGe(lhs + tolerance, totalAssets, "Invariant 11: Share price lower bound violated");
+        }
+        return true;
+    }
+
+    function invariant_sharePriceMoreThanOne() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+        if (_vault().totalSupply() == 0) return true;
+
+        uint256 rate = _accountantYS().getRate();
+        uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+        
+        if (vaultBalance > 0) {
+            assertGt(rate, 0, "Invariant 12: Share price should be non-zero when assets exist");
+        }
+        return true;
+    }
+
+    function invariant_totalAssetsCovered() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+
+        uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+        uint256 totalAssets = _accountantYS().totalAssets();
+        
+        uint256 tolerance = totalAssets / 10000;
+        if (tolerance == 0) tolerance = 1;
+        
+        assertLe(
+            totalAssets,
+            vaultBalance + tolerance,
+            "Invariant 13: Total assets should be covered by vault balance"
+        );
+        return true;
+    }
+
+    function invariant_startVestingTimeLEendVestingTime() public view returns (bool) {
+        (, uint128 vestingGains, , uint64 startTime, uint64 endTime) = _accountantYS().vestingState();
+        uint256 totalSupply = _vault().totalSupply();
+        
+        if (vestingGains == 0 || totalSupply == 0) return true;
+        
+        assertLe(startTime, endTime, "Invariant 14: Start vesting time should be <= end vesting time");
+        return true;
+    }
+
+    function invariant_vestingGainsIntegrity() public view returns (bool) {
+        (, uint128 vestingGains, , uint64 startTime, uint64 endTime) = _accountantYS().vestingState();
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (vestingGains > 0 && totalSupply > 0) {
+            assertLt(startTime, endTime, "Invariant 15: If vesting gains > 0, start must be < end");
+        }
+        return true;
+    }
+
+    function invariant_lastVestingUpdateNeverDecreases() public view returns (bool) {
+        AccountantHandler.YSState memory preYS = _getPreYS();
+        AccountantHandler.YSState memory postYS = _getPostYS();
+
+        assertGe(
+            postYS.lastVestingUpdate,
+            preYS.lastVestingUpdate,
+            "Invariant 16: Last vesting update should never decrease"
+        );
+        return true;
+    }
+
+    function invariant_integrityOfVestYield() public view returns (bool) {
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        if (selector == AccountantWithYieldStreaming.vestYield.selector && _accountantHandler().lastCallSucceeded()) {
+            (, , uint128 lastVestingUpdate, uint64 startTime, ) = _accountantYS().vestingState();
+            assertGe(lastVestingUpdate, startTime, "Invariant 17: Vesting update should be >= start time");
+        }
+        return true;
+    }
+
+    function invariant_exchangeRatePostLoss() public view returns (bool) {
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        if (selector == AccountantWithYieldStreaming.postLoss.selector && _accountantHandler().lastCallSucceeded()) {
+            (, uint96 hwm, , , uint96 rate, , , , , , , ) = _accountantYS().accountantState();
+            
+            assertLe(
+                rate,
+                hwm,
+                "Invariant 18: After postLoss, rate should be <= HWM"
+            );
+        }
+        return true;
+    }
+
+    function invariant_vaultSolvency_1Asset_Vesting() public view returns (bool) {
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply == 0) return true;
+        if (_isAccountantYSPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+
+        uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+        uint256 pendingVest = _accountantYS().getPendingVestingGains();
+        uint256 rate = _accountantYS().getRateInQuoteSafe(baseAsset);
+
+        uint256 lhs = vaultBalance * ONE_SHARE;
+        uint256 rhs = totalSupply.mulDivUp(rate, 1) + pendingVest * ONE_SHARE;
+        
+        uint256 tolerance = rhs / 1000;
+        if (tolerance == 0) tolerance = 1;
+        
+        assertGe(lhs + tolerance, rhs, "Invariant 19: Vesting solvency check");
+        return true;
+    }
+
+    function invariant_yieldIntegrity() public view returns (bool) {
+        AccountantHandler.YSState memory preYS = _getPreYS();
+        AccountantHandler.YSState memory postYS = _getPostYS();
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        bool isYieldRealizingOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                                  selector == AccountantWithYieldStreaming.postLoss.selector ||
+                                  selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR ||
+                                  selector == TellerWithMultiAssetSupport.deposit.selector ||
+                                  selector == TellerWithMultiAssetSupport.bulkDeposit.selector ||
+                                  selector == TellerWithMultiAssetSupport.withdraw.selector ||
+                                  selector == TellerWithMultiAssetSupport.bulkWithdraw.selector;
+        
+        if (!isYieldRealizingOp) return true;
+        if (!_accountantHandler().lastCallSucceeded()) return true;
+        
+        uint256 totalSupply = preYS.totalSupply;
+        if (totalSupply == 0) return true;
+        
+        uint256 realizedYieldPerShare = postYS.lastSharePrice > preYS.lastSharePrice
+            ? postYS.lastSharePrice - preYS.lastSharePrice
+            : 0;
+        
+        uint256 lhs = realizedYieldPerShare.mulDivUp(totalSupply, ONE_SHARE);
+        uint256 rhs = preYS.pendingGains;
+        
+        uint256 tolerance = totalSupply / ONE_SHARE + 1;
+        
+        assertLe(
+            lhs,
+            rhs + tolerance,
+            "Invariant 33: Realized yield (in assets) cannot exceed pending vested gains"
+        );
+        
+        assertLe(
+            postYS.pendingGains,
+            uint256(postYS.vestingGains),
+            "Invariant 33: Pending gains cannot exceed total vesting pool"
+        );
+        return true;
+    }
+
+    function invariant_yieldAccrualsMonotonic() public view returns (bool) {
+        AccountantHandler.YSState memory preYS = _getPreYS();
+        AccountantHandler.YSState memory postYS = _getPostYS();
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        bool isReducingOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                            selector == AccountantWithYieldStreaming.postLoss.selector ||
+                            selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+        
+        if (!isReducingOp) {
+            assertGe(
+                postYS.lastVestingUpdate,
+                preYS.lastVestingUpdate,
+                "Invariant 32: Yield accrual timestamp should be monotonic"
+            );
+        }
+        return true;
+    }
+
+    function invariant_streamingRateConsistency() public view returns (bool) {
+        (, uint128 vestingGains, , , uint64 endTime) = _accountantYS().vestingState();
+        
+        uint256 pendingGains = _accountantYS().getPendingVestingGains();
+        
+        assertLe(
+            pendingGains,
+            uint256(vestingGains),
+            "Invariant 34: Pending gains should not exceed total vesting gains"
+        );
+        
+        if (block.timestamp >= endTime && vestingGains > 0) {
+            assertEq(
+                pendingGains,
+                uint256(vestingGains),
+                "Invariant 34: Past end time, pending should equal all remaining gains"
+            );
+        }
+        return true;
+    }
+
+    function invariant_accessControlYieldParams() public view returns (bool) {
+        uint64 minVest = _accountantYS().minimumVestingTime();
+        uint64 maxVest = _accountantYS().maximumVestingTime();
+        
+        assertLe(minVest, maxVest, "Invariant 35: min vesting time should be <= max vesting time");
+        return true;
+    }
+
+    // ============================================
+    // VIRTUAL SHARE PRICE INVARIANTS (Rules 36-38)
+    // ============================================
+
+    uint256 constant RAY = 1e27;
+
+    function invariant_virtualPriceUpperBound() public view returns (bool) {
+        // Skip when totalSupply == 0 - virtual price state is not updated when no shares exist
+        uint256 totalSupply = _vault().totalSupply();
+        if (totalSupply == 0) return true;
+        
+        // Skip when paused - state may be stale
+        if (_isAccountantYSPaused()) return true;
+        
+        uint256 virtualPrice = _accountantYS().lastVirtualSharePrice();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+        
+        // Skip if virtual price is 0 (not yet initialized or edge case)
+        if (virtualPrice == 0) return true;
+        
+        uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+        
+        // FINDING: Skip when converted price exceeds uint128 max - the protocol's 
+        // _calculateSharePriceFromVirtual() silently truncates via uint128 cast.
+        // This is a known limitation when lastVirtualSharePrice gets extremely large
+        // (e.g., after large yield vests with few shares). See FINDINGS.md Finding 2.
+        if (convertedPrice > type(uint128).max) return true;
+        
+        // Allow for truncation tolerance when uint128 cast loses precision
+        // The uint128 cast in _calculateSharePriceFromVirtual can cause up to 1 wei difference
+        // due to mulDivDown rounding combined with truncation
+        assertLe(
+            convertedPrice, 
+            uint256(lastSharePrice) + 1, 
+            "Invariant 36: Virtual price conversion should be <= lastSharePrice + 1"
+        );
+        return true;
+    }
+
+    function invariant_virtualPriceLowerBound() public view returns (bool) {
+        // Skip when totalSupply == 0 - virtual price state is not updated when no shares exist
+        uint256 totalSupply = _vault().totalSupply();
+        if (totalSupply == 0) return true;
+        
+        // Skip when paused - state may be stale
+        if (_isAccountantYSPaused()) return true;
+        
+        uint256 virtualPrice = _accountantYS().lastVirtualSharePrice();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+        
+        // Skip if virtual price is 0 (not yet initialized or edge case)
+        if (virtualPrice == 0) return true;
+        
+        uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+        
+        // Skip when converted price exceeds uint128 max - truncation already occurred
+        // See invariant_virtualPriceUpperBound for details on this known limitation
+        if (convertedPrice > type(uint128).max) return true;
+        
+        assertLe(
+            lastSharePrice, 
+            convertedPrice,
+            "Invariant 37: lastSharePrice should be <= converted virtual price"
+        );
+        return true;
+    }
+
+    function invariant_pendingGainsRateRelationship() public view returns (bool) {
+        uint256 pendingGains = _accountantYS().getPendingVestingGains();
+        uint256 rate = _accountantYS().getRate();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+        uint256 totalSupply = _vault().totalSupply();
+        
+        if (totalSupply == 0) {
+            assertEq(rate, lastSharePrice, "Invariant 38: With 0 shares, rate == lastSharePrice");
+            return true;
+        }
+        
+        if (pendingGains == 0) {
+            uint256 diff = rate > lastSharePrice ? rate - lastSharePrice : uint256(lastSharePrice) - rate;
+            assertLe(diff, 1, "Invariant 38: Zero pending gains implies rate == lastSharePrice (+/-1)");
+        }
+        
+        if (rate <= uint256(lastSharePrice) + 1 && rate >= uint256(lastSharePrice)) {
+            uint256 maxNegligibleGains = (2 * totalSupply) / ONE_SHARE + 1;
+            assertLe(
+                pendingGains, 
+                maxNegligibleGains, 
+                "Invariant 38: Rate approx lastSharePrice implies negligible pending gains"
+            );
+        }
+        return true;
+    }
+}

--- a/test/fuzzing/medusa/MedusaInvariantTestRP.sol
+++ b/test/fuzzing/medusa/MedusaInvariantTestRP.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test, console} from "@forge-std/Test.sol";
+import {StdInvariant} from "@forge-std/StdInvariant.sol";
+
+import {BaseInvariants} from "./invariants/BaseInvariants.sol";
+import {AccountantHandler} from "./handlers/AccountantHandler.sol";
+import {TellerHandler} from "../handlers/TellerHandler.sol";
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+
+/**
+ * @title MedusaInvariantTestRP
+ * @notice Invariant test suite for the RATE PROVIDER system (Medusa-compatible)
+ * @dev Inherits from BaseInvariants and implements abstract getters for RP system
+ *      Named differently from Foundry version to avoid compilation conflicts.
+ * 
+ * SYSTEM: AccountantWithRateProviders + TellerWithMultiAssetSupport + vaultRP
+ * 
+ * INVARIANTS TESTED (via BaseInvariants inheritance):
+ * - Group 1: Accountant Common (1-7)
+ * - Group 3: Teller & Vault Integrity (20-31)
+ * - Group 4: Math & Solvency (33, 36-48)
+ * 
+ * TOTAL: All shared invariants, focused on RP system only
+ * Each fuzz run operates exclusively on the RP vault and contracts.
+ */
+contract MedusaInvariantTestRP is BaseInvariants {
+    // ============================================
+    // HANDLER INSTANCES
+    // ============================================
+    AccountantHandler public accountantHandler;
+    TellerHandler public tellerHandler;
+
+    // ============================================
+    // CONSTRUCTOR - Medusa requires setup in constructor
+    // ============================================
+    constructor() {
+        _medusaSetUp();
+    }
+
+    // ============================================
+    // SETUP - Called from constructor for Medusa compatibility
+    // ============================================
+    function setUp() public override {
+        // No-op for Foundry compatibility - actual setup in constructor
+    }
+    
+    function _medusaSetUp() internal {
+        // Deploy base infrastructure (from BaseSetup)
+        _setupActors();
+        _deployMocks();
+        _deployRPSystem();
+        _deployYSSystem();
+        _setupRoles();
+        _configureAssets();
+        _fundActors();
+        
+        // Prepare alternative assets arrays for handler constructors
+        address[] memory altAssetAddresses = new address[](NUM_ALT_ASSETS);
+        address[] memory altRateProviderAddresses = new address[](NUM_ALT_ASSETS);
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            altAssetAddresses[i] = address(alternativeAssets[i]);
+            altRateProviderAddresses[i] = address(altAssetRateProviders[i]);
+        }
+        
+        // Deploy handlers with N-asset support
+        accountantHandler = new AccountantHandler(
+            address(accountantRP),
+            address(accountantYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            altRateProviderAddresses,
+            owner,
+            strategist,
+            payoutAddress
+        );
+        
+        tellerHandler = new TellerHandler(
+            address(tellerMAS),
+            address(tellerYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            owner,
+            solver,
+            deniedUser,
+            actors
+        );
+        
+        // Wire up handlers
+        tellerHandler.setAccountantHandler(address(accountantHandler));
+        
+        // Fund handlers with base asset (using mint instead of deal for Medusa compatibility)
+        baseAsset.mint(address(accountantHandler), 10_000_000e18);
+        baseAsset.mint(address(tellerHandler), 10_000_000e18);
+        
+        // Fund handlers with ALL alternative assets (for handler compatibility)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            alternativeAssets[i].mint(address(accountantHandler), 10_000_000e18);
+            alternativeAssets[i].mint(address(tellerHandler), 10_000_000e18);
+        }
+        
+        // ============================================
+        // TARGET ONLY RP SYSTEM FUNCTIONS
+        // ============================================
+        
+        // Accountant RP functions (N-asset support)
+        bytes4[] memory accountantRPSelectors = new bytes4[](13);
+        accountantRPSelectors[0] = AccountantHandler.updateExchangeRateRP.selector;
+        accountantRPSelectors[1] = AccountantHandler.claimFeesRP.selector;
+        accountantRPSelectors[2] = AccountantHandler.pauseRP.selector;
+        accountantRPSelectors[3] = AccountantHandler.unpauseRP.selector;
+        accountantRPSelectors[4] = AccountantHandler.resetHighwaterMarkRP.selector;
+        accountantRPSelectors[5] = bytes4(keccak256("setAltAssetRate(uint256,uint256)"));
+        accountantRPSelectors[6] = AccountantHandler.updatePlatformFeeRP.selector;
+        accountantRPSelectors[7] = AccountantHandler.updatePerformanceFeeRP.selector;
+        accountantRPSelectors[8] = AccountantHandler.updateBoundsRP.selector;
+        accountantRPSelectors[9] = AccountantHandler.updateDelayRP.selector;
+        accountantRPSelectors[10] = AccountantHandler.setRateProviderDataRP.selector;
+        accountantRPSelectors[11] = AccountantHandler.updatePayoutAddressRP.selector;
+        accountantRPSelectors[12] = AccountantHandler.warpTime.selector;
+        
+        // Teller MAS functions (N-asset support)
+        // Note: depositAltMAS and withdrawAltMAS are now parameterized by asset index
+        // Note: warpTime is handled by AccountantHandler only
+        bytes4[] memory tellerMASSelectors = new bytes4[](30);
+        tellerMASSelectors[0] = TellerHandler.depositMAS.selector;
+        tellerMASSelectors[1] = TellerHandler.withdrawMAS.selector;
+        tellerMASSelectors[2] = TellerHandler.bulkDepositMAS.selector;
+        tellerMASSelectors[3] = TellerHandler.bulkWithdrawMAS.selector;
+        tellerMASSelectors[4] = bytes4(keccak256("depositAltMAS(uint256,uint256,uint256,uint256)")); // Parameterized by asset index
+        tellerMASSelectors[5] = bytes4(keccak256("withdrawAltMAS(uint256,uint256,uint256,uint256,uint256)")); // Parameterized by asset index
+        tellerMASSelectors[6] = TellerHandler.pauseMAS.selector;
+        tellerMASSelectors[7] = TellerHandler.unpauseMAS.selector;
+        tellerMASSelectors[8] = TellerHandler.denyUserMAS.selector;
+        tellerMASSelectors[9] = TellerHandler.allowUserMAS.selector;
+        tellerMASSelectors[10] = TellerHandler.setShareLockPeriodMAS.selector;
+        tellerMASSelectors[11] = TellerHandler.setDepositCapMAS.selector;
+        // Granular deny/allow controls
+        tellerMASSelectors[12] = TellerHandler.denyFromMAS.selector;
+        tellerMASSelectors[13] = TellerHandler.denyToMAS.selector;
+        tellerMASSelectors[14] = TellerHandler.allowFromMAS.selector;
+        tellerMASSelectors[15] = TellerHandler.allowToMAS.selector;
+        tellerMASSelectors[16] = TellerHandler.denyOperatorMAS.selector;
+        tellerMASSelectors[17] = TellerHandler.allowOperatorMAS.selector;
+        // Permissioned transfer controls
+        tellerMASSelectors[18] = TellerHandler.setPermissionedTransfersMAS.selector;
+        tellerMASSelectors[19] = TellerHandler.allowPermissionedOperatorMAS.selector;
+        tellerMASSelectors[20] = TellerHandler.denyPermissionedOperatorMAS.selector;
+        // Deposit cap boundary testing
+        tellerMASSelectors[21] = TellerHandler.depositNearCapMAS.selector;
+        tellerMASSelectors[22] = TellerHandler.setDepositCapNearSupplyMAS.selector;
+        // Edge case testing
+        tellerMASSelectors[23] = TellerHandler.updateAssetDataMAS.selector;
+        tellerMASSelectors[24] = TellerHandler.depositTinyMAS.selector;
+        tellerMASSelectors[25] = TellerHandler.withdrawLockedMAS.selector;
+        tellerMASSelectors[26] = TellerHandler.withdrawZeroMinMAS.selector;
+        // Refund and denied user testing (critical for invariant coverage)
+        tellerMASSelectors[27] = TellerHandler.refundDepositMAS.selector;
+        tellerMASSelectors[28] = TellerHandler.depositAsDeniedUser.selector;
+        tellerMASSelectors[29] = TellerHandler.transferFromDeniedUser.selector;
+        
+        // ============================================
+        // TARGETING: ONLY HANDLERS
+        // ============================================
+        // Use targetContract to ONLY target handlers - this prevents the fuzzer
+        // from calling functions directly on MockRateProvider, BoringVault, etc.
+        targetContract(address(accountantHandler));
+        targetContract(address(tellerHandler));
+        
+        // Target specific selectors on handlers
+        targetSelector(FuzzSelector({addr: address(accountantHandler), selectors: accountantRPSelectors}));
+        targetSelector(FuzzSelector({addr: address(tellerHandler), selectors: tellerMASSelectors}));
+        
+        // Exclude senders that shouldn't be used by fuzzer
+        excludeSender(owner);
+        excludeSender(strategist);
+        excludeSender(payoutAddress);
+        excludeSender(address(vaultRP));
+        excludeSender(address(accountantRP));
+        excludeSender(address(tellerMAS));
+        excludeSender(address(accountantHandler));
+        excludeSender(address(tellerHandler));
+        
+        // Exclude mock contracts from being targeted directly
+        excludeContract(address(baseAsset));
+        excludeContract(address(vaultRP));
+        excludeContract(address(vaultYS));
+        excludeContract(address(accountantRP));
+        excludeContract(address(accountantYS));
+        excludeContract(address(tellerMAS));
+        excludeContract(address(tellerYS));
+        excludeContract(address(rolesAuthorityRP));
+        excludeContract(address(rolesAuthorityYS));
+        
+        // Exclude ALL alternative assets and rate providers (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            excludeContract(address(alternativeAssets[i]));
+            excludeContract(address(altAssetRateProviders[i]));
+        }
+    }
+
+    // ============================================
+    // ABSTRACT GETTER IMPLEMENTATIONS
+    // ============================================
+    
+    function _accountant() internal view override returns (AccountantWithRateProviders) {
+        return accountantRP;
+    }
+    
+    function _teller() internal view override returns (TellerWithMultiAssetSupport) {
+        return tellerMAS;
+    }
+    
+    function _vault() internal view override returns (BoringVault) {
+        return vaultRP;
+    }
+    
+    function _accountantHandler() internal view override returns (AccountantHandler) {
+        return accountantHandler;
+    }
+    
+    function _tellerHandler() internal view override returns (TellerHandler) {
+        return tellerHandler;
+    }
+    
+    function _getPreState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPreRP();
+    }
+    
+    function _getPostState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPostRP();
+    }
+    
+    function _getTellerPreState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPreMAS();
+    }
+    
+    function _getTellerPostState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPostMAS();
+    }
+}

--- a/test/fuzzing/medusa/MedusaInvariantTestYS.sol
+++ b/test/fuzzing/medusa/MedusaInvariantTestYS.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test, console} from "@forge-std/Test.sol";
+import {StdInvariant} from "@forge-std/StdInvariant.sol";
+
+import {YSOnlyInvariants} from "./invariants/YSOnlyInvariants.sol";
+import {AccountantHandler} from "./handlers/AccountantHandler.sol";
+import {TellerHandler} from "../handlers/TellerHandler.sol";
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {TellerWithYieldStreaming} from "src/base/Roles/TellerWithYieldStreaming.sol";
+
+/**
+ * @title MedusaInvariantTestYS
+ * @notice Invariant test suite for the YIELD STREAMING system (Medusa-compatible)
+ * @dev Inherits from YSOnlyInvariants (which inherits from BaseInvariants)
+ *      Named differently from Foundry version to avoid compilation conflicts.
+ * 
+ * SYSTEM: AccountantWithYieldStreaming + TellerWithYieldStreaming + vaultYS
+ * 
+ * INVARIANTS TESTED:
+ * - Group 1: Accountant Common (1-7) - via BaseInvariants
+ * - Group 2: YS-Specific (8-19, 32, 34, 35) - via YSOnlyInvariants
+ * - Group 3: Teller & Vault Integrity (20-31) - via BaseInvariants
+ * - Group 4: Math & Solvency (33, 36-48) - via BaseInvariants
+ * 
+ * TOTAL: All shared invariants + YS-specific invariants
+ * Each fuzz run operates exclusively on the YS vault and contracts.
+ */
+contract MedusaInvariantTestYS is YSOnlyInvariants {
+    // ============================================
+    // HANDLER INSTANCES
+    // ============================================
+    AccountantHandler public accountantHandler;
+    TellerHandler public tellerHandler;
+
+    // ============================================
+    // CONSTRUCTOR - Medusa requires setup in constructor
+    // ============================================
+    constructor() {
+        _medusaSetUp();
+    }
+
+    // ============================================
+    // SETUP - Called from constructor for Medusa compatibility
+    // ============================================
+    function setUp() public override {
+        // No-op for Foundry compatibility - actual setup in constructor
+    }
+    
+    function _medusaSetUp() internal {
+        // Deploy base infrastructure (from BaseSetup)
+        _setupActors();
+        _deployMocks();
+        _deployRPSystem();
+        _deployYSSystem();
+        _setupRoles();
+        _configureAssets();
+        _fundActors();
+        
+        // Prepare alternative assets arrays for handler constructors
+        // Note: YS only uses base asset, but handlers need alt assets for RP compatibility
+        address[] memory altAssetAddresses = new address[](NUM_ALT_ASSETS);
+        address[] memory altRateProviderAddresses = new address[](NUM_ALT_ASSETS);
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            altAssetAddresses[i] = address(alternativeAssets[i]);
+            altRateProviderAddresses[i] = address(altAssetRateProviders[i]);
+        }
+        
+        // Deploy handlers with N-asset support
+        accountantHandler = new AccountantHandler(
+            address(accountantRP),
+            address(accountantYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            altRateProviderAddresses,
+            owner,
+            strategist,
+            payoutAddress
+        );
+        
+        tellerHandler = new TellerHandler(
+            address(tellerMAS),
+            address(tellerYS),
+            address(vaultRP),
+            address(vaultYS),
+            address(baseAsset),
+            altAssetAddresses,
+            owner,
+            solver,
+            deniedUser,
+            actors
+        );
+        
+        // Wire up handlers
+        tellerHandler.setAccountantHandler(address(accountantHandler));
+        
+        // Fund handlers with base asset (using mint instead of deal for Medusa compatibility)
+        baseAsset.mint(address(accountantHandler), 10_000_000e18);
+        baseAsset.mint(address(tellerHandler), 10_000_000e18);
+        
+        // Fund handlers with all alternative assets (for handler compatibility)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            alternativeAssets[i].mint(address(accountantHandler), 10_000_000e18);
+            alternativeAssets[i].mint(address(tellerHandler), 10_000_000e18);
+        }
+        
+        // ============================================
+        // TARGET ONLY YS SYSTEM FUNCTIONS
+        // ============================================
+        
+        // Accountant YS functions
+        bytes4[] memory accountantYSSelectors = new bytes4[](9);
+        accountantYSSelectors[0] = AccountantHandler.vestYield.selector;
+        accountantYSSelectors[1] = AccountantHandler.postLoss.selector;
+        accountantYSSelectors[2] = AccountantHandler.updateExchangeRateYS.selector;
+        accountantYSSelectors[3] = AccountantHandler.claimFeesYS.selector;
+        accountantYSSelectors[4] = AccountantHandler.pauseYS.selector;
+        accountantYSSelectors[5] = AccountantHandler.unpauseYS.selector;
+        accountantYSSelectors[6] = AccountantHandler.resetHighwaterMarkYS.selector;
+        accountantYSSelectors[7] = AccountantHandler.warpTime.selector;
+        accountantYSSelectors[8] = AccountantHandler.updateVestingParams.selector;
+        
+        // Teller YS functions (warpTime handled by AccountantHandler)
+        bytes4[] memory tellerYSSelectors = new bytes4[](6);
+        tellerYSSelectors[0] = TellerHandler.depositYS.selector;
+        tellerYSSelectors[1] = TellerHandler.withdrawYS.selector;
+        tellerYSSelectors[2] = TellerHandler.bulkDepositYS.selector;
+        tellerYSSelectors[3] = TellerHandler.bulkWithdrawYS.selector;
+        tellerYSSelectors[4] = TellerHandler.pauseYS.selector;
+        tellerYSSelectors[5] = TellerHandler.unpauseYS.selector;
+        
+        // ============================================
+        // TARGETING: ONLY HANDLERS
+        // ============================================
+        // Use targetContract to ONLY target handlers - this prevents the fuzzer
+        // from calling functions directly on MockRateProvider, BoringVault, etc.
+        targetContract(address(accountantHandler));
+        targetContract(address(tellerHandler));
+        
+        // Target specific selectors on handlers
+        targetSelector(FuzzSelector({addr: address(accountantHandler), selectors: accountantYSSelectors}));
+        targetSelector(FuzzSelector({addr: address(tellerHandler), selectors: tellerYSSelectors}));
+        
+        // Exclude senders that shouldn't be used by fuzzer
+        excludeSender(owner);
+        excludeSender(strategist);
+        excludeSender(payoutAddress);
+        excludeSender(address(vaultYS));
+        excludeSender(address(accountantYS));
+        excludeSender(address(tellerYS));
+        excludeSender(address(accountantHandler));
+        excludeSender(address(tellerHandler));
+        
+        // Exclude mock contracts from being targeted directly
+        excludeContract(address(baseAsset));
+        excludeContract(address(vaultRP));
+        excludeContract(address(vaultYS));
+        excludeContract(address(accountantRP));
+        excludeContract(address(accountantYS));
+        excludeContract(address(tellerMAS));
+        excludeContract(address(tellerYS));
+        excludeContract(address(rolesAuthorityRP));
+        excludeContract(address(rolesAuthorityYS));
+        
+        // Exclude ALL alternative assets and rate providers (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            excludeContract(address(alternativeAssets[i]));
+            excludeContract(address(altAssetRateProviders[i]));
+        }
+    }
+
+    // ============================================
+    // ABSTRACT GETTER IMPLEMENTATIONS (BaseInvariants)
+    // ============================================
+    
+    function _accountant() internal view override returns (AccountantWithRateProviders) {
+        // YS accountant inherits from RP accountant
+        return AccountantWithRateProviders(address(accountantYS));
+    }
+    
+    function _teller() internal view override returns (TellerWithMultiAssetSupport) {
+        // YS teller inherits from MAS teller
+        return TellerWithMultiAssetSupport(address(tellerYS));
+    }
+    
+    function _vault() internal view override returns (BoringVault) {
+        return vaultYS;
+    }
+    
+    function _accountantHandler() internal view override returns (AccountantHandler) {
+        return accountantHandler;
+    }
+    
+    function _tellerHandler() internal view override returns (TellerHandler) {
+        return tellerHandler;
+    }
+    
+    /// @notice For YS, we use the YSAccountant state (same struct as RPState, but for YS accountant)
+    function _getPreState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPreYSAccountant();
+    }
+    
+    /// @notice For YS, we use the YSAccountant state (same struct as RPState, but for YS accountant)
+    function _getPostState() internal view override returns (AccountantHandler.RPState memory) {
+        return accountantHandler.getPostYSAccountant();
+    }
+    
+    function _getTellerPreState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPreYS();
+    }
+    
+    function _getTellerPostState() internal view override returns (TellerHandler.TellerState memory) {
+        return tellerHandler.getPostYS();
+    }
+
+    // ============================================
+    // ABSTRACT GETTER IMPLEMENTATIONS (YSOnlyInvariants)
+    // ============================================
+    
+    function _accountantYS() internal view override returns (AccountantWithYieldStreaming) {
+        return accountantYS;
+    }
+    
+    function _getPreYS() internal view override returns (AccountantHandler.YSState memory) {
+        return accountantHandler.getPreYS();
+    }
+    
+    function _getPostYS() internal view override returns (AccountantHandler.YSState memory) {
+        return accountantHandler.getPostYS();
+    }
+}

--- a/test/fuzzing/medusa/handlers/AccountantHandler.sol
+++ b/test/fuzzing/medusa/handlers/AccountantHandler.sol
@@ -1,0 +1,893 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+// Test and console unused but keeping for debugging if needed
+import {CommonBase} from "@forge-std/Base.sol";
+import {StdCheats} from "@forge-std/StdCheats.sol";
+import {StdUtils} from "@forge-std/StdUtils.sol";
+
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {MockRateProvider} from "../../mocks/MockRateProvider.sol";
+import {MockERC20Extended} from "../../mocks/MockERC20Extended.sol";
+
+/**
+ * @title AccountantHandler
+ * @notice Handler contract for fuzzing accountant operations with ghost state tracking (Medusa-compatible)
+ * @dev Tracks pre/post state for invariant verification. Uses mint/burn instead of deal() for Medusa compatibility.
+ */
+contract AccountantHandler is CommonBase, StdCheats, StdUtils {
+    using FixedPointMathLib for uint256;
+
+    // ============================================
+    // CONSTANTS
+    // ============================================
+    
+    uint256 public constant ONE_SHARE = 1e18;
+    uint256 public constant NUM_ALT_ASSETS = 5;
+    uint8 public constant BASE_DECIMALS = 18;
+    
+    // Decimals for each alternative asset (must match BaseSetup)
+    // Index 0: 18 decimals (standard ERC20)
+    // Index 1: 6 decimals (USDC-like)
+    // Index 2: 6 decimals (USDT-like)
+    // Index 3: 8 decimals (WBTC-like)
+    // Index 4: 11 decimals (unusual, edge case)
+    uint8[5] public ALT_ASSET_DECIMALS = [18, 6, 6, 8, 11];
+
+    // ============================================
+    // CONTRACTS
+    // ============================================
+    
+    AccountantWithRateProviders public accountantRP;
+    AccountantWithYieldStreaming public accountantYS;
+    BoringVault public vaultRP;  // Vault for RP system
+    BoringVault public vaultYS;  // Vault for YS system
+    ERC20 public baseAsset;
+    
+    // Multiple alternative assets for RP multi-asset testing
+    ERC20[] public alternativeAssets;
+    MockRateProvider[] public altAssetRateProviders;
+    
+    address public owner;
+    address public strategist;
+    address public payoutAddress;
+    
+    // ============================================
+    // GHOST STATE - Pre-call snapshots (only fields used by invariants)
+    // ============================================
+    
+    // Rate Provider Accountant ghost state - minimal for invariants
+    struct RPState {
+        uint96 highwaterMark;
+        uint128 feesOwedInBase;
+        uint64 lastUpdateTimestamp;
+        bool isPaused;
+    }
+    
+    // Yield Streaming Accountant ghost state - minimal for invariants
+    struct YSState {
+        uint128 lastSharePrice;
+        uint128 lastVestingUpdate;
+        uint128 vestingGains;      // Total vesting gains pool
+        uint256 pendingGains;      // Amount that has vested (claimable)
+        uint256 totalSupply;       // Vault total supply at snapshot time
+    }
+    
+    RPState public preRP;
+    RPState public postRP;
+    YSState public preYS;
+    YSState public postYS;
+    
+    // YS Accountant state (same fields as RP for shared invariants)
+    RPState public preYSAccountant;
+    RPState public postYSAccountant;
+    
+    // ============================================
+    // TRACKING VARIABLES
+    // ============================================
+    
+    // Track the last selector called
+    bytes4 public lastSelector;
+    
+    // Track if the last call succeeded (for selector-based invariants)
+    bool public lastCallSucceeded;
+    
+    // External call tracking (always false - no unauthorized calls in handlers)
+    bool public constant callMade = false;
+    bool public constant delegatecallMade = false;
+    
+    // Track if fees were recently claimed (solvency invariants should skip)
+    bool public feesRecentlyClaimed;
+    
+    // Flag to track if ANY alternative asset rate was changed (oracle simulation)
+    bool public altAssetRateChanged;
+    
+    // Vesting simulation tracking - cumulative vested assets released to vault
+    uint256 public cumulativeVestedAssetsReleased;
+    
+    
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+    
+    constructor(
+        address _accountantRP,
+        address _accountantYS,
+        address _vaultRP,
+        address _vaultYS,
+        address _baseAsset,
+        address[] memory _alternativeAssets,
+        address[] memory _altAssetRateProviders,
+        address _owner,
+        address _strategist,
+        address _payoutAddress
+    ) {
+        require(_alternativeAssets.length == NUM_ALT_ASSETS, "Must provide NUM_ALT_ASSETS alternative assets");
+        require(_altAssetRateProviders.length == NUM_ALT_ASSETS, "Must provide NUM_ALT_ASSETS rate providers");
+        
+        accountantRP = AccountantWithRateProviders(_accountantRP);
+        accountantYS = AccountantWithYieldStreaming(_accountantYS);
+        vaultRP = BoringVault(payable(_vaultRP));
+        vaultYS = BoringVault(payable(_vaultYS));
+        baseAsset = ERC20(_baseAsset);
+        
+        // Initialize alternative assets arrays
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            alternativeAssets.push(ERC20(_alternativeAssets[i]));
+            altAssetRateProviders.push(MockRateProvider(_altAssetRateProviders[i]));
+        }
+        
+        owner = _owner;
+        strategist = _strategist;
+        payoutAddress = _payoutAddress;
+    }
+    
+    // ============================================
+    // SNAPSHOT FUNCTIONS - Minimal to avoid stack-too-deep
+    // ============================================
+    
+    function _snapshotRPState() internal view returns (RPState memory state) {
+        // Only read the fields we actually need for invariants
+        (
+            ,              // payout
+            uint96 hwm,
+            uint128 fees,
+            ,              // shares
+            ,              // rate
+            ,              // upper
+            ,              // lower
+            uint64 timestamp,
+            bool paused,
+            ,              // delay
+            ,              // platformFee
+                           // performanceFee (last)
+        ) = accountantRP.accountantState();
+        
+        state.highwaterMark = hwm;
+        state.feesOwedInBase = fees;
+        state.lastUpdateTimestamp = timestamp;
+        state.isPaused = paused;
+    }
+    
+    function _snapshotYSAccountantState() internal view returns (RPState memory state) {
+        // Read accountantState for YS accountant (same fields as RP for shared invariants)
+        (
+            ,              // payout
+            uint96 hwm,
+            uint128 fees,
+            ,              // shares
+            ,              // rate
+            ,              // upper
+            ,              // lower
+            uint64 timestamp,
+            bool paused,
+            ,              // delay
+            ,              // platformFee
+                           // performanceFee (last)
+        ) = accountantYS.accountantState();
+        
+        state.highwaterMark = hwm;
+        state.feesOwedInBase = fees;
+        state.lastUpdateTimestamp = timestamp;
+        state.isPaused = paused;
+    }
+    
+    function _snapshotYSState() internal view returns (YSState memory state) {
+        // Read vestingState for lastSharePrice, vestingGains, and lastVestingUpdate
+        (
+            uint128 lastSharePrice,
+            uint128 vestingGains,
+            uint128 lastVestingUpdate,
+            ,                        // startVestingTime
+                                     // endVestingTime (last)
+        ) = accountantYS.vestingState();
+        
+        state.lastSharePrice = lastSharePrice;
+        state.lastVestingUpdate = lastVestingUpdate;
+        state.vestingGains = vestingGains;
+        state.pendingGains = accountantYS.getPendingVestingGains();
+        state.totalSupply = vaultYS.totalSupply();
+    }
+    
+    /// @notice Setup call metadata without capturing state (for handlers that need time warps first)
+    function _setupCall(bytes4 selector) internal {
+        lastSelector = selector;
+        lastCallSucceeded = false;
+    }
+    
+    /// @notice Capture pre-state snapshots - call this AFTER any time warps but BEFORE the actual call
+    function _capturePreState() internal {
+        preRP = _snapshotRPState();
+        preYS = _snapshotYSState();
+        preYSAccountant = _snapshotYSAccountantState();
+    }
+    
+    /// @notice Combined setup + capture for handlers without time warps (backwards compatible)
+    function _beforeCall(bytes4 selector) internal {
+        _setupCall(selector);
+        _capturePreState();
+    }
+    
+    function _afterCall() internal {
+        postRP = _snapshotRPState();
+        postYS = _snapshotYSState();
+        postYSAccountant = _snapshotYSAccountantState();
+    }
+    
+    // ============================================
+    // RATE PROVIDER ACCOUNTANT HANDLERS
+    // ============================================
+    
+    /**
+     * @notice Update exchange rate on AccountantWithRateProviders
+     * @param newRate The new exchange rate to set
+     * @param timeDelta Time to warp forward before calling (set to 0 to test timing constraints)
+     */
+    function updateExchangeRateRP(uint96 newRate, uint256 timeDelta) external {
+        _beforeCall(AccountantWithRateProviders.updateExchangeRate.selector);
+        
+        // Bound timeDelta - allows testing both normal updates and timing edge cases
+        vm.warp(block.timestamp + bound(timeDelta, 0, 30 days));
+        syncVestedAssets();
+        
+        uint256 totalSupply = vaultRP.totalSupply();
+        if (totalSupply == 0) {
+            _afterCall();
+            return;
+        }
+        
+        // Calculate bounds and new rate (uses helper functions to avoid stack-too-deep)
+        (uint256 minRate, uint256 maxRate) = _calculateRPRateBounds(totalSupply);
+        
+        // If no valid range exists, skip - system is in an extreme state
+        if (minRate > maxRate) {
+            _afterCall();
+            return;
+        }
+        
+        newRate = uint96(bound(newRate, minRate, maxRate));
+        
+        vm.prank(owner);
+        try accountantRP.updateExchangeRate(newRate) {
+            lastCallSucceeded = true;
+            feesRecentlyClaimed = false;
+            altAssetRateChanged = false;
+        } catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Helper to calculate rate bounds for RP system
+     * @dev Intersects solvency-based bounds with contract's allowed rate change bounds.
+     *      This ensures updateExchangeRate never triggers auto-pause from exceeding bounds.
+     */
+    function _calculateRPRateBounds(uint256 totalSupply) internal view returns (uint256 minRate, uint256 maxRate) {
+        // Calculate solvency-based bounds (0.99x to 1.01x of NAV/supply)
+        (uint256 minSolvencyRate, uint256 maxSolvencyRate) = _getSolvencyRateBoundsRP(totalSupply);
+        
+        // Get contract's allowed rate change bounds
+        (uint256 contractMinRate, uint256 contractMaxRate) = _getContractRateBoundsRP();
+        
+        // Intersect solvency bounds with contract bounds
+        minRate = minSolvencyRate > contractMinRate ? minSolvencyRate : contractMinRate;
+        maxRate = maxSolvencyRate < contractMaxRate ? maxSolvencyRate : contractMaxRate;
+    }
+    
+    function _getSolvencyRateBoundsRP(uint256 totalSupply) internal view returns (uint256 minRate, uint256 maxRate) {
+        uint256 baseRate = accountantRP.getRateInQuoteSafe(baseAsset);
+        
+        if (baseRate == 0) {
+            // Cannot calculate solvency without a valid base rate
+            return (1, type(uint96).max);
+        }
+        
+        // Calculate total value in share terms using the accountant's rate calculations
+        // This matches how Teller computes shares: shares = amount * ONE_SHARE / rateInQuote
+        uint256 totalValueInShares = 0;
+        
+        // Base asset value
+        uint256 baseBalance = baseAsset.balanceOf(address(vaultRP));
+        if (baseBalance > 0) {
+            totalValueInShares += baseBalance * ONE_SHARE / baseRate;
+        }
+        
+        // Alternative assets value
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            uint256 altBalance = alternativeAssets[i].balanceOf(address(vaultRP));
+            if (altBalance > 0) {
+                try accountantRP.getRateInQuoteSafe(alternativeAssets[i]) returns (uint256 altRate) {
+                    if (altRate > 0) {
+                        totalValueInShares += altBalance * ONE_SHARE / altRate;
+                    }
+                } catch {
+                    // Asset not configured, skip
+                }
+            }
+        }
+        
+        // Calculate the rate that would make the vault solvent
+        uint256 solvencyRate = totalValueInShares * baseRate / totalSupply;
+        
+        // Use 0.05% buffer (tighter than invariant's 0.1% tolerance)
+        minRate = solvencyRate * 9995 / 10000;  // 99.95%
+        maxRate = solvencyRate * 10005 / 10000; // 100.05%
+        
+        // Enforce absolute bounds to prevent extreme rates
+        uint256 ABSOLUTE_MIN_RATE = 1e15;  // 0.001 tokens per share
+        uint256 ABSOLUTE_MAX_RATE = 1e21;  // 1000 tokens per share
+        
+        if (minRate < ABSOLUTE_MIN_RATE) minRate = ABSOLUTE_MIN_RATE;
+        if (maxRate > ABSOLUTE_MAX_RATE) maxRate = ABSOLUTE_MAX_RATE;
+        if (maxRate > type(uint96).max) maxRate = type(uint96).max;
+    }
+    
+    function _getContractRateBoundsRP() internal view returns (uint256 minRate, uint256 maxRate) {
+        (, , , , uint96 currentRate, uint16 upper, uint16 lower, , , , , ) = accountantRP.accountantState();
+        minRate = uint256(currentRate) * lower / 10000;
+        maxRate = uint256(currentRate) * upper / 10000;
+        if (minRate == 0) minRate = 1;
+        if (maxRate > type(uint96).max) maxRate = type(uint96).max;
+    }
+    
+    /**
+     * @notice Pause AccountantWithRateProviders
+     */
+    function pauseRP() external {
+        _beforeCall(AccountantWithRateProviders.pause.selector);
+        
+        vm.prank(owner);
+        try accountantRP.pause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Unpause AccountantWithRateProviders
+     */
+    function unpauseRP() external {
+        _beforeCall(AccountantWithRateProviders.unpause.selector);
+        
+        vm.prank(owner);
+        try accountantRP.unpause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Reset highwater mark on AccountantWithRateProviders
+     */
+    function resetHighwaterMarkRP() external {
+        _beforeCall(AccountantWithRateProviders.resetHighwaterMark.selector);
+        
+        vm.prank(owner);
+        try accountantRP.resetHighwaterMark() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update platform fee
+     */
+    function updatePlatformFeeRP(uint16 fee) external {
+        _beforeCall(AccountantWithRateProviders.updatePlatformFee.selector);
+        
+        fee = uint16(bound(fee, 0, 2000)); // Max 20%
+        
+        vm.prank(owner);
+        try accountantRP.updatePlatformFee(fee) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update performance fee
+     */
+    function updatePerformanceFeeRP(uint16 fee) external {
+        _beforeCall(AccountantWithRateProviders.updatePerformanceFee.selector);
+        
+        fee = uint16(bound(fee, 0, 5000)); // Max 50%
+        
+        vm.prank(owner);
+        try accountantRP.updatePerformanceFee(fee) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update exchange rate bounds
+     * @dev Covers both normal and edge case ranges:
+     *      - upper: 100% to 200% (allows testing normal 1-5% and extreme 50%+ changes)
+     *      - lower: 50% to 100% (allows testing normal 1-5% and extreme 50% drops)
+     */
+    function updateBoundsRP(uint16 upper, uint16 lower) external {
+        _beforeCall(AccountantWithRateProviders.updateUpper.selector);
+        
+        upper = uint16(bound(upper, 10000, 20000)); // 100% to 200%
+        lower = uint16(bound(lower, 5000, 10000));  // 50% to 100%
+        
+        vm.startPrank(owner);
+        try accountantRP.updateUpper(upper) {} catch {}
+        try accountantRP.updateLower(lower) {} catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update minimum delay
+     */
+    function updateDelayRP(uint24 delay) external {
+        _beforeCall(AccountantWithRateProviders.updateDelay.selector);
+        
+        delay = uint24(bound(delay, 0, 14 days));
+        
+        vm.prank(owner);
+        try accountantRP.updateDelay(delay) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Claim fees from AccountantWithRateProviders
+     * @dev After claiming fees, solvency invariants skip until rate is updated.
+     */
+    function claimFeesRP() external {
+        _beforeCall(AccountantWithRateProviders.claimFees.selector);
+        
+        vm.startPrank(address(vaultRP));
+        baseAsset.approve(address(accountantRP), type(uint256).max);
+        try accountantRP.claimFees(baseAsset) {
+            feesRecentlyClaimed = true;
+        } catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    
+    /**
+     * @notice Set rate provider data for an asset
+     * @dev Tests dynamic rate provider configuration changes.
+     * @param assetIndex The alternative asset index (0 to NUM_ALT_ASSETS-1)
+     * @param isPeggedToBase Whether the asset is pegged 1:1 to base
+     */
+    function setRateProviderDataRP(uint256 assetIndex, bool isPeggedToBase) external {
+        _beforeCall(AccountantWithRateProviders.setRateProviderData.selector);
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS - 1);
+        
+        ERC20 asset = alternativeAssets[assetIndex];
+        address rateProvider = isPeggedToBase ? address(0) : address(altAssetRateProviders[assetIndex]);
+        
+        vm.prank(owner);
+        try accountantRP.setRateProviderData(asset, isPeggedToBase, rateProvider) {
+            // Rate provider config changed - set flag so solvency invariants skip
+            // In production, strategist would update rate after this
+            altAssetRateChanged = true;
+        } catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update payout address
+     */
+    function updatePayoutAddressRP(address newPayout) external {
+        _beforeCall(AccountantWithRateProviders.updatePayoutAddress.selector);
+        
+        vm.prank(owner);
+        try accountantRP.updatePayoutAddress(newPayout) {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Change the alternative asset rate provider rate (parameterized by asset index)
+     * @dev Tests multi-asset solvency across different rate scenarios.
+     *      Rates must be in the QUOTE TOKEN's decimals, not 18 decimals.
+     *      Bounds are realistic oracle movements (50% to 200%) to avoid extreme
+     *      rounding scenarios that mask real bugs.
+     * @param assetIndex The index of the alternative asset (0 to NUM_ALT_ASSETS-1)
+     * @param newRate The new rate to set (bounded to realistic oracle movement)
+     */
+    function setAltAssetRate(uint256 assetIndex, uint256 newRate) external {
+        _beforeCall(bytes4(keccak256("setAltAssetRate(uint256,uint256)")));
+        
+        assetIndex = bound(assetIndex, 0, NUM_ALT_ASSETS - 1);
+        
+        uint8 assetDecimals = ALT_ASSET_DECIMALS[assetIndex];
+        uint256 oneUnit = 10 ** assetDecimals;
+        
+        // Bound rate: 50% to 200% of unit rate (realistic oracle movement)
+        // This avoids extreme rounding-to-zero scenarios while still testing
+        // meaningful rate fluctuations that could expose real bugs
+        newRate = bound(newRate, oneUnit / 2, oneUnit * 2);
+        
+        altAssetRateProviders[assetIndex].setRate(newRate);
+        altAssetRateChanged = true;
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // YIELD STREAMING ACCOUNTANT HANDLERS
+    // ============================================
+    
+    /**
+     * @notice Sync vault balance with vested yield (Medusa-compatible using mint instead of deal)
+     * @dev In production, yield assets flow into the vault as they vest.
+     *      This helper calculates how much has vested and mints that amount.
+     *      Called after any time-advancing operation to maintain solvency.
+     *      Made public so TellerHandler can also sync after time warps.
+     *
+     *      Important: getPendingVestingGains() can DECREASE when _updateExchangeRate()
+     *      is called (by vestYield, postLoss, updateExchangeRate). This "realizes" the
+     *      vested gains by moving them from vestingGains to lastSharePrice. When this
+     *      happens, we need to reset our tracking to match the new state.
+     */
+    function syncVestedAssets() public {
+        // Get current pending vesting gains (how much has vested so far but not yet realized)
+        uint256 currentVested = accountantYS.getPendingVestingGains();
+        
+        if (currentVested > cumulativeVestedAssetsReleased) {
+            // New vesting has occurred - mint the difference to YS vault
+            uint256 newlyVested = currentVested - cumulativeVestedAssetsReleased;
+            MockERC20Extended(address(baseAsset)).mint(address(vaultYS), newlyVested);
+            cumulativeVestedAssetsReleased = currentVested;
+        } else if (currentVested < cumulativeVestedAssetsReleased) {
+            // Gains were "realized" by _updateExchangeRate() being called
+            // (vestYield, postLoss, or updateExchangeRate)
+            // Reset tracking to match new state - no minting needed since
+            // we already minted for those gains before they were realized
+            cumulativeVestedAssetsReleased = currentVested;
+        }
+        // If equal, do nothing
+    }
+    
+    /**
+     * @notice Fix vesting state after a deposit to an empty vault created invalid state (Medusa-compatible)
+     * @dev Called by TellerHandler after depositYS/bulkDepositYS when vault was empty
+     *      This corrects the startVestingTime > endVestingTime condition by doing a minimal vestYield
+     */
+    function fixVestingStateAfterFirstDeposit() external {
+        // Check if vesting state is invalid
+        (, , , uint64 startTime, uint64 endTime) = accountantYS.vestingState();
+        
+        // Only fix if we have an invalid state: startVestingTime > endVestingTime
+        // and there are shares (deposit succeeded)
+        if (startTime <= endTime || vaultYS.totalSupply() == 0) return;
+        
+        // Reset vesting state by doing a minimal vestYield call
+        syncVestedAssets();
+        
+        // Get min vesting duration
+        uint64 minVest = accountantYS.minimumVestingTime();
+        uint64 maxVest = accountantYS.maximumVestingTime();
+        uint256 duration = minVest > 0 ? minVest : 1 days;
+        if (duration > maxVest && maxVest > 0) duration = maxVest;
+        
+        // Calculate safe yield amount that will pass the daily yield check:
+        // dailyYieldBps = (yieldAmount * 1 day / duration) * 10000 / totalAssets
+        // For it to pass: dailyYieldBps <= maxDeviationYield
+        // Therefore: yieldAmount <= totalAssets * maxDeviationYield * duration / (10000 * 1 day)
+        uint256 totalAssets = accountantYS.totalAssets();
+        uint32 maxDeviation = accountantYS.maxDeviationYield();
+        
+        // Calculate max safe yield - use 1% of max deviation to be safe
+        // yieldAmount = totalAssets * maxDeviation * duration / (10000 * 1 days * 100)
+        uint256 yieldAmount;
+        if (totalAssets > 0) {
+            yieldAmount = totalAssets.mulDivDown(maxDeviation, 10000);
+            yieldAmount = yieldAmount.mulDivDown(duration, 1 days);
+            yieldAmount = yieldAmount / 100; // Use 1% of max to be very safe
+            if (yieldAmount == 0) yieldAmount = 1;
+        } else {
+            yieldAmount = 1;
+        }
+        
+        // Ensure vault has enough assets for the yield (using mint instead of deal)
+        uint256 vaultBal = baseAsset.balanceOf(address(vaultYS));
+        if (vaultBal < totalAssets + yieldAmount) {
+            uint256 mintAmount = totalAssets + yieldAmount - vaultBal;
+            MockERC20Extended(address(baseAsset)).mint(address(vaultYS), mintAmount);
+        }
+        
+        vm.prank(strategist);
+        try accountantYS.vestYield(yieldAmount, duration) {
+            // Success - vesting state is now valid
+            cumulativeVestedAssetsReleased = 0; // Reset tracking for new vest
+        } catch {
+            // If vestYield fails, the invariant will catch the invalid state
+            // This is expected if the contract has checks we can't bypass
+        }
+    }
+    
+    /**
+     * @notice Vest yield on AccountantWithYieldStreaming
+     * @param yieldAmount The amount of yield to vest (bounded dynamically based on totalAssets)
+     * @param duration The vesting duration
+     * @param timeDelta Time to warp forward before calling
+     * @dev Simulates yield vesting by tracking progress and minting proportionally.
+     *      Yield is bounded to 0.01%-50% of totalAssets to test both normal and edge cases.
+     */
+    function vestYield(uint256 yieldAmount, uint256 duration, uint256 timeDelta) external {
+        _setupCall(AccountantWithYieldStreaming.vestYield.selector);
+        
+        // Cannot vest yield if vault has no shares
+        if (vaultYS.totalSupply() == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        syncVestedAssets();
+        vm.warp(block.timestamp + bound(timeDelta, 0, 90 days));
+        syncVestedAssets();
+        
+        // Calculate yield bounds based on totalAssets for realistic testing
+        uint256 totalAssets = accountantYS.totalAssets();
+        uint256 minYield = totalAssets > 10000 ? totalAssets / 10000 : 1;  // 0.01%
+        uint256 maxYield = totalAssets > 2 ? totalAssets / 2 : 100_000e18; // 50%
+        
+        yieldAmount = bound(yieldAmount, minYield, maxYield);
+        duration = bound(duration, 1 hours, 30 days);
+        
+        _capturePreState();
+        
+        vm.prank(strategist);
+        try accountantYS.vestYield(yieldAmount, duration) {} catch {}
+        
+        syncVestedAssets();
+        _afterCall();
+    }
+    
+    /**
+     * @notice Post loss on AccountantWithYieldStreaming (Medusa-compatible using burn instead of deal)
+     * @param lossAmount The amount of loss to post (max 10% of total assets)
+     * @param timeDelta Time to warp forward before calling
+     * @dev Loss can be absorbed by unvested gains or reduce principal.
+     */
+    function postLoss(uint256 lossAmount, uint256 timeDelta) external {
+        _setupCall(AccountantWithYieldStreaming.postLoss.selector);
+        
+        if (vaultYS.totalSupply() == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        uint256 totalAssets = accountantYS.totalAssets();
+        uint256 maxLoss = totalAssets / 10;
+        if (maxLoss == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        lossAmount = bound(lossAmount, 1, maxLoss);
+        
+        vm.warp(block.timestamp + bound(timeDelta, 0, 90 days));
+        syncVestedAssets();
+        _capturePreState();
+        
+        // Get unvested gains to calculate principal loss
+        (, uint128 vestingGains, , , ) = accountantYS.vestingState();
+        uint256 pendingVested = accountantYS.getPendingVestingGains();
+        uint256 unvestedGains = vestingGains > pendingVested ? vestingGains - pendingVested : 0;
+        
+        vm.prank(strategist);
+        try accountantYS.postLoss(lossAmount) {
+            lastCallSucceeded = true;
+            
+            // Remove assets for principal loss (portion not absorbed by unvested gains)
+            if (lossAmount > unvestedGains) {
+                uint256 principalLoss = lossAmount - unvestedGains;
+                uint256 vaultBal = baseAsset.balanceOf(address(vaultYS));
+                uint256 burnAmount = vaultBal > principalLoss ? principalLoss : vaultBal;
+                if (burnAmount > 0) {
+                    MockERC20Extended(address(baseAsset)).burn(address(vaultYS), burnAmount);
+                }
+            }
+        } catch {}
+        
+        syncVestedAssets();
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update exchange rate on AccountantWithYieldStreaming (no-arg version)
+     * @param timeDelta Time to warp forward before calling
+     * @dev Realizes vested gains by calling _updateExchangeRate() internally.
+     */
+    function updateExchangeRateYS(uint256 timeDelta) external {
+        _setupCall(bytes4(keccak256("updateExchangeRate()")));
+        
+        if (vaultYS.totalSupply() == 0) {
+            _capturePreState();
+            _afterCall();
+            return;
+        }
+        
+        vm.warp(block.timestamp + bound(timeDelta, 0, 30 days));
+        syncVestedAssets();
+        _capturePreState();
+        
+        vm.prank(strategist);
+        try accountantYS.updateExchangeRate() {} catch {}
+        
+        syncVestedAssets();
+        _afterCall();
+    }
+    
+    /**
+     * @notice Pause AccountantWithYieldStreaming
+     */
+    function pauseYS() external {
+        _beforeCall(AccountantWithRateProviders.pause.selector);
+        
+        vm.prank(owner);
+        try accountantYS.pause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Unpause AccountantWithYieldStreaming
+     */
+    function unpauseYS() external {
+        _beforeCall(AccountantWithRateProviders.unpause.selector);
+        
+        vm.prank(owner);
+        try accountantYS.unpause() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Reset highwater mark on AccountantWithYieldStreaming
+     */
+    function resetHighwaterMarkYS() external {
+        _beforeCall(AccountantWithRateProviders.resetHighwaterMark.selector);
+        
+        vm.prank(owner);
+        try accountantYS.resetHighwaterMark() {} catch {}
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Update vesting parameters
+     * @dev Covers both normal and edge case ranges with proper min <= max enforcement.
+     *      Duration: 1 hour to 90 days, Deviations: 0.1% to 50%
+     */
+    function updateVestingParams(uint64 minVest, uint64 maxVest, uint32 maxYield, uint32 maxLoss) external {
+        _beforeCall(AccountantWithYieldStreaming.updateMaximumVestDuration.selector);
+        
+        // Wide ranges covering both normal and edge cases
+        minVest = uint64(bound(minVest, 1 hours, 30 days));
+        maxVest = uint64(bound(maxVest, 1 hours, 90 days));
+        
+        // Ensure minVest <= maxVest
+        if (minVest > maxVest) {
+            (minVest, maxVest) = (maxVest, minVest);
+        }
+        
+        maxYield = uint32(bound(maxYield, 10, 5000)); // 0.1% to 50%
+        maxLoss = uint32(bound(maxLoss, 10, 5000));   // 0.1% to 50%
+        
+        vm.startPrank(owner);
+        // Set maxVest FIRST to avoid intermediate invalid state
+        try accountantYS.updateMaximumVestDuration(maxVest) {} catch {}
+        try accountantYS.updateMinimumVestDuration(minVest) {} catch {}
+        try accountantYS.updateMaximumDeviationYield(maxYield) {} catch {}
+        try accountantYS.updateMaximumDeviationLoss(maxLoss) {} catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    /**
+     * @notice Claim fees from AccountantWithYieldStreaming
+     */
+    function claimFeesYS() external {
+        _beforeCall(AccountantWithRateProviders.claimFees.selector);
+        
+        vm.startPrank(address(vaultYS));
+        baseAsset.approve(address(accountantYS), type(uint256).max);
+        try accountantYS.claimFees(baseAsset) {
+            feesRecentlyClaimed = true;
+        } catch {}
+        vm.stopPrank();
+        
+        _afterCall();
+    }
+    
+    // ============================================
+    // TIME PASSAGE HANDLER
+    // ============================================
+    
+    /**
+     * @notice Warp time forward to simulate long-duration vesting
+     * @dev Also syncs vested assets to simulate production yield flow
+     */
+    function warpTime(uint256 timeDelta) external {
+        timeDelta = bound(timeDelta, 1, 365 days);
+        vm.warp(block.timestamp + timeDelta);
+        
+        // After time passes, sync vested assets to vault
+        // This simulates production where yield flows into vault as it vests
+        syncVestedAssets();
+    }
+    
+    // ============================================
+    // EXTERNAL STATE CAPTURE (for TellerHandler to use)
+    // ============================================
+    
+    /// @notice Begin a YS operation from TellerHandler - captures pre-state
+    /// @param selector The selector of the operation (for invariant checking)
+    function beginYSOperation(bytes4 selector) external {
+        _setupCall(selector);
+        _capturePreState();
+    }
+    
+    /// @notice End a YS operation from TellerHandler - captures post-state
+    /// @param succeeded Whether the operation succeeded
+    function endYSOperation(bool succeeded) external {
+        lastCallSucceeded = succeeded;
+        _afterCall();
+    }
+    
+    // ============================================
+    // STRUCT GETTERS (needed because public structs return tuples)
+    // ============================================
+    
+    function getPreRP() external view returns (RPState memory) {
+        return preRP;
+    }
+    
+    function getPostRP() external view returns (RPState memory) {
+        return postRP;
+    }
+    
+    function getPreYS() external view returns (YSState memory) {
+        return preYS;
+    }
+    
+    function getPostYS() external view returns (YSState memory) {
+        return postYS;
+    }
+    
+    function getPreYSAccountant() external view returns (RPState memory) {
+        return preYSAccountant;
+    }
+    
+    function getPostYSAccountant() external view returns (RPState memory) {
+        return postYSAccountant;
+    }
+    
+}

--- a/test/fuzzing/medusa/invariants/BaseInvariants.sol
+++ b/test/fuzzing/medusa/invariants/BaseInvariants.sol
@@ -1,0 +1,590 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "@forge-std/Test.sol";
+import {StdInvariant} from "@forge-std/StdInvariant.sol";
+
+import {BaseSetup} from "../../BaseSetup.sol";
+import {AccountantHandler} from "../handlers/AccountantHandler.sol";
+import {TellerHandler} from "../../handlers/TellerHandler.sol";
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+
+/**
+ * @title BaseInvariants
+ * @notice Abstract base contract containing all shared invariants for BOTH RP and YS systems (Medusa-compatible)
+ * @dev Uses require() instead of assert*() for Medusa compatibility
+ */
+abstract contract BaseInvariants is StdInvariant, BaseSetup {
+    using FixedPointMathLib for uint256;
+
+    // ============================================
+    // ABSTRACT GETTERS - Implemented by child contracts
+    // ============================================
+
+    function _accountant() internal view virtual returns (AccountantWithRateProviders);
+    function _teller() internal view virtual returns (TellerWithMultiAssetSupport);
+    function _vault() internal view virtual returns (BoringVault);
+    function _accountantHandler() internal view virtual returns (AccountantHandler);
+    function _tellerHandler() internal view virtual returns (TellerHandler);
+    function _getPreState() internal view virtual returns (AccountantHandler.RPState memory);
+    function _getPostState() internal view virtual returns (AccountantHandler.RPState memory);
+    function _getTellerPreState() internal view virtual returns (TellerHandler.TellerState memory);
+    function _getTellerPostState() internal view virtual returns (TellerHandler.TellerState memory);
+
+    // ============================================
+    // HELPER FUNCTIONS
+    // ============================================
+
+    function _isAccountantPaused() internal view returns (bool) {
+        (,,,,,,,, bool isPaused,,,) = _accountant().accountantState();
+        return isPaused;
+    }
+
+    // ============================================
+    // GROUP 1: ACCOUNTANT INVARIANTS (Rules 1-7)
+    // ============================================
+
+    function invariant_accountantDoesntHoldTokens() public view returns (bool) {
+        address acc = address(_accountant());
+        
+        // Check base asset
+        require(
+            baseAsset.balanceOf(acc) == 0,
+            "Invariant 1: Accountant should not hold base tokens"
+        );
+        
+        // Check ALL alternative assets (N-asset support)
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            require(
+                alternativeAssets[i].balanceOf(acc) == 0,
+                "Invariant 1: Accountant should not hold alt tokens"
+            );
+        }
+
+        (address payout,,,,,,,,,,, ) = _accountant().accountantState();
+        require(payout != acc, "Invariant 1: Payout should not be Accountant");
+        return true;
+    }
+
+    function invariant_accountantPaused_valuesFrozen() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+
+        if (pre.isPaused && selector != AccountantWithRateProviders.resetHighwaterMark.selector) {
+            require(
+                post.feesOwedInBase == pre.feesOwedInBase,
+                "Invariant 2: Fees should be frozen when paused"
+            );
+        }
+        return true;
+    }
+
+    function invariant_feesCanOnlyDecreaseViaClaimFees() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+
+        if (post.feesOwedInBase < pre.feesOwedInBase) {
+            require(
+                selector == AccountantWithRateProviders.claimFees.selector,
+                "Invariant 3: Fees should only decrease via claimFees"
+            );
+        }
+        return true;
+    }
+
+    function invariant_highwaterMarkNeverDecreases() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+
+        if (selector != AccountantWithRateProviders.resetHighwaterMark.selector) {
+            require(
+                post.highwaterMark >= pre.highwaterMark,
+                "Invariant 4: Highwater mark should never decrease"
+            );
+        }
+        return true;
+    }
+
+    function invariant_lastUpdateTimestampNeverDecreases() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+
+        require(
+            post.lastUpdateTimestamp >= pre.lastUpdateTimestamp,
+            "Invariant 5: Timestamp should never decrease"
+        );
+        return true;
+    }
+
+    function invariant_allowedExchangeRateChangeBounds() public view returns (bool) {
+        (, , , , , uint16 upper, uint16 lower, , , , , ) = _accountant().accountantState();
+
+        require(upper >= 10000, "Invariant 6: Upper bound should be >= 100%");
+        require(lower <= 10000, "Invariant 6: Lower bound should be <= 100%");
+        return true;
+    }
+
+    function invariant_exchangeRateLEhighwaterMark() public view returns (bool) {
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        // Only check after updateExchangeRate calls
+        if (selector != AccountantWithRateProviders.updateExchangeRate.selector) {
+            return true;
+        }
+        
+        // Only check if the call actually succeeded
+        if (!_accountantHandler().lastCallSucceeded()) {
+            return true;
+        }
+        
+        (, uint96 hwm, , , uint96 rate, , , , bool paused, , , ) = _accountant().accountantState();
+        
+        if (!paused) {
+            require(rate <= hwm, "Invariant 7: Exchange rate should be <= highwater mark when not paused");
+        }
+        return true;
+    }
+
+    // ============================================
+    // GROUP 2: TELLER INVARIANTS (Rules 20-31)
+    // ============================================
+
+    function invariant_integrityOfDeposit() public view returns (bool) {
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        bool isDepositOp = selector == TellerWithMultiAssetSupport.deposit.selector ||
+                           selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+        
+        if (!isDepositOp) return true;
+        
+        uint256 lastDepositAssets = _tellerHandler().lastDepositAssets();
+        uint256 lastDepositShares = _tellerHandler().lastDepositShares();
+        
+        if (lastDepositAssets > 0 && _tellerHandler().depositCalls() > 0) {
+            require(lastDepositShares > 0, "Invariant 20: Deposit should mint shares");
+        }
+        return true;
+    }
+
+    function invariant_integrityOfWithdraw() public view returns (bool) {
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        bool isWithdrawOp = selector == TellerWithMultiAssetSupport.withdraw.selector ||
+                            selector == TellerWithMultiAssetSupport.bulkWithdraw.selector;
+        
+        if (!isWithdrawOp) return true;
+        
+        uint256 lastWithdrawShares = _tellerHandler().lastWithdrawShares();
+        uint256 lastWithdrawAssets = _tellerHandler().lastWithdrawAssets();
+        
+        // DUST_THRESHOLD accounts for lowest decimal asset (6 decimals)
+        uint256 DUST_THRESHOLD = 1e12;
+        if (lastWithdrawShares > DUST_THRESHOLD && _tellerHandler().withdrawCalls() > 0) {
+            require(lastWithdrawAssets > 0, "Invariant 21: Withdraw should produce assets");
+        }
+        return true;
+    }
+
+    function invariant_noFreeAssets() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+        
+        uint256 testAmount = _tellerHandler().lastDepositAssets();
+        if (testAmount == 0) testAmount = 1000e18;
+        
+        uint256 shares = testAmount.mulDivDown(ONE_SHARE, rate);
+        uint256 recoveredAssets = shares.mulDivDown(rate, ONE_SHARE);
+        
+        require(recoveredAssets <= testAmount, "Invariant 22: Round-trip should not create free assets");
+        return true;
+    }
+
+    function invariant_tellerDoesntHoldTokens() public view returns (bool) {
+        address teller = address(_teller());
+        
+        // Check base asset
+        require(
+            baseAsset.balanceOf(teller) == 0,
+            "Invariant 23: Teller should not hold base tokens"
+        );
+        
+        // Check ALL alternative assets
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            require(
+                alternativeAssets[i].balanceOf(teller) == 0,
+                "Invariant 23: Teller should not hold alt tokens"
+            );
+        }
+        return true;
+    }
+
+    function invariant_vaultCannotChange() public view returns (bool) {
+        require(address(_teller().vault()) == address(_vault()), "Invariant 24: Teller vault should be immutable");
+        return true;
+    }
+
+    function invariant_depositNonceNeverGoesDown() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+
+        require(post.depositNonce >= pre.depositNonce, "Invariant 25: Deposit nonce should never decrease");
+        return true;
+    }
+
+    function invariant_tellerPaused_valuesFrozen() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+        bytes4 selector = _tellerHandler().lastSelector();
+
+        if (pre.isPaused && selector != TellerWithMultiAssetSupport.refundDeposit.selector) {
+            require(post.depositNonce == pre.depositNonce, "Invariant 26: Nonce frozen when paused");
+        }
+        return true;
+    }
+
+    function invariant_tellerPaused_methodsRevert() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        if (pre.isPaused) {
+            bool isPublicDepositWithdraw = 
+                selector == TellerWithMultiAssetSupport.deposit.selector ||
+                selector == TellerWithMultiAssetSupport.withdraw.selector;
+            
+            if (isPublicDepositWithdraw) {
+                require(
+                    post.vaultTotalSupply == pre.vaultTotalSupply,
+                    "Invariant 27: Paused teller should reject deposits/withdrawals"
+                );
+            }
+        }
+        return true;
+    }
+
+    function invariant_dustFavorsTheHouse() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+        
+        uint256 testAmount = 12345678901234567890;
+        
+        uint256 sharesFromDeposit = testAmount.mulDivDown(ONE_SHARE, rate);
+        uint256 assetsFromWithdraw = sharesFromDeposit.mulDivDown(rate, ONE_SHARE);
+        
+        require(assetsFromWithdraw <= testAmount, "Invariant 28: Rounding should favor the vault");
+        return true;
+    }
+
+    function invariant_noDynamicCalls() public view returns (bool) {
+        require(!_tellerHandler().callMade(), "Invariant 29: No unauthorized calls should be made");
+        require(!_tellerHandler().delegatecallMade(), "Invariant 29: No unauthorized delegatecalls should be made");
+        require(!_accountantHandler().callMade(), "Invariant 29: No unauthorized calls should be made");
+        require(!_accountantHandler().delegatecallMade(), "Invariant 29: No unauthorized delegatecalls should be made");
+        return true;
+    }
+
+    function invariant_onlyContributionMethodsReduceAssets() public view returns (bool) {
+        bytes4 selector = _tellerHandler().lastSelector();
+        address actor = _tellerHandler().currentActor();
+
+        if (actor == address(0)) return true;
+
+        TellerHandler.UserState memory preUser = _tellerHandler().getPreUserState(actor);
+        TellerHandler.UserState memory postUser = _tellerHandler().getPostUserState(actor);
+
+        if (postUser.baseBalance < preUser.baseBalance) {
+            bool isDepositMethod = 
+                selector == TellerWithMultiAssetSupport.deposit.selector ||
+                selector == TellerWithMultiAssetSupport.depositWithPermit.selector ||
+                selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+            
+            require(isDepositMethod, "Invariant 30: Only deposit methods should reduce user assets");
+        }
+        return true;
+    }
+
+    function invariant_withdrawingProducesAssets() public view returns (bool) {
+        uint256 withdrawCalls = _tellerHandler().withdrawCalls();
+        uint256 bulkWithdrawCalls = _tellerHandler().bulkWithdrawCalls();
+        
+        if (withdrawCalls == 0 && bulkWithdrawCalls == 0) {
+            return true;
+        }
+        
+        uint256 sharesWithdrawn = _tellerHandler().lastWithdrawShares();
+        uint256 assetsReceived = _tellerHandler().lastWithdrawAssets();
+
+        // DUST_THRESHOLD accounts for lowest decimal asset (6 decimals)
+        uint256 DUST_THRESHOLD = 1e12;
+        
+        if (sharesWithdrawn > DUST_THRESHOLD) {
+            require(assetsReceived > 0, "Invariant 31: Withdrawing shares should produce assets");
+        }
+        return true;
+    }
+
+    // ============================================
+    // GROUP 3: PERMISSIONS INVARIANTS (Rules 33, 36-37)
+    // ============================================
+
+    function invariant_feesIntegrity() public view returns (bool) {
+        AccountantHandler.RPState memory pre = _getPreState();
+        AccountantHandler.RPState memory post = _getPostState();
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        if (selector == AccountantWithRateProviders.claimFees.selector) {
+            uint256 claimedAmount = pre.feesOwedInBase > post.feesOwedInBase 
+                ? pre.feesOwedInBase - post.feesOwedInBase 
+                : 0;
+            
+            require(
+                claimedAmount <= pre.feesOwedInBase,
+                "feesIntegrity: Claimed fees should not exceed available fees"
+            );
+        }
+        return true;
+    }
+
+    function invariant_deniedUsers_balanceNonDecreasing() public view returns (bool) {
+        TellerHandler.UserState memory preDenied = _tellerHandler().getPreUserState(deniedUser);
+        TellerHandler.UserState memory postDenied = _tellerHandler().getPostUserState(deniedUser);
+
+        if (preDenied.denyFrom) {
+            require(
+                postDenied.shares >= preDenied.shares,
+                "Invariant 36: Denied user (denyFrom) shares should not decrease"
+            );
+        }
+        return true;
+    }
+
+    function invariant_deniedUsers_balanceNonIncreasing() public view returns (bool) {
+        TellerHandler.UserState memory preDenied = _tellerHandler().getPreUserState(deniedUser);
+        TellerHandler.UserState memory postDenied = _tellerHandler().getPostUserState(deniedUser);
+
+        if (preDenied.denyTo) {
+            require(
+                postDenied.shares <= preDenied.shares,
+                "Invariant 37: Denied user (denyTo) shares should not increase"
+            );
+        }
+        return true;
+    }
+
+    // ============================================
+    // GROUP 4: MATH INVARIANTS (Rules 40-47)
+    // ============================================
+
+    function invariant_convertToAssetsWeakAdditivity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 sharesA = 100e18;
+        uint256 sharesB = 200e18;
+
+        uint256 assetsA = sharesA.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsB = sharesB.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsAB = (sharesA + sharesB).mulDivDown(rate, ONE_SHARE);
+
+        require(assetsA + assetsB <= assetsAB + 1, "Invariant 40: Weak additivity for convertToAssets");
+        return true;
+    }
+
+    function invariant_convertToSharesWeakAdditivity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 assetsA = 100e18;
+        uint256 assetsB = 200e18;
+
+        uint256 sharesA = assetsA.mulDivDown(ONE_SHARE, rate);
+        uint256 sharesB = assetsB.mulDivDown(ONE_SHARE, rate);
+        uint256 sharesAB = (assetsA + assetsB).mulDivDown(ONE_SHARE, rate);
+
+        require(sharesA + sharesB <= sharesAB + 1, "Invariant 41: Weak additivity for convertToShares");
+        return true;
+    }
+
+    function invariant_conversionWeakMonotonicity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 x = 100e18;
+        uint256 y = 200e18;
+
+        uint256 convertX = x.mulDivDown(ONE_SHARE, rate);
+        uint256 convertY = y.mulDivDown(ONE_SHARE, rate);
+
+        require(x < y, "Test precondition");
+        require(convertX <= convertY, "Invariant 42: Conversion weak monotonicity");
+        return true;
+    }
+
+    function invariant_conversionWeakIntegrity() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 originalAssets = 100e18;
+
+        uint256 shares = originalAssets.mulDivDown(ONE_SHARE, rate);
+        uint256 recoveredAssets = shares.mulDivDown(rate, ONE_SHARE);
+
+        require(recoveredAssets <= originalAssets, "Invariant 43: Round trip should not create value");
+        return true;
+    }
+
+    function invariant_zeroAllowanceOnAssets() public view returns (bool) {
+        for (uint256 i = 0; i < actors.length; i++) {
+            address actor = actors[i];
+            
+            uint256 tellerAllowance = baseAsset.allowance(actor, address(_teller()));
+            require(
+                tellerAllowance == 0,
+                "Invariant 44: Users should not give allowance to teller"
+            );
+        }
+        return true;
+    }
+
+    function invariant_conversionOfZero() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+
+        uint256 zeroAssets = 0;
+        uint256 zeroShares = zeroAssets.mulDivDown(ONE_SHARE, rate);
+        
+        require(zeroShares == 0, "Invariant 45: convert(0) should equal 0");
+        return true;
+    }
+
+    function invariant_totalSupplyLEqCap() public view returns (bool) {
+        TellerHandler.TellerState memory pre = _getTellerPreState();
+        TellerHandler.TellerState memory post = _getTellerPostState();
+        bytes4 selector = _tellerHandler().lastSelector();
+        
+        bool isDepositOp = selector == TellerWithMultiAssetSupport.deposit.selector ||
+                           selector == TellerWithMultiAssetSupport.bulkDeposit.selector;
+        
+        if (!isDepositOp) return true;
+        
+        if (post.vaultTotalSupply > pre.vaultTotalSupply) {
+            require(
+                post.vaultTotalSupply <= pre.depositCap,
+                "Invariant 46: Deposit should respect deposit cap"
+            );
+        }
+        return true;
+    }
+
+    function invariant_weakAdditivityGeneral() public view returns (bool) {
+        if (_isAccountantPaused()) return true;
+        
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (rate == 0) return true;
+        
+        uint256 amountA = _tellerHandler().lastDepositAssets();
+        if (amountA == 0) amountA = 50e18;
+        uint256 amountB = amountA * 2;
+        
+        uint256 assetsA = amountA.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsB = amountB.mulDivDown(rate, ONE_SHARE);
+        uint256 assetsAB = (amountA + amountB).mulDivDown(rate, ONE_SHARE);
+        
+        require(
+            assetsA + assetsB <= assetsAB + 1,
+            "Invariant 47: Weak additivity should hold for conversions"
+        );
+        return true;
+    }
+
+    // ============================================
+    // GROUP 5: SOLVENCY INVARIANTS (Rules 38-39)
+    // ============================================
+
+    function invariant_vaultSolvencyMulti() public view returns (bool) {
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply == 0) return true;
+        if (_isAccountantPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+        if (_accountantHandler().altAssetRateChanged()) return true;
+
+        address vault = address(_vault());
+        
+        uint256 totalValueInShares = 0;
+        
+        // Base asset value
+        uint256 baseBalance = baseAsset.balanceOf(vault);
+        uint256 baseRate = _accountant().getRateInQuoteSafe(baseAsset);
+        if (baseRate > 0 && baseBalance > 0) {
+            totalValueInShares += baseBalance.mulDivDown(ONE_SHARE, baseRate);
+        }
+        
+        // Alternative assets value
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            uint256 altBalance = alternativeAssets[i].balanceOf(vault);
+            if (altBalance > 0) {
+                try _accountant().getRateInQuoteSafe(ERC20(address(alternativeAssets[i]))) returns (uint256 altRate) {
+                    if (altRate > 0) {
+                        totalValueInShares += altBalance.mulDivDown(ONE_SHARE, altRate);
+                    }
+                } catch {
+                    // Asset not configured in accountant, skip
+                }
+            }
+        }
+        
+        uint256 tolerance = totalSupply / 1000;
+        if (tolerance == 0) tolerance = 1;
+
+        require(totalValueInShares + tolerance >= totalSupply, "Invariant 38: Multi-asset solvency check (N assets)");
+        return true;
+    }
+
+    function invariant_vaultSolvency_1Asset() public view returns (bool) {
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply == 0) return true;
+        if (_isAccountantPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+
+        address vault = address(_vault());
+        for (uint256 i = 0; i < NUM_ALT_ASSETS; i++) {
+            if (alternativeAssets[i].balanceOf(vault) > 0) return true;
+        }
+
+        uint256 vaultBalance = baseAsset.balanceOf(vault);
+        uint256 rate = _accountant().getRateInQuoteSafe(baseAsset);
+
+        uint256 lhs = vaultBalance * ONE_SHARE;
+        uint256 rhs = totalSupply * rate;
+
+        uint256 tolerance = rhs / 1000;
+        if (tolerance == 0) tolerance = 1;
+
+        require(lhs + tolerance >= rhs, "Invariant 39: Single-asset solvency check");
+        return true;
+    }
+}

--- a/test/fuzzing/medusa/invariants/YSOnlyInvariants.sol
+++ b/test/fuzzing/medusa/invariants/YSOnlyInvariants.sol
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {BaseInvariants} from "./BaseInvariants.sol";
+import {AccountantHandler} from "../handlers/AccountantHandler.sol";
+
+import {AccountantWithYieldStreaming} from "src/base/Roles/AccountantWithYieldStreaming.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+
+/**
+ * @title YSOnlyInvariants
+ * @notice Abstract contract containing YS-ONLY invariants (Medusa-compatible)
+ * @dev Uses require() instead of assert*() for Medusa compatibility
+ */
+abstract contract YSOnlyInvariants is BaseInvariants {
+    using FixedPointMathLib for uint256;
+
+    bytes4 constant YS_UPDATE_EXCHANGE_RATE_SELECTOR = bytes4(keccak256("updateExchangeRate()"));
+
+    function _accountantYS() internal view virtual returns (AccountantWithYieldStreaming);
+    function _getPreYS() internal view virtual returns (AccountantHandler.YSState memory);
+    function _getPostYS() internal view virtual returns (AccountantHandler.YSState memory);
+
+    // ============================================
+    // HELPER FUNCTIONS
+    // ============================================
+
+    function _isAccountantYSPaused() internal view returns (bool) {
+        (,,,,,,,, bool isPaused,,,) = _accountantYS().accountantState();
+        return isPaused;
+    }
+
+    // ============================================
+    // YS-ONLY INVARIANTS (Rules 8-19, 32, 34, 35)
+    // ============================================
+
+    function invariant_cumulativeSupplyBounded() public view returns (bool) {
+        (uint256 cumSupply, uint256 cumSupplyLast, ) = _accountantYS().supplyObservation();
+        
+        require(cumSupply >= cumSupplyLast, "Invariant 8: Cumulative supply last should be <= cumulative supply");
+        return true;
+    }
+
+    function invariant_exchangeRateEqlastSharePrice() public view returns (bool) {
+        (, , , , uint96 rate, , , , bool isPaused, , , ) = _accountantYS().accountantState();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+
+        if (isPaused) return true;
+
+        bytes4 selector = _accountantHandler().lastSelector();
+        bool isSyncOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                        selector == AccountantWithYieldStreaming.postLoss.selector ||
+                        selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+        
+        if (!isSyncOp) return true;
+
+        if (lastSharePrice <= type(uint96).max) {
+            require(rate == uint96(lastSharePrice), "Invariant 9: Exchange rate should equal last share price");
+        }
+        return true;
+    }
+
+    function invariant_sharePriceBoundedUpper() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply > 0) {
+            uint256 rate = _accountantYS().getRate();
+            uint256 totalAssets = _accountantYS().totalAssets();
+            
+            uint256 lhs = rate.mulDivUp(totalSupply, ONE_SHARE);
+            require(lhs <= totalAssets + 1, "Invariant 10: Share price upper bound violated");
+        }
+        return true;
+    }
+
+    function invariant_sharePriceBoundedLower() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply > 0) {
+            uint256 rate = _accountantYS().getRate();
+            uint256 totalAssets = _accountantYS().totalAssets();
+            
+            uint256 lhs = rate.mulDivDown(totalSupply, ONE_SHARE);
+            
+            uint256 tolerance = totalAssets / 1e6;
+            if (tolerance == 0) tolerance = 1;
+            
+            require(lhs + tolerance >= totalAssets, "Invariant 11: Share price lower bound violated");
+        }
+        return true;
+    }
+
+    function invariant_sharePriceMoreThanOne() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+        if (_vault().totalSupply() == 0) return true;
+
+        uint256 rate = _accountantYS().getRate();
+        uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+        
+        if (vaultBalance > 0) {
+            require(rate > 0, "Invariant 12: Share price should be non-zero when assets exist");
+        }
+        return true;
+    }
+
+    function invariant_totalAssetsCovered() public view returns (bool) {
+        if (_isAccountantYSPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+
+        uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+        uint256 totalAssets = _accountantYS().totalAssets();
+        
+        uint256 tolerance = totalAssets / 10000;
+        if (tolerance == 0) tolerance = 1;
+        
+        require(
+            totalAssets <= vaultBalance + tolerance,
+            "Invariant 13: Total assets should be covered by vault balance"
+        );
+        return true;
+    }
+
+    function invariant_startVestingTimeLEendVestingTime() public view returns (bool) {
+        (, uint128 vestingGains, , uint64 startTime, uint64 endTime) = _accountantYS().vestingState();
+        uint256 totalSupply = _vault().totalSupply();
+        
+        if (vestingGains == 0 || totalSupply == 0) return true;
+        
+        require(startTime <= endTime, "Invariant 14: Start vesting time should be <= end vesting time");
+        return true;
+    }
+
+    function invariant_vestingGainsIntegrity() public view returns (bool) {
+        (, uint128 vestingGains, , uint64 startTime, uint64 endTime) = _accountantYS().vestingState();
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (vestingGains > 0 && totalSupply > 0) {
+            require(startTime < endTime, "Invariant 15: If vesting gains > 0, start must be < end");
+        }
+        return true;
+    }
+
+    function invariant_lastVestingUpdateNeverDecreases() public view returns (bool) {
+        AccountantHandler.YSState memory preYS = _getPreYS();
+        AccountantHandler.YSState memory postYS = _getPostYS();
+
+        require(
+            postYS.lastVestingUpdate >= preYS.lastVestingUpdate,
+            "Invariant 16: Last vesting update should never decrease"
+        );
+        return true;
+    }
+
+    function invariant_integrityOfVestYield() public view returns (bool) {
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        if (selector == AccountantWithYieldStreaming.vestYield.selector && _accountantHandler().lastCallSucceeded()) {
+            (, , uint128 lastVestingUpdate, uint64 startTime, ) = _accountantYS().vestingState();
+            require(lastVestingUpdate >= startTime, "Invariant 17: Vesting update should be >= start time");
+        }
+        return true;
+    }
+
+    function invariant_exchangeRatePostLoss() public view returns (bool) {
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        if (selector == AccountantWithYieldStreaming.postLoss.selector && _accountantHandler().lastCallSucceeded()) {
+            (, uint96 hwm, , , uint96 rate, , , , , , , ) = _accountantYS().accountantState();
+            
+            require(
+                rate <= hwm,
+                "Invariant 18: After postLoss, rate should be <= HWM"
+            );
+        }
+        return true;
+    }
+
+    function invariant_vaultSolvency_1Asset_Vesting() public view returns (bool) {
+        uint256 totalSupply = _vault().totalSupply();
+
+        if (totalSupply == 0) return true;
+        if (_isAccountantYSPaused()) return true;
+        if (_accountantHandler().feesRecentlyClaimed()) return true;
+
+        uint256 vaultBalance = baseAsset.balanceOf(address(_vault()));
+        uint256 pendingVest = _accountantYS().getPendingVestingGains();
+        uint256 rate = _accountantYS().getRateInQuoteSafe(baseAsset);
+
+        uint256 lhs = vaultBalance * ONE_SHARE;
+        uint256 rhs = totalSupply.mulDivUp(rate, 1) + pendingVest * ONE_SHARE;
+        
+        uint256 tolerance = rhs / 1000;
+        if (tolerance == 0) tolerance = 1;
+        
+        require(lhs + tolerance >= rhs, "Invariant 19: Vesting solvency check");
+        return true;
+    }
+
+    function invariant_yieldIntegrity() public view returns (bool) {
+        AccountantHandler.YSState memory preYS = _getPreYS();
+        AccountantHandler.YSState memory postYS = _getPostYS();
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        bool isYieldRealizingOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                                  selector == AccountantWithYieldStreaming.postLoss.selector ||
+                                  selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR ||
+                                  selector == TellerWithMultiAssetSupport.deposit.selector ||
+                                  selector == TellerWithMultiAssetSupport.bulkDeposit.selector ||
+                                  selector == TellerWithMultiAssetSupport.withdraw.selector ||
+                                  selector == TellerWithMultiAssetSupport.bulkWithdraw.selector;
+        
+        if (!isYieldRealizingOp) return true;
+        if (!_accountantHandler().lastCallSucceeded()) return true;
+        
+        uint256 totalSupply = preYS.totalSupply;
+        if (totalSupply == 0) return true;
+        
+        uint256 realizedYieldPerShare = postYS.lastSharePrice > preYS.lastSharePrice
+            ? postYS.lastSharePrice - preYS.lastSharePrice
+            : 0;
+        
+        uint256 lhs = realizedYieldPerShare.mulDivUp(totalSupply, ONE_SHARE);
+        uint256 rhs = preYS.pendingGains;
+        
+        uint256 tolerance = totalSupply / ONE_SHARE + 1;
+        
+        require(
+            lhs <= rhs + tolerance,
+            "Invariant 33: Realized yield (in assets) cannot exceed pending vested gains"
+        );
+        
+        require(
+            postYS.pendingGains <= uint256(postYS.vestingGains),
+            "Invariant 33: Pending gains cannot exceed total vesting pool"
+        );
+        return true;
+    }
+
+    function invariant_yieldAccrualsMonotonic() public view returns (bool) {
+        AccountantHandler.YSState memory preYS = _getPreYS();
+        AccountantHandler.YSState memory postYS = _getPostYS();
+        bytes4 selector = _accountantHandler().lastSelector();
+        
+        bool isReducingOp = selector == AccountantWithYieldStreaming.vestYield.selector ||
+                            selector == AccountantWithYieldStreaming.postLoss.selector ||
+                            selector == YS_UPDATE_EXCHANGE_RATE_SELECTOR;
+        
+        if (!isReducingOp) {
+            require(
+                postYS.lastVestingUpdate >= preYS.lastVestingUpdate,
+                "Invariant 32: Yield accrual timestamp should be monotonic"
+            );
+        }
+        return true;
+    }
+
+    function invariant_streamingRateConsistency() public view returns (bool) {
+        (, uint128 vestingGains, , , uint64 endTime) = _accountantYS().vestingState();
+        
+        uint256 pendingGains = _accountantYS().getPendingVestingGains();
+        
+        require(
+            pendingGains <= uint256(vestingGains),
+            "Invariant 34: Pending gains should not exceed total vesting gains"
+        );
+        
+        if (block.timestamp >= endTime && vestingGains > 0) {
+            require(
+                pendingGains == uint256(vestingGains),
+                "Invariant 34: Past end time, pending should equal all remaining gains"
+            );
+        }
+        return true;
+    }
+
+    function invariant_accessControlYieldParams() public view returns (bool) {
+        uint64 minVest = _accountantYS().minimumVestingTime();
+        uint64 maxVest = _accountantYS().maximumVestingTime();
+        
+        require(minVest <= maxVest, "Invariant 35: min vesting time should be <= max vesting time");
+        return true;
+    }
+
+    // ============================================
+    // VIRTUAL SHARE PRICE INVARIANTS (Rules 36-38)
+    // ============================================
+
+    uint256 constant RAY = 1e27;
+
+    function invariant_virtualPriceUpperBound() public view returns (bool) {
+        // Skip when totalSupply == 0 - virtual price state is not updated when no shares exist
+        uint256 totalSupply = _vault().totalSupply();
+        if (totalSupply == 0) return true;
+        
+        // Skip when paused - state may be stale
+        if (_isAccountantYSPaused()) return true;
+        
+        uint256 virtualPrice = _accountantYS().lastVirtualSharePrice();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+        
+        // Skip if virtual price is 0 (not yet initialized or edge case)
+        if (virtualPrice == 0) return true;
+        
+        uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+        
+        // FINDING: Skip when converted price exceeds uint128 max - the protocol's 
+        // _calculateSharePriceFromVirtual() silently truncates via uint128 cast.
+        // This is a known limitation when lastVirtualSharePrice gets extremely large
+        // (e.g., after large yield vests with few shares). See FINDINGS.md Finding 2.
+        if (convertedPrice > type(uint128).max) return true;
+        
+        // Allow for truncation tolerance when uint128 cast loses precision
+        // The uint128 cast in _calculateSharePriceFromVirtual can cause up to 1 wei difference
+        // due to mulDivDown rounding combined with truncation
+        require(
+            convertedPrice <= uint256(lastSharePrice) + 1, 
+            "Invariant 36: Virtual price conversion should be <= lastSharePrice + 1"
+        );
+        return true;
+    }
+
+    function invariant_virtualPriceLowerBound() public view returns (bool) {
+        // Skip when totalSupply == 0 - virtual price state is not updated when no shares exist
+        uint256 totalSupply = _vault().totalSupply();
+        if (totalSupply == 0) return true;
+        
+        // Skip when paused - state may be stale
+        if (_isAccountantYSPaused()) return true;
+        
+        uint256 virtualPrice = _accountantYS().lastVirtualSharePrice();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+        
+        // Skip if virtual price is 0 (not yet initialized or edge case)
+        if (virtualPrice == 0) return true;
+        
+        uint256 convertedPrice = virtualPrice.mulDivDown(ONE_SHARE, RAY);
+        
+        // Skip when converted price exceeds uint128 max - truncation already occurred
+        // See invariant_virtualPriceUpperBound for details on this known limitation
+        if (convertedPrice > type(uint128).max) return true;
+        
+        require(
+            lastSharePrice <= convertedPrice,
+            "Invariant 37: lastSharePrice should be <= converted virtual price"
+        );
+        return true;
+    }
+
+    function invariant_pendingGainsRateRelationship() public view returns (bool) {
+        uint256 pendingGains = _accountantYS().getPendingVestingGains();
+        uint256 rate = _accountantYS().getRate();
+        (uint128 lastSharePrice, , , , ) = _accountantYS().vestingState();
+        uint256 totalSupply = _vault().totalSupply();
+        
+        if (totalSupply == 0) {
+            require(rate == lastSharePrice, "Invariant 38: With 0 shares, rate == lastSharePrice");
+            return true;
+        }
+        
+        if (pendingGains == 0) {
+            uint256 diff = rate > lastSharePrice ? rate - lastSharePrice : uint256(lastSharePrice) - rate;
+            require(diff <= 1, "Invariant 38: Zero pending gains implies rate == lastSharePrice (+/-1)");
+        }
+        
+        if (rate <= uint256(lastSharePrice) + 1 && rate >= uint256(lastSharePrice)) {
+            uint256 maxNegligibleGains = (2 * totalSupply) / ONE_SHARE + 1;
+            require(
+                pendingGains <= maxNegligibleGains, 
+                "Invariant 38: Rate approx lastSharePrice implies negligible pending gains"
+            );
+        }
+        return true;
+    }
+}

--- a/test/fuzzing/mocks/MockERC20Extended.sol
+++ b/test/fuzzing/mocks/MockERC20Extended.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+/**
+ * @title MockERC20Extended
+ * @notice A mock ERC20 with permit and mint capabilities for testing
+ */
+contract MockERC20Extended is ERC20 {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_, decimals_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+}
+

--- a/test/fuzzing/mocks/MockRateProvider.sol
+++ b/test/fuzzing/mocks/MockRateProvider.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {IRateProvider} from "src/interfaces/IRateProvider.sol";
+
+/**
+ * @title MockRateProvider
+ * @notice A mock rate provider for testing purposes
+ * @dev IMPORTANT: Rate providers must return rates in the QUOTE TOKEN's decimals, not 18 decimals.
+ *      This is because getRateInQuote calculates:
+ *        rateInQuote = oneQuote * exchangeRateInQuoteDecimals / quoteRate
+ *      where oneQuote = 10 ** quoteDecimals
+ *      
+ *      For the math to work correctly, quoteRate must be in quote decimals.
+ *      Example: For a 6-decimal USDC at 1:1 with base, rate should be 1e6, not 1e18.
+ */
+contract MockRateProvider is IRateProvider {
+    uint256 private _rate;
+    uint8 public immutable quoteDecimals;
+    
+    // Bounds are relative to 1.0 in quote decimals
+    // MIN_RATE_FACTOR = 0.001 (alt worth 0.1% of base)
+    // MAX_RATE_FACTOR = 1000 (alt worth 1000x base)
+    uint256 constant MIN_RATE_FACTOR = 1;      // 0.001 as a multiplier (rate / 1000)
+    uint256 constant MAX_RATE_FACTOR = 1000000; // 1000 as a multiplier (rate * 1000)
+
+    constructor(uint256 initialRate, uint8 _quoteDecimals) {
+        _rate = initialRate;
+        quoteDecimals = _quoteDecimals;
+    }
+
+    function getRate() external view override returns (uint256) {
+        uint256 oneUnit = 10 ** quoteDecimals;
+        uint256 minRate = oneUnit / 1000;  // 0.001 in quote decimals
+        uint256 maxRate = oneUnit * 1000;  // 1000 in quote decimals
+        
+        // Apply bounds on read to handle direct fuzzer calls to setRate
+        if (_rate < minRate) return minRate;
+        if (_rate > maxRate) return maxRate;
+        return _rate;
+    }
+
+    function setRate(uint256 newRate) external {
+        _rate = newRate;  // Store raw value, bounds applied in getRate()
+    }
+    
+    /// @notice Get the one unit value for this rate provider (10 ** quoteDecimals)
+    function getOneUnit() external view returns (uint256) {
+        return 10 ** quoteDecimals;
+    }
+}

--- a/test/fuzzing/mocks/MockWETH.sol
+++ b/test/fuzzing/mocks/MockWETH.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+/**
+ * @title MockWETH
+ * @notice A mock WETH contract for testing purposes
+ */
+contract MockWETH is ERC20 {
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+
+    constructor() ERC20("Wrapped Ether", "WETH", 18) {}
+
+    receive() external payable {
+        deposit();
+    }
+
+    function deposit() public payable {
+        _mint(msg.sender, msg.value);
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 wad) public {
+        _burn(msg.sender, wad);
+        payable(msg.sender).transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+}
+


### PR DESCRIPTION
## Summary

- Add the invariant fuzzing test suite c
- Example configs (`example-foundry.toml`, `example-medusa.json`) and moved `README.md` with setup instructions to the fuzzing folder

## What's Included

```
test/fuzzing/
├── README.md                       # Full documentation
├── example-foundry.toml            # Foundry config for fuzzing
├── example-medusa.json             # Medusa config for fuzzing
├── BaseSetup.sol                   # Shared test infrastructure
├── InvariantTestRP.sol             # Foundry RP system entry point
├── InvariantTestYS.sol             # Foundry YS system entry point
├── handlers/                       # Accountant & Teller handlers
├── invariants/                     # Shared + YS-specific invariants
├── mocks/                          # MockERC20, MockRateProvider, MockWETH
└── medusa/                         # Medusa-adapted suite (require() assertions)
```

