### PR TITLE
Add sGHO staking and GHO GSM decoder with integration tests

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/SGHODecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SGHODecoderAndSanitizer.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
+
+contract SGHODecoderAndSanitizer is BaseDecoderAndSanitizer {
+    //============================== sGHO STAKING ===============================
+
+    function stake(address to, uint256 /*amount*/) external pure virtual returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(to);
+    }
+
+    function redeem(address to, uint256 /*amount*/) external pure virtual returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(to);
+    }
+
+    function cooldown() external pure virtual returns (bytes memory addressesFound) {
+        return addressesFound;
+    }
+
+    //============================== GHO GSM ===============================
+
+    function buyAsset(uint256 /*minAmount*/, address receiver) external pure virtual returns (bytes memory addressesFound) {
+        addressesFound = abi.encodePacked(receiver);
+    }
+
+    function sellAsset(uint256 /*maxAmount*/, address receiver)
+        external
+        pure
+        virtual
+        returns (bytes memory addressesFound)
+    {
+        addressesFound = abi.encodePacked(receiver);
+    }
+}

--- a/test/integrations/SGHOIntegration.t.sol
+++ b/test/integrations/SGHOIntegration.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {SGHODecoderAndSanitizer} from
+    "src/base/DecodersAndSanitizers/Protocols/SGHODecoderAndSanitizer.sol";
+
+interface IGSM {
+    function UNDERLYING_ASSET() external view returns (address);
+}
+
+contract SGHOIntegrationTest is BaseTestIntegration {
+    function _setUpMainnet() internal {
+        super.setUp();
+        _setupChain("mainnet", 24577143);
+        _overrideDecoder(address(new SGHODecoderAndSanitizer()));
+    }
+
+    function testSGHOStakeAndRedeem() external {
+        _setUpMainnet();
+
+        uint256 stakeAmount = 100e18;
+        deal(getAddress(sourceChain, "GHO"), address(boringVault), stakeAmount);
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](4);
+        _addSGHOLeafs(leafs);
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        // Approve + Stake
+        Tx memory tx_ = _getTxArrays(2);
+        tx_.manageLeafs[0] = leafs[0]; // approve
+        tx_.manageLeafs[1] = leafs[1]; // stake
+
+        bytes32[][] memory manageProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);
+
+        tx_.targets[0] = getAddress(sourceChain, "GHO");
+        tx_.targets[1] = getAddress(sourceChain, "stkGHO");
+
+        tx_.targetData[0] =
+            abi.encodeWithSignature("approve(address,uint256)", getAddress(sourceChain, "stkGHO"), type(uint256).max);
+        tx_.targetData[1] = abi.encodeWithSignature("stake(address,uint256)", address(boringVault), stakeAmount);
+
+        tx_.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+        tx_.decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+        _submitManagerCall(manageProofs, tx_);
+
+        uint256 stkGHOBalance = getERC20(sourceChain, "stkGHO").balanceOf(address(boringVault));
+        assertGt(stkGHOBalance, 0, "BoringVault should have stkGHO after staking");
+
+        // Cooldown
+        {
+            Tx memory cooldownTx = _getTxArrays(1);
+            cooldownTx.manageLeafs[0] = leafs[2];
+
+            bytes32[][] memory cooldownProofs = _getProofsUsingTree(cooldownTx.manageLeafs, manageTree);
+
+            cooldownTx.targets[0] = getAddress(sourceChain, "stkGHO");
+            cooldownTx.targetData[0] = abi.encodeWithSignature("cooldown()");
+            cooldownTx.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+
+            _submitManagerCall(cooldownProofs, cooldownTx);
+        }
+
+        // Redeem
+        {
+            Tx memory redeemTx = _getTxArrays(1);
+            redeemTx.manageLeafs[0] = leafs[3];
+
+            bytes32[][] memory redeemProofs = _getProofsUsingTree(redeemTx.manageLeafs, manageTree);
+
+            redeemTx.targets[0] = getAddress(sourceChain, "stkGHO");
+            redeemTx.targetData[0] =
+                abi.encodeWithSignature("redeem(address,uint256)", address(boringVault), stkGHOBalance);
+            redeemTx.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+
+            _submitManagerCall(redeemProofs, redeemTx);
+        }
+
+        uint256 ghoAfterRedeem = getERC20(sourceChain, "GHO").balanceOf(address(boringVault));
+        assertGt(ghoAfterRedeem, 0, "BoringVault should have GHO after redeem");
+    }
+
+    function testGSMBuyAndSell() external {
+        _setUpMainnet();
+
+        address gsmUsdc = getAddress(sourceChain, "gsmUsdc");
+        ERC20 gsmUnderlying = ERC20(IGSM(gsmUsdc).UNDERLYING_ASSET());
+        deal(getAddress(sourceChain, "GHO"), address(boringVault), 1_000e18);
+
+        ManageLeaf[] memory leafs = new ManageLeaf[](4);
+        _addGHOGSMLeafs(leafs, gsmUsdc, gsmUnderlying);
+
+        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
+        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
+
+        // Approve GHO + buyAsset
+        {
+            Tx memory tx_ = _getTxArrays(2);
+            tx_.manageLeafs[0] = leafs[0];
+            tx_.manageLeafs[1] = leafs[2];
+
+            bytes32[][] memory manageProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);
+
+            tx_.targets[0] = getAddress(sourceChain, "GHO");
+            tx_.targets[1] = gsmUsdc;
+
+            tx_.targetData[0] = abi.encodeWithSignature("approve(address,uint256)", gsmUsdc, type(uint256).max);
+            tx_.targetData[1] = abi.encodeWithSignature("buyAsset(uint256,address)", 100e6, address(boringVault));
+
+            tx_.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+            tx_.decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+            _submitManagerCall(manageProofs, tx_);
+        }
+
+        uint256 underlyingBalance = gsmUnderlying.balanceOf(address(boringVault));
+        assertGt(underlyingBalance, 0, "BoringVault should have GSM underlying after buyAsset");
+
+        // Approve underlying + sellAsset
+        {
+            Tx memory tx_ = _getTxArrays(2);
+            tx_.manageLeafs[0] = leafs[1];
+            tx_.manageLeafs[1] = leafs[3];
+
+            bytes32[][] memory sellProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);
+
+            tx_.targets[0] = address(gsmUnderlying);
+            tx_.targets[1] = gsmUsdc;
+
+            tx_.targetData[0] = abi.encodeWithSignature("approve(address,uint256)", gsmUsdc, type(uint256).max);
+            tx_.targetData[1] =
+                abi.encodeWithSignature("sellAsset(uint256,address)", underlyingBalance, address(boringVault));
+
+            tx_.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
+            tx_.decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
+
+            _submitManagerCall(sellProofs, tx_);
+        }
+
+        assertGt(getERC20(sourceChain, "GHO").balanceOf(address(boringVault)), 0, "Should have GHO after sellAsset");
+        assertEq(gsmUnderlying.balanceOf(address(boringVault)), 0, "GSM underlying should be fully sold");
+    }
+}

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -434,6 +434,8 @@ contract ChainValues {
         values[mainnet]["dV3CrvUsd"] = 0x028f7886F3e937f8479efaD64f31B3fE1119857a.toBytes32();
         values[mainnet]["aV3WeETH"] = 0xBdfa7b7893081B35Fb54027489e2Bc7A38275129.toBytes32();
         values[mainnet]["aRLUSD"] = 0xFa82580c16A31D0c1bC632A36F82e83EfEF3Eec0.toBytes32();
+        values[mainnet]["gsmUsdc"] = 0xFeeb6FE430B7523fEF2a38327241eE7153779535.toBytes32();
+        values[mainnet]["gsmUsdt"] = 0x535b2f7C20B9C83d70e519cf9991578eF9816B7B.toBytes32();
 
         // Balancer V2 Addresses
         values[mainnet]["BB_A_USD"] = 0xfeBb0bbf162E64fb9D0dfe186E517d84C395f016.toBytes32();

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -15485,6 +15485,133 @@ function _addTellerLeafsWithReferral(
         }
     }
 
+    // ========================================= sGHO Staking =========================================
+
+    function _addSGHOLeafs(ManageLeaf[] memory leafs) internal {
+        address stkGHO = getAddress(sourceChain, "stkGHO");
+        address gho = getAddress(sourceChain, "GHO");
+        address boringVault_ = getAddress(sourceChain, "boringVault");
+
+        // Approve GHO for stkGHO
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            gho,
+            false,
+            "approve(address,uint256)",
+            new address[](1),
+            "Approve stkGHO to spend GHO",
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = stkGHO;
+
+        // Stake GHO for sGHO
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            stkGHO,
+            false,
+            "stake(address,uint256)",
+            new address[](1),
+            "Stake GHO into stkGHO",
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = boringVault_;
+
+        // Cooldown
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            stkGHO,
+            false,
+            "cooldown()",
+            new address[](0),
+            "Activate stkGHO cooldown",
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+
+        // Redeem sGHO for GHO
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            stkGHO,
+            false,
+            "redeem(address,uint256)",
+            new address[](1),
+            "Redeem stkGHO for GHO",
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = boringVault_;
+    }
+
+    // ========================================= GHO GSM =========================================
+
+    function _addGHOGSMLeafs(ManageLeaf[] memory leafs, address gsm, ERC20 underlying) internal {
+        address gho = getAddress(sourceChain, "GHO");
+        address boringVault_ = getAddress(sourceChain, "boringVault");
+        string memory underlyingSymbol = underlying.symbol();
+
+        // Approve GHO for GSM
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            gho,
+            false,
+            "approve(address,uint256)",
+            new address[](1),
+            "Approve GSM to spend GHO",
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = gsm;
+
+        // Approve underlying for GSM
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            address(underlying),
+            false,
+            "approve(address,uint256)",
+            new address[](1),
+            string.concat("Approve GSM to spend ", underlyingSymbol),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = gsm;
+
+        // buyAsset
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            gsm,
+            false,
+            "buyAsset(uint256,address)",
+            new address[](1),
+            string.concat("Buy ", underlyingSymbol, " from GSM with GHO"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = boringVault_;
+
+        // sellAsset
+        unchecked {
+            leafIndex++;
+        }
+        leafs[leafIndex] = ManageLeaf(
+            gsm,
+            false,
+            "sellAsset(uint256,address)",
+            new address[](1),
+            string.concat("Sell ", underlyingSymbol, " to GSM for GHO"),
+            getAddress(sourceChain, "rawDataDecoderAndSanitizer")
+        );
+        leafs[leafIndex].argumentAddresses[0] = boringVault_;
+    }
+
     function _generateProof(bytes32 leaf, bytes32[][] memory tree) internal pure returns (bytes32[] memory proof) {
         // The length of each proof is the height of the tree - 1.
         uint256 tree_length = tree.length;


### PR DESCRIPTION
  Adds support for sGHO staking (stake, redeem, cooldown) and GHO GSM (buyAsset, sellAsset) operations.                                  
                                                                                                                                         
  - New SGHODecoderAndSanitizer contract for stkGHO and GSM function signatures
  - Integration tests for stake/redeem flow and GSM buy/sell flow
  - MerkleTreeHelper leaf functions: _addSGHOLeafs, _addGHOGSMLeafs
  - ChainValues entries for gsmUsdc and gsmUsdt on mainnet