### PR TITLE
LayerZero OFT multihop bridging support

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
@@ -17,12 +17,38 @@ contract OFTDecoderAndSanitizer {
         DecoderCustomTypes.MessagingFee calldata, /*_fee*/
         address _refundAddress
     ) external pure virtual returns (bytes memory sensitiveArguments) {
-        // Sanitize Message.
-        if (_sendParam.composeMsg.length > 0) {
-            revert OFTDecoderAndSanitizer__NonZeroMessage();
-        }
         if (_sendParam.oftCmd.length > 0) {
             revert OFTDecoderAndSanitizer__NonZeroOFTCommand();
+        }
+
+        // MultiHop support.
+        if (_sendParam.composeMsg.length > 0) {
+            // It requires the final destination parameters to be encoded in the compose message.
+            DecoderCustomTypes.SendParam memory finalDestinationParams =
+                abi.decode(_sendParam.composeMsg, (DecoderCustomTypes.SendParam));
+
+            bytes32 amountBytes = bytes32(_sendParam.amountLD);
+            bytes32 finalAmountBytes = bytes32(finalDestinationParams.amountLD);
+
+            // Layout (10 addresses):
+            //   [0]   Packed endpoint IDs: (firstHopEid << 32 | finalDestEid) as address
+            //   [1-2] First hop receiver (bytes32 `to`, split upper/lower)
+            //   [3-4] Final destination receiver (bytes32 `to`, split upper/lower)
+            //   [5-6] First hop amount (uint256 `amountLD`, split upper/lower)
+            //   [7-8] Final destination amount (uint256 `amountLD`, split upper/lower)
+            //   [9]   Refund address
+            return abi.encodePacked(
+                address(uint160((uint256(_sendParam.dstEid) << 32) | uint256(finalDestinationParams.dstEid))),
+                address(bytes20(bytes16(_sendParam.to))),
+                address(bytes20(bytes16(_sendParam.to << 128))),
+                address(bytes20(bytes16(finalDestinationParams.to))),
+                address(bytes20(bytes16(finalDestinationParams.to << 128))),
+                address(bytes20(bytes16(amountBytes))),
+                address(bytes20(bytes16(amountBytes << 128))),
+                address(bytes20(bytes16(finalAmountBytes))),
+                address(bytes20(bytes16(finalAmountBytes << 128))),
+                _refundAddress
+            );
         }
 
         sensitiveArguments = abi.encodePacked(

--- a/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
@@ -7,7 +7,6 @@ pragma solidity 0.8.21;
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
 
 contract OFTDecoderAndSanitizer {
-    error OFTDecoderAndSanitizer__NonZeroMessage();
     error OFTDecoderAndSanitizer__NonZeroOFTCommand();
 
     //============================== OFT ===============================
@@ -27,26 +26,21 @@ contract OFTDecoderAndSanitizer {
             DecoderCustomTypes.SendParam memory finalDestinationParams =
                 abi.decode(_sendParam.composeMsg, (DecoderCustomTypes.SendParam));
 
-            bytes32 amountBytes = bytes32(_sendParam.amountLD);
-            bytes32 finalAmountBytes = bytes32(finalDestinationParams.amountLD);
+            if (finalDestinationParams.oftCmd.length > 0) {
+                revert OFTDecoderAndSanitizer__NonZeroOFTCommand();
+            }
 
-            // Layout (10 addresses):
+            // Layout (6 addresses):
             //   [0]   Packed endpoint IDs: (firstHopEid << 32 | finalDestEid) as address
             //   [1-2] First hop receiver (bytes32 `to`, split upper/lower)
             //   [3-4] Final destination receiver (bytes32 `to`, split upper/lower)
-            //   [5-6] First hop amount (uint256 `amountLD`, split upper/lower)
-            //   [7-8] Final destination amount (uint256 `amountLD`, split upper/lower)
-            //   [9]   Refund address
+            //   [5]   Refund address
             return abi.encodePacked(
                 address(uint160((uint256(_sendParam.dstEid) << 32) | uint256(finalDestinationParams.dstEid))),
                 address(bytes20(bytes16(_sendParam.to))),
                 address(bytes20(bytes16(_sendParam.to << 128))),
                 address(bytes20(bytes16(finalDestinationParams.to))),
                 address(bytes20(bytes16(finalDestinationParams.to << 128))),
-                address(bytes20(bytes16(amountBytes))),
-                address(bytes20(bytes16(amountBytes << 128))),
-                address(bytes20(bytes16(finalAmountBytes))),
-                address(bytes20(bytes16(finalAmountBytes << 128))),
                 _refundAddress
             );
         }

--- a/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
@@ -7,6 +7,7 @@ pragma solidity 0.8.21;
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
 
 contract OFTDecoderAndSanitizer {
+    error OFTDecoderAndSanitizer__NonZeroMessage();
     error OFTDecoderAndSanitizer__NonZeroOFTCommand();
 
     //============================== OFT ===============================
@@ -28,6 +29,11 @@ contract OFTDecoderAndSanitizer {
 
             if (finalDestinationParams.oftCmd.length > 0) {
                 revert OFTDecoderAndSanitizer__NonZeroOFTCommand();
+            }
+
+            // Do not allow more than one compose message.
+            if (finalDestinationParams.composeMsg.length > 0) {
+                revert OFTDecoderAndSanitizer__NonZeroMessage();
             }
 
             // Layout (6 addresses):

--- a/test/integrations/OFTBridgeIntegration.t.sol
+++ b/test/integrations/OFTBridgeIntegration.t.sol
@@ -43,7 +43,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
         setSourceChainName(mainnet);
         // Setup forked environment.
         string memory rpcKey = "MAINNET_RPC_URL";
-        uint256 blockNumber = 22238413;
+        uint256 blockNumber = 24575933;
 
         _startFork(rpcKey, blockNumber);
 
@@ -165,14 +165,26 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
         manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
     }
 
-    function testBridgingToBaseERC20Reverts() external {
-        deal(getAddress(sourceChain, "WEETH"), address(boringVault), 101e18);
+    function testMultiHopBridging() external {
+        deal(getAddress(sourceChain, "PYUSD"), address(boringVault), 101e18);
         deal(getAddress(sourceChain, "boringVault"), 101e18);
 
+        uint32 firstHopEndpoint = 30110; // Arbitrum 
+        uint32 finalDestEndpoint = 30292; // Ink
+        bytes32 finalDestTo = makeAddr("boringVaultRecipient").toBytes32();
+
         ManageLeaf[] memory leafs = new ManageLeaf[](2);
-        _addLayerZeroLeafs(
-            leafs, getERC20(sourceChain, "WEETH"), getAddress(sourceChain, "EtherFiOFTAdapter"), layerZeroBaseEndpointId, getBytes32(sourceChain, "boringVault")
-        );
+        _addLayerZeroMultiHopLeafs({
+            leafs: leafs,
+            asset: getERC20(sourceChain, "PYUSD"),
+            oftAdapter: getAddress(sourceChain, "PYUSDOFTAdapter"),
+            firstHopEndpoint: firstHopEndpoint,
+            firstHopTo: getBytes32("arbitrum", "PYUSDOFTAdapter"),
+            finalDestEndpoint: finalDestEndpoint,
+            finalDestTo: finalDestTo,
+            amountLD: 100e6,
+            finalAmountLD: 100e6
+        });
 
         bytes32[][] memory manageTree = _generateMerkleTree(leafs);
 
@@ -185,66 +197,121 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
         bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
 
         address[] memory targets = new address[](2);
-        targets[0] = getAddress(sourceChain, "WEETH");
-        targets[1] = getAddress(sourceChain, "EtherFiOFTAdapter");
+        targets[0] = getAddress(sourceChain, "PYUSD");
+        targets[1] = getAddress(sourceChain, "PYUSDOFTAdapter");
 
         bytes[] memory targetData = new bytes[](2);
         targetData[0] = abi.encodeWithSignature(
-            "approve(address,uint256)", getAddress(sourceChain, "EtherFiOFTAdapter"), type(uint256).max
+            "approve(address,uint256)", getAddress(sourceChain, "PYUSDOFTAdapter"), type(uint256).max
         );
-        DecoderCustomTypes.SendParam memory param;
-        param.dstEid = layerZeroBaseEndpointId;
-        param.to = address(boringVault).toBytes32();
-        param.amountLD = 100e18;
-        param.minAmountLD = 99e18;
-        param.extraOptions = hex"0003";
-        param.composeMsg = hex"00";
-        param.oftCmd = hex"";
 
+        // First Hop parameters
+        DecoderCustomTypes.SendParam memory hopParam;
+        hopParam.dstEid = firstHopEndpoint;
+        hopParam.to = getBytes32("arbitrum", "PYUSDOFTAdapter");
+        hopParam.amountLD = 100e6;
+        hopParam.minAmountLD = 99e6;
+        hopParam.extraOptions = hex"";
+        hopParam.oftCmd = hex"";
+
+        // Final destination parameters
+        DecoderCustomTypes.SendParam memory finalDestParam;
+        finalDestParam.dstEid = finalDestEndpoint;
+        finalDestParam.to = finalDestTo;
+        finalDestParam.amountLD = 100e6;
+        finalDestParam.minAmountLD = 99e6;
+        finalDestParam.extraOptions = hex"0003";
+
+        // Set the final destination parameters as the compose message for the first hop
+        hopParam.composeMsg = abi.encode(finalDestParam);
+        
         DecoderCustomTypes.MessagingFee memory fee;
         fee.nativeFee = 0.0006e18;
         fee.lzTokenFee = 0;
 
-        targetData[1] = abi.encodeWithSignature(
-            "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
-            param,
-            fee,
-            boringVault
-        );
         uint256[] memory values = new uint256[](2);
         values[1] = fee.nativeFee;
         address[] memory decodersAndSanitizers = new address[](2);
         decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
         decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
 
-        vm.expectRevert(
-            bytes(abi.encodeWithSelector(OFTDecoderAndSanitizer.OFTDecoderAndSanitizer__NonZeroMessage.selector))
-        );
-        manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
-
-        param.composeMsg = hex"";
-        param.oftCmd = hex"00";
-
         targetData[1] = abi.encodeWithSignature(
             "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
-            param,
+            hopParam,
             fee,
             boringVault
         );
 
-        vm.expectRevert(
-            bytes(abi.encodeWithSelector(OFTDecoderAndSanitizer.OFTDecoderAndSanitizer__NonZeroOFTCommand.selector))
-        );
         manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
+    }
 
-        param.oftCmd = hex"";
+    function testRevertInvalidComposeMsg() external {
+        deal(getAddress(sourceChain, "PYUSD"), address(boringVault), 101e18);
+        deal(getAddress(sourceChain, "boringVault"), 101e18);
+
+        uint32 firstHopEndpoint = 30110; // Arbitrum
+        uint32 finalDestEndpoint = 30292; // Ink
+        bytes32 finalDestTo = makeAddr("boringVaultRecipient").toBytes32();
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](2);
+        _addLayerZeroMultiHopLeafs({
+            leafs: leafs,
+            asset: getERC20(sourceChain, "PYUSD"),
+            oftAdapter: getAddress(sourceChain, "PYUSDOFTAdapter"),
+            firstHopEndpoint: firstHopEndpoint,
+            firstHopTo: getBytes32("arbitrum", "PYUSDOFTAdapter"),
+            finalDestEndpoint: finalDestEndpoint,
+            finalDestTo: finalDestTo,
+            amountLD: 100e6,
+            finalAmountLD: 100e6
+        });
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
+        manageLeafs[0] = leafs[0];
+        manageLeafs[1] = leafs[1];
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
+
+        address[] memory targets = new address[](2);
+        targets[0] = getAddress(sourceChain, "PYUSD");
+        targets[1] = getAddress(sourceChain, "PYUSDOFTAdapter");
+
+        bytes[] memory targetData = new bytes[](2);
+        targetData[0] = abi.encodeWithSignature(
+            "approve(address,uint256)", getAddress(sourceChain, "PYUSDOFTAdapter"), type(uint256).max
+        );
+
+        DecoderCustomTypes.SendParam memory hopParam;
+        hopParam.dstEid = firstHopEndpoint;
+        hopParam.to = getBytes32("arbitrum", "PYUSDOFTAdapter");
+        hopParam.amountLD = 100e6;
+        hopParam.minAmountLD = 99e6;
+        hopParam.extraOptions = hex"";
+        hopParam.oftCmd = hex"";
+        // Invalid composeMsg: non-empty but not a valid ABI-encoded SendParam
+        hopParam.composeMsg = hex"deadbeef";
+
+        DecoderCustomTypes.MessagingFee memory fee;
+        fee.nativeFee = 0.0006e18;
+        fee.lzTokenFee = 0;
+
+        uint256[] memory values = new uint256[](2);
+        values[1] = fee.nativeFee;
+        address[] memory decodersAndSanitizers = new address[](2);
+        decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
         targetData[1] = abi.encodeWithSignature(
             "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
-            param,
+            hopParam,
             fee,
             boringVault
         );
 
+        vm.expectRevert();
         manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
     }
 

--- a/test/integrations/OFTBridgeIntegration.t.sol
+++ b/test/integrations/OFTBridgeIntegration.t.sol
@@ -181,9 +181,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
             firstHopEndpoint: firstHopEndpoint,
             firstHopTo: getBytes32("arbitrum", "PYUSDOFTAdapter"),
             finalDestEndpoint: finalDestEndpoint,
-            finalDestTo: finalDestTo,
-            amountLD: 100e6,
-            finalAmountLD: 100e6
+            finalDestTo: finalDestTo
         });
 
         bytes32[][] memory manageTree = _generateMerkleTree(leafs);
@@ -224,7 +222,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
 
         // Set the final destination parameters as the compose message for the first hop
         hopParam.composeMsg = abi.encode(finalDestParam);
-        
+
         DecoderCustomTypes.MessagingFee memory fee;
         fee.nativeFee = 0.0006e18;
         fee.lzTokenFee = 0;
@@ -261,9 +259,7 @@ contract OFTBridgeIntegrationTest is Test, MerkleTreeHelper {
             firstHopEndpoint: firstHopEndpoint,
             firstHopTo: getBytes32("arbitrum", "PYUSDOFTAdapter"),
             finalDestEndpoint: finalDestEndpoint,
-            finalDestTo: finalDestTo,
-            amountLD: 100e6,
-            finalAmountLD: 100e6
+            finalDestTo: finalDestTo
         });
 
         bytes32[][] memory manageTree = _generateMerkleTree(leafs);

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -1348,6 +1348,7 @@ contract ChainValues {
         values[mainnet]["USDTOFTAdapter2"] = 0x1F748c76dE468e9D11bd340fA9D5CBADf315dFB0.toBytes32();
         values[mainnet]["SUSDEOFTAdapter"] = 0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2.toBytes32();
         values[mainnet]["wstUSROFTAdapter"] = 0xab17c1fE647c37ceb9b96d1c27DD189bf8451978.toBytes32();
+        values[mainnet]["PYUSDOFTAdapter"] = 0xa2C323fE5A74aDffAd2bf3E007E36bb029606444.toBytes32();
 
         // Stargate OFTs
         values[mainnet]["stargateUSDC"] = 0xc026395860Db2d07ee33e05fE50ed7bD583189C7.toBytes32();
@@ -1869,6 +1870,9 @@ contract ChainValues {
         values[arbitrum]["dolomiteMargin"] = 0x6Bd780E7fDf01D77e4d475c821f1e7AE05409072.toBytes32();
         values[arbitrum]["dolomiteDepositWithdrawRouter"] = 0xAdB9D68c613df4AA363B42161E1282117C7B9594.toBytes32();
         values[arbitrum]["dolomiteBorrowProxy"] = 0x38E49A617305101216eC6306e3a18065D14Bf3a7.toBytes32(); //V2
+
+        // OFT
+        values[arbitrum]["PYUSDOFTAdapter"] = 0x3CD2b89C49D130C08f1d683225b2e5DeB63ff876.toBytes32();
     }
 
     function _addOptimismValues() private {
@@ -2948,6 +2952,7 @@ contract ChainValues {
         values[ink]["LayerZeroEndPoint"] = 0xca29f3A6f966Cb2fc0dE625F8f325c0C46dbE958.toBytes32();
         values[ink]["ZRO"] = address(1).toBytes32();
         values[ink]["usdt0OFTAdapter"] = 0x1cB6De532588fCA4a21B7209DE7C456AF8434A65.toBytes32(); 
+        values[ink]["PYUSDOFTAdapter"] = 0x3CD2b89C49D130C08f1d683225b2e5DeB63ff876.toBytes32();
 
         // Balancer
         values[ink]["balancerVault"] = address(1).toBytes32();

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -8344,6 +8344,60 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex].argumentAddresses[3] = getAddress(sourceChain, "boringVault");
     }
 
+    function _addLayerZeroMultiHopLeafs(
+        ManageLeaf[] memory leafs,
+        ERC20 asset,
+        address oftAdapter,
+        uint32 firstHopEndpoint,
+        bytes32 firstHopTo,
+        uint32 finalDestEndpoint,
+        bytes32 finalDestTo,
+        uint256 amountLD,
+        uint256 finalAmountLD
+    )
+        internal
+    {
+        if (address(asset) != oftAdapter) {
+            unchecked {
+                leafIndex++;
+            }
+            leafs[leafIndex] = ManageLeaf(
+                address(asset),
+                false,
+                "approve(address,uint256)",
+                new address[](1),
+                string.concat("Approve LayerZero to spend ", asset.symbol()),
+                getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+            );
+            leafs[leafIndex].argumentAddresses[0] = oftAdapter;
+        }
+        unchecked {
+            leafIndex++;
+        }
+
+        bytes32 amountBytes = bytes32(amountLD);
+        bytes32 finalAmountBytes = bytes32(finalAmountLD);
+
+        leafs[leafIndex] = ManageLeaf(
+            oftAdapter,
+            true,
+            "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
+            new address[](10),
+            string.concat("Bridge ", asset.symbol(), " to LayerZero MultiHop endpoint: ", vm.toString(firstHopEndpoint)),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = address(uint160((uint256(firstHopEndpoint) << 32) | uint256(finalDestEndpoint)));
+        leafs[leafIndex].argumentAddresses[1] = address(bytes20(bytes16(firstHopTo)));
+        leafs[leafIndex].argumentAddresses[2] = address(bytes20(bytes16(firstHopTo << 128)));
+        leafs[leafIndex].argumentAddresses[3] = address(bytes20(bytes16(finalDestTo)));
+        leafs[leafIndex].argumentAddresses[4] = address(bytes20(bytes16(finalDestTo << 128)));
+        leafs[leafIndex].argumentAddresses[5] = address(bytes20(bytes16(amountBytes)));
+        leafs[leafIndex].argumentAddresses[6] = address(bytes20(bytes16(amountBytes << 128)));
+        leafs[leafIndex].argumentAddresses[7] = address(bytes20(bytes16(finalAmountBytes)));
+        leafs[leafIndex].argumentAddresses[8] = address(bytes20(bytes16(finalAmountBytes << 128)));
+        leafs[leafIndex].argumentAddresses[9] = getAddress(sourceChain, "boringVault");
+    }
+
     function _addLayerZeroLeafNative(ManageLeaf[] memory leafs, address oftAdapter, uint32 endpoint, bytes32 to)
         internal
     {

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -8351,9 +8351,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         uint32 firstHopEndpoint,
         bytes32 firstHopTo,
         uint32 finalDestEndpoint,
-        bytes32 finalDestTo,
-        uint256 amountLD,
-        uint256 finalAmountLD
+        bytes32 finalDestTo
     )
         internal
     {
@@ -8375,14 +8373,11 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
             leafIndex++;
         }
 
-        bytes32 amountBytes = bytes32(amountLD);
-        bytes32 finalAmountBytes = bytes32(finalAmountLD);
-
         leafs[leafIndex] = ManageLeaf(
             oftAdapter,
             true,
             "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)",
-            new address[](10),
+            new address[](6),
             string.concat("Bridge ", asset.symbol(), " to LayerZero MultiHop endpoint: ", vm.toString(firstHopEndpoint)),
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
@@ -8391,11 +8386,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues, Test {
         leafs[leafIndex].argumentAddresses[2] = address(bytes20(bytes16(firstHopTo << 128)));
         leafs[leafIndex].argumentAddresses[3] = address(bytes20(bytes16(finalDestTo)));
         leafs[leafIndex].argumentAddresses[4] = address(bytes20(bytes16(finalDestTo << 128)));
-        leafs[leafIndex].argumentAddresses[5] = address(bytes20(bytes16(amountBytes)));
-        leafs[leafIndex].argumentAddresses[6] = address(bytes20(bytes16(amountBytes << 128)));
-        leafs[leafIndex].argumentAddresses[7] = address(bytes20(bytes16(finalAmountBytes)));
-        leafs[leafIndex].argumentAddresses[8] = address(bytes20(bytes16(finalAmountBytes << 128)));
-        leafs[leafIndex].argumentAddresses[9] = getAddress(sourceChain, "boringVault");
+        leafs[leafIndex].argumentAddresses[5] = getAddress(sourceChain, "boringVault");
     }
 
     function _addLayerZeroLeafNative(ManageLeaf[] memory leafs, address oftAdapter, uint32 endpoint, bytes32 to)


### PR DESCRIPTION
  - Add multi-hop compose message decoding to `OFTDecoderAndSanitizer`, allowing bridging through intermediate chains via LayerZero      
  - Add `_addLayerZeroMultiHopLeafs` helper in `MerkleTreeHelper` for multi-hop leaf construction with 10-address layout (packed endpoint
   IDs, split receiver/amount pairs, refund address)                                                                                     
  - Add PYUSD OFT adapter addresses for mainnet, arbitrum, and ink                                                                       
  - Add integration tests for multi-hop bridging and invalid compose message revert  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates `OFTDecoderAndSanitizer.send` to accept and decode `composeMsg` for multi-hop bridging, changing how sensitive arguments are derived for merkle-verified vault management. Incorrect encoding/decoding or endpoint packing could cause unexpected authorization failures or allow unintended routing if assumptions differ from the on-chain adapter behavior.
> 
> **Overview**
> Adds **LayerZero OFT multi-hop bridging support** by allowing `OFTDecoderAndSanitizer.send` to parse an ABI-encoded `SendParam` from `composeMsg` and include both first-hop and final-destination endpoints/receivers in the sanitized argument payload (while still forbidding non-empty `oftCmd` and nested compose messages).
> 
> Extends test tooling with `_addLayerZeroMultiHopLeafs` (new 6-address argument layout with packed endpoint IDs and split `bytes32` receivers), adds PYUSD OFT adapter addresses for mainnet/arbitrum/ink, and updates integration tests to cover a successful multi-hop PYUSD bridge plus a revert on malformed `composeMsg` (and bumps the mainnet fork block used by the test).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4745d5fbcff91cf92a04cb6aa13bab4ae869aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->