### PR TITLE
add morpho and rlUSD leaves

### DIFF
--- a/leafs/Mainnet/SentoraStrategistLeafs.json
+++ b/leafs/Mainnet/SentoraStrategistLeafs.json
@@ -10,8 +10,8 @@
       "Bytes4(TARGET_FUNCTION_SELECTOR)",
       "Bytes{N*20}(ADDRESS_ARGUMENT_0,...,ADDRESS_ARGUMENT_N)"
     ],
-    "LeafCount": 34,
-    "ManageRoot": "0x3807b04242740a24774cbf5bac137c8816770b329fad17fa94f6cc7b989dd00d",
+    "LeafCount": 50,
+    "ManageRoot": "0x03a11f7c2411cf69e674e23bedc62dc3a967cf0eb8549b6b9fe4b9745df551d5",
     "ManagerAddress": "0xdd5C7C5206558e4eA66a58592fEaE13424ED6F07",
     "TreeCapacity": 128
   },
@@ -118,6 +118,66 @@
       "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
     },
     {
+      "AddressArguments": [
+        "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap RLUSD for LBTC",
+      "FunctionSelector": "0x3b635ce4",
+      "FunctionSignature": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
+      "LeafDigest": "0xa0fbd2df87d4a174e9bf8ab4e96bdd60187e96930093552ce1e213adf9adb2e7",
+      "PackedArgumentAddresses": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed8236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap Compact RLUSD for LBTC",
+      "FunctionSelector": "0x83bd37f9",
+      "FunctionSignature": "swapCompact()",
+      "LeafDigest": "0x685e85ccdab2e7b39109503dbf4211a0203d4bac56cf525f28967fd160259846",
+      "PackedArgumentAddresses": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed8236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap MORPHO for LBTC",
+      "FunctionSelector": "0x3b635ce4",
+      "FunctionSignature": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
+      "LeafDigest": "0xa3723c326ca726bcbcd30f6a56ed7d5d158cd66599e5f074b3626ce277686f14",
+      "PackedArgumentAddresses": "0x58d97b57bb95320f9a05dc918aef65434969c2b28236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap Compact MORPHO for LBTC",
+      "FunctionSelector": "0x83bd37f9",
+      "FunctionSignature": "swapCompact()",
+      "LeafDigest": "0xb03da4c5741c8719bfbfd96b69611328c770124f486a26504b14972aefa642f0",
+      "PackedArgumentAddresses": "0x58d97b57bb95320f9a05dc918aef65434969c2b28236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
       "AddressArguments": ["0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
@@ -159,6 +219,66 @@
       "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
     },
     {
+      "AddressArguments": [
+        "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap RLUSD for WBTC",
+      "FunctionSelector": "0x3b635ce4",
+      "FunctionSignature": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
+      "LeafDigest": "0x4612ef202b3e7541548bcd284d6a55dd9f4209bc0dee354ed2a536f50778d485",
+      "PackedArgumentAddresses": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed2260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap Compact RLUSD for WBTC",
+      "FunctionSelector": "0x83bd37f9",
+      "FunctionSignature": "swapCompact()",
+      "LeafDigest": "0xd75677f708772e77d559146679a987e336b87dbf5b3b1a8aef1573b7a01c6fc4",
+      "PackedArgumentAddresses": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed2260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap MORPHO for WBTC",
+      "FunctionSelector": "0x3b635ce4",
+      "FunctionSignature": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
+      "LeafDigest": "0x50ce55a8dfc68d8e2ff7ed72d6ecaf5b07d1f04ebaea0ace9bd151bdd8dcbcc3",
+      "PackedArgumentAddresses": "0x58d97b57bb95320f9a05dc918aef65434969c2b22260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
+      "AddressArguments": [
+        "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Swap Compact MORPHO for WBTC",
+      "FunctionSelector": "0x83bd37f9",
+      "FunctionSignature": "swapCompact()",
+      "LeafDigest": "0x9c3f2ec91a67a75a297129d58cade3a7970f64a824daee49f9aab0f7fd712bf0",
+      "PackedArgumentAddresses": "0x58d97b57bb95320f9a05dc918aef65434969c2b22260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"
+    },
+    {
       "AddressArguments": ["0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
@@ -168,6 +288,28 @@
       "LeafDigest": "0x05a149c7c82498728c25cb346a77528e308e14ed1deef657de2023657329fa17",
       "PackedArgumentAddresses": "0xcf5540fffcdc3d510b18bfca6d2b9987b0772559",
       "TargetAddress": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    },
+    {
+      "AddressArguments": ["0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Approve Odos Router V2 to spend RLUSD",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0xe2f2727150d3271ae402a7a7179009a7ad2b4c3aa657a21839f2f286d01a4225",
+      "PackedArgumentAddresses": "0xcf5540fffcdc3d510b18bfca6d2b9987b0772559",
+      "TargetAddress": "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD"
+    },
+    {
+      "AddressArguments": ["0xCf5540fFFCdC3d510B18bFcA6d2b9987b0772559"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x6149c711434C54A48D757078EfbE0E2B2FE2cF6a",
+      "Description": "Approve Odos Router V2 to spend MORPHO",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0xa2c6f4b338b72b15bfdb1e020778950b3480d45dda67cba6928d78289a49a372",
+      "PackedArgumentAddresses": "0xcf5540fffcdc3d510b18bfca6d2b9987b0772559",
+      "TargetAddress": "0x58D97B57BB95320F9a05dC918Aef65434969c2B2"
     },
     {
       "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
@@ -226,6 +368,36 @@
       "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
     },
     {
+      "AddressArguments": [
+        "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Swap RLUSD for LBTC using 1inch router",
+      "FunctionSelector": "0x12aa3caf",
+      "FunctionSignature": "swap(address,(address,address,address,address,uint256,uint256,uint256),bytes,bytes)",
+      "LeafDigest": "0xbf807da750658f5ed561610bf84367c0599bf5f7eb2806a34aa0dbdf21aeb3e7",
+      "PackedArgumentAddresses": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed8236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
+    },
+    {
+      "AddressArguments": [
+        "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+        "0x8236a87084f8B84306f72007F36F2618A5634494",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Swap MORPHO for LBTC using 1inch router",
+      "FunctionSelector": "0x12aa3caf",
+      "FunctionSignature": "swap(address,(address,address,address,address,uint256,uint256,uint256),bytes,bytes)",
+      "LeafDigest": "0xf8b0500f75ae9c41eda324d10da51df83bb30b76f0051890d5259985a751d899",
+      "PackedArgumentAddresses": "0x58d97b57bb95320f9a05dc918aef65434969c2b28236a87084f8b84306f72007f36f2618a563449413cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
+    },
+    {
       "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
@@ -252,6 +424,36 @@
       "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
     },
     {
+      "AddressArguments": [
+        "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Swap RLUSD for WBTC using 1inch router",
+      "FunctionSelector": "0x12aa3caf",
+      "FunctionSignature": "swap(address,(address,address,address,address,uint256,uint256,uint256),bytes,bytes)",
+      "LeafDigest": "0xc117fa6e3971bbb7ba63ef951bde2f6b784e3c61ed072cb34f4cc9816fabaa96",
+      "PackedArgumentAddresses": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed2260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
+    },
+    {
+      "AddressArguments": [
+        "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+        "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "0x13Cc1b39cb259BA10cd174EAe42012e698ed7c51"
+      ],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Swap MORPHO for WBTC using 1inch router",
+      "FunctionSelector": "0x12aa3caf",
+      "FunctionSignature": "swap(address,(address,address,address,address,uint256,uint256,uint256),bytes,bytes)",
+      "LeafDigest": "0xb6ebe21166717a5304c4c0d146fa47c015f09951ce37549b06f60a30d381c5d3",
+      "PackedArgumentAddresses": "0x58d97b57bb95320f9a05dc918aef65434969c2b22260fac5e5542a773aa44fbcfedf7c193bc2c59913cc1b39cb259ba10cd174eae42012e698ed7c51",
+      "TargetAddress": "0x1111111254EEB25477B68fb85Ed929f73A960582"
+    },
+    {
       "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
       "CanSendValue": false,
       "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
@@ -261,6 +463,28 @@
       "LeafDigest": "0x7c0aea73befb71ee0dbc74b3c3bea5445d92b8a630aaad8fa0747bc94d688eae",
       "PackedArgumentAddresses": "0x1111111254eeb25477b68fb85ed929f73a960582",
       "TargetAddress": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8"
+    },
+    {
+      "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Approve 1Inch router to spend RLUSD",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0xd380a591b93ee635242f1a4427d2d76f0d531c170fea9ec717890e257dc99eb4",
+      "PackedArgumentAddresses": "0x1111111254eeb25477b68fb85ed929f73a960582",
+      "TargetAddress": "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD"
+    },
+    {
+      "AddressArguments": ["0x1111111254EEB25477B68fb85Ed929f73A960582"],
+      "CanSendValue": false,
+      "DecoderAndSanitizerAddress": "0x42842201E199E6328ADBB98e7C2CbE77561FAC88",
+      "Description": "Approve 1Inch router to spend MORPHO",
+      "FunctionSelector": "0x095ea7b3",
+      "FunctionSignature": "approve(address,uint256)",
+      "LeafDigest": "0x2c053877b6e85b940b004e12eca16e13aaaa5042be09c00957db92b6cbe6770c",
+      "PackedArgumentAddresses": "0x1111111254eeb25477b68fb85ed929f73a960582",
+      "TargetAddress": "0x58D97B57BB95320F9a05dC918Aef65434969c2B2"
     },
     {
       "AddressArguments": [],
@@ -1295,214 +1519,38 @@
       "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "PackedArgumentAddresses": "0x",
       "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
-    },
-    {
-      "AddressArguments": [],
-      "CanSendValue": false,
-      "DecoderAndSanitizerAddress": "0x0000000000000000000000000000000000000000",
-      "Description": "",
-      "FunctionSelector": "0xc5d24601",
-      "FunctionSignature": "",
-      "LeafDigest": "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "PackedArgumentAddresses": "0x",
-      "TargetAddress": "0x0000000000000000000000000000000000000000"
     }
   ],
   "MerkleTree": {
-    "0": ["0x3807b04242740a24774cbf5bac137c8816770b329fad17fa94f6cc7b989dd00d"],
+    "0": ["0x03a11f7c2411cf69e674e23bedc62dc3a967cf0eb8549b6b9fe4b9745df551d5"],
     "1": [
-      "0x5a5eb545bcd2330a70ed3854d216da91a33010c9609a16b98f41ce71d5062448",
+      "0x7126866725a188b33b022f2f1ddf6ee8dc93f890ed81def89d22ee1eb3a2d922",
       "0xf70e6eeacf0ca2800bee387294f368bb304fe5f55d96f86ff896d1bcbe16ba34"
     ],
     "2": [
-      "0xa7a589cf6720172c5219eb75d76fb2c75ddbb9075803d772e6c25dcccc5a5ea6",
-      "0xeffdf45bff41322861c5ea792ed52ddc5cbe3905d7ca832d60f099020a08cf1d",
+      "0xebfd9806188c9eb9be143b8268ca09d5a97359848308feb022ff63def51b92fc",
+      "0x88d378ddbb32194dd7d15f7e664402690dfd897acf8583971f61d7f4e3002e7f",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a",
       "0xec36dbe395dc9c97e82d5ef9325fb13a264faf4bc614c184837bb3dfc0c6a31a"
     ],
     "3": [
-      "0xe9fc9a77172d0f854ca8ab383ca8c245679963134d78286b2e4b0ae1e9e2fae2",
-      "0x9152c4ddc09c0570c642126489920e9ade86bcf43584ec3de211e4bc7c22c1d5",
+      "0xedcea8baf9705d44fa8a6e1089c26ad6ef28962689c0128db911774c86f69ad5",
+      "0xa34742769d01f3e6743a4ffe29b1923dfc74f788a994c94fb78c8fae08347137",
+      "0x5cc35955a0caf8a8035866fcb72368566a4313893ebe4c481284c0b93170a9c8",
       "0x006cfb3d4ebc0799028cac46e36acc71f5f65c15905e248ddcd1233cd6881a1f",
-      "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c",
       "0xc8e2d8c65f68c2edf703a349b0189c66520f43472e76097f69a501107adf656c"
     ],
     "4": [
-      "0xb17f633d9c88d0362cba06d8856adc09d837bf4180ab31b8aec076336800993d",
-      "0xc039373764b7fe28b269e3ef244bed1ce295d5dd1737eb32873ccbd41bf73900",
-      "0xeae1c96c99d4b4d2198e74dc2123a9de3032b9bb982d5c64e7301faf8e036e34",
+      "0x98bf9401b070ca1a0fffe50ccaed603607aeedf02476035cd6d7ecb0a4e88346",
+      "0x69b1bde077ece74305192cdada952b98e577555fb3150fa3d8cffd462cf665d7",
+      "0xf18725a8d06af75101e7575c399813cd34cbbf7277578fec31bf405c639c1d4e",
+      "0x418af71fb4433fc49e8ba278849e66e22bb091d92bae7622af373d9ac218bd6f",
+      "0x81ffbb104f64c5b1bfa3470ecca557dcf1b650e6c1888d08c39fa9b50b31c17e",
       "0x4b02436ffbf180acaa9c24435383bd51802d80fde2a70f0ea5d8a17a848439c8",
       "0xa578255e1fa8e917f48c12e157a18131cd1dfc0726f7d34cd04a04342a02c686",
-      "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
-      "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
       "0x41fbd3a0cfdfcee05cf3eb16d95ed1c81f50c3c6268bb806b406ec06ee93e704",
@@ -1515,18 +1563,18 @@
     ],
     "5": [
       "0x1f98f067a9b0ab58af72fc1304b0b610f6ce85a3a40dc798e0fa978ca8f18353",
-      "0xc001044a9a9166b9246e9829c8ca5548608a1eac13814acf8fffc41c6a38a14f",
-      "0x37c0484117198bbac0ecff57945c4bc0205f4cba3e92c37455aa87006d6b58c7",
-      "0x6f2d2138a698d7b71b96da207f6710b7fbf8e5870924c9b95ba7e07aba8a0031",
-      "0x118fb1408018dc403275c31938fca33ce19241157541d560aa747773eef4c1c5",
+      "0x1e7ce6cbf39c16ba767aa7c1579b735969656a36035a8e78510d78d0e9c53156",
+      "0x0784c7e5b25264304ce3c96ad30ffa48c12508fb9a24b61975b76fd789515e5c",
+      "0x38b2685cf46e2ed127caf057a301bbebf291f312b9c258e890f55b63c249e6d3",
+      "0x36f74440bbca699add69b1879c5bd6400eb37826573438ac6321694a7e5a5228",
+      "0x20825312907c9369a6eeae0fc08b0e8c2f1e8ba333cf37248699ee6bf2647dd9",
+      "0x9b5d4f5bf62006e0f3d50d367828a82ffde47eb2116c3e6f72f88526b34f80f3",
+      "0xd410ae6b7df798566d1004dd5c1d4a878bcb68eb9cd49ea70e9484f291946a28",
+      "0x229637f1247b5eac08e457aa7cea3c6cd9086eda35d86cb4356bc9c8e784205b",
       "0xa15dfe14d521d3d42b836d5e094e309b09391668acf3a76b0f3edd6ed8acebe8",
       "0x7a72a22f97ca8df0529fbd7124603fd0717d1a3c1c974902d798ede34d5accf9",
       "0x30121ee17b77a216e574dff9921bc6e0c7bd50bb7da29c46f115ce6d57273de0",
       "0x665a327f9e9ed5bb79641b3067900a93001810a4cc9c950901e229a32a0594e5",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
-      "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
       "0x849eda7a295b642e5ddaf49a30eec4470cf507efa83b4104c0752d069c7638fe",
@@ -1551,12 +1599,20 @@
       "0x6e9ccf97fcf3442dbfc0461333c5913584d0401dfba00650f23eed06243a2206",
       "0xc5fe156adc2edb76a89e6b4c4f9cb17c2895397ac5f4758077088d1fe70c731d",
       "0x332411b8566e79f001ac681684586e2d7896534c85fd24fe5df77c48826e6deb",
-      "0xa08c39b3dc31376d584b7c307d908a6b9c21f35c0b8a8699d8ffe950cc047a4a",
+      "0xcc66edb327f0a4b466eccfe6d1fc5f13c894d3a1f1f40d84118e3f617f6a07b6",
+      "0x2185e7804e1d9f56a90cf7341e019138fdd1ccfa0523b27f2f42493177193fa2",
+      "0xef52745c6b3c5de5fb0fd43a824a7f996299d7e90d4bb2e671296702ad0d082c",
       "0xe606a6ba7fe062dd57a74e9d479dedd788a0c556b0d4c5a35ae757b26c2cc429",
-      "0x7b4dc5102fe2e7c8a55396a6d26799032072134298e1f17b5ab868fa9dade355",
+      "0xfc233a401b921a4a059b2f800d3b48c76c781b3c71210a5be277d2321ae7f669",
+      "0xc5fe3681a4a7ac7faf8b5f54641d08ac8b2e97a5cfb6c11b3f9ad4563455e410",
+      "0x11db5d0e6b3fcd382b7316e6e85b1c178c8fff906d2bb652f2234f4f0f1b7a40",
+      "0x3175dd3338f9b258075283267f62fc8e07ddef18214408c6702eebff9e86ed09",
       "0xf2b23d854335267f510fb52433ca8d05fd6edd4283e78e9e3c65e0b91358d170",
-      "0xdad39f386b2f7edf3e11ca9c6a960c3db22a96eb2aa9baffc7748237027250e9",
-      "0x381b042f411a569aef2efe3ed2a853ea8709f389a47e4fa4e9f9390187f76458",
+      "0xe280ded01dbb819ef21e97d2739b524e71696abb86504123c2bd52cf1868c2c6",
+      "0xa456eee39865abd84cbb19ddf757f04588a97378cabaff97a125772f80a801c0",
+      "0x23653120f3ea7541c8d6c1c1f9f736f988b7dd2a7bd06b041111854190967e68",
+      "0x8e74b48afc2da62dd34d912c5058b164da1f748e4322e1bfda6fdaef86812c27",
+      "0xd577330e9d587807aa30f30525e1d982ad72a534872ed0e151e73ca22e3ac8d9",
       "0xa7d359786df8e5f47c1b0314fd3244bcce5a242e49d461ba6c3778b0a986c31c",
       "0xfaf1f673f67847aa4d5c966b166678d2ea2fcc5e42fb13f64d04a1a50214d578",
       "0xc38d3883f898cd041d565572a721e8c795205fd498a4fce6dcb7b5a45b6841b5",
@@ -1565,14 +1621,6 @@
       "0x34384f1f6f0b6dd9c9a4d5920af7e87c720b9fab92647331f322acc6b9b76679",
       "0xa711c25cc97722e177120fefc495273b29871de8b0deb8b19ec0bd1b633ee304",
       "0x13de0c6a522e399977b81cea950362359b46a2cc9db14a36e15e90421e9bacfa",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
-      "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
       "0xc5a36f3b7b955966d5ed3135dcc612f978306d73bce3697e230afae57fbaeeba",
@@ -1621,17 +1669,33 @@
       "0x885283e3174aa3dd11893db9d24ddd803c8f53452c72d4c07dd37d2108ff4497",
       "0x4e0dacf1dfeddbf75463ffb6f66cd5d26da0408c755782837fd339b6de892a72",
       "0x41a348fd9d70a1b1109e84a9fb4a42d1abfb1c3ac6321eb528341aa7f280ef7f",
+      "0xa0fbd2df87d4a174e9bf8ab4e96bdd60187e96930093552ce1e213adf9adb2e7",
+      "0x685e85ccdab2e7b39109503dbf4211a0203d4bac56cf525f28967fd160259846",
+      "0xa3723c326ca726bcbcd30f6a56ed7d5d158cd66599e5f074b3626ce277686f14",
+      "0xb03da4c5741c8719bfbfd96b69611328c770124f486a26504b14972aefa642f0",
       "0xd3cac52bd91b0a78c48dd93a53b892fa1f4235118a2797e99f105a654ce60a62",
       "0x4d3d1fcd6b6f8a259ffdc5f9ecae29a92f1f2c8fbcf2d381e079ad9ad2bb85a5",
       "0x7e536cb4b0db880d2a0418a2c147f76f3306c9ae920cb997c6dfd6956cd418c0",
+      "0x4612ef202b3e7541548bcd284d6a55dd9f4209bc0dee354ed2a536f50778d485",
+      "0xd75677f708772e77d559146679a987e336b87dbf5b3b1a8aef1573b7a01c6fc4",
+      "0x50ce55a8dfc68d8e2ff7ed72d6ecaf5b07d1f04ebaea0ace9bd151bdd8dcbcc3",
+      "0x9c3f2ec91a67a75a297129d58cade3a7970f64a824daee49f9aab0f7fd712bf0",
       "0x05a149c7c82498728c25cb346a77528e308e14ed1deef657de2023657329fa17",
+      "0xe2f2727150d3271ae402a7a7179009a7ad2b4c3aa657a21839f2f286d01a4225",
+      "0xa2c6f4b338b72b15bfdb1e020778950b3480d45dda67cba6928d78289a49a372",
       "0x2ea62230d9eba8ddf71acbabf025eaa1bf25f1750a185821eeb897897cfd6fca",
       "0xf2517b40128880acda543e6b78735530abbcad569fecb2aa0e7d603e5db01151",
       "0xdb54f5303f82e56990069bb581d55390902d7e2d589f8e5a822d22dbbae756da",
       "0xc7da98e67754352cd995df4cb545832aca6bb42c91f8fd40545f52fba27d35dd",
+      "0xbf807da750658f5ed561610bf84367c0599bf5f7eb2806a34aa0dbdf21aeb3e7",
+      "0xf8b0500f75ae9c41eda324d10da51df83bb30b76f0051890d5259985a751d899",
       "0xe6977e1a74c5c253d9c3e5a98fa0276769c13d2e7a9c42019895b1fe7ff2f14f",
       "0x444c93cc817c6044cad636b83806b9c35958399911cf676208c2adbe7df8a643",
+      "0xc117fa6e3971bbb7ba63ef951bde2f6b784e3c61ed072cb34f4cc9816fabaa96",
+      "0xb6ebe21166717a5304c4c0d146fa47c015f09951ce37549b06f60a30d381c5d3",
       "0x7c0aea73befb71ee0dbc74b3c3bea5445d92b8a630aaad8fa0747bc94d688eae",
+      "0xd380a591b93ee635242f1a4427d2d76f0d531c170fea9ec717890e257dc99eb4",
+      "0x2c053877b6e85b940b004e12eca16e13aaaa5042be09c00957db92b6cbe6770c",
       "0x6e4ada845ed8d018899ee186b34755b0335a36523d97937532864d704111f7df",
       "0x1bbf2b2fa391eb0d935775bc94a8257086f37ac519e598bed48deb1021e3f4f9",
       "0xf0df85ca55d1beb5c9bf9e66ee38e40929367711be2955a4dbd261c92b88025b",
@@ -1648,22 +1712,6 @@
       "0x0dd990d88c89013c828ff2c281ddf12436483bd54b293351d61dd7264c7e2407",
       "0x1561960d02e9123cb740d2d61ffc00e72f27a9ae6b64e7f90b71da549ab85217",
       "0x065d73b9c51c9ed40c142f531fa6d8b875196f355aa40b45cad1ee8a19efbb04",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
-      "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",
       "0xa7a0fd846665d92e66be6155c6221b3acd7145ca7c4e4b67a594e4c516969400",

--- a/script/MerkleRootCreation/Mainnet/CreateSentoraMerkleRoot.s.sol
+++ b/script/MerkleRootCreation/Mainnet/CreateSentoraMerkleRoot.s.sol
@@ -44,14 +44,18 @@ contract CreateSentoraMerkleRootScript is Script, MerkleTreeHelper {
         ManageLeaf[] memory leafs = new ManageLeaf[](128);
 
         // ========================== Odos/1inch ==========================
-        address[] memory assets = new address[](3);
+        address[] memory assets = new address[](5);
         assets[0] = getAddress(sourceChain, "LBTC");
         assets[1] = getAddress(sourceChain, "WBTC");
         assets[2] = getAddress(sourceChain, "PYUSD");
-        SwapKind[] memory kind = new SwapKind[](3);
+        assets[3] = getAddress(sourceChain, "RLUSD");
+        assets[4] = getAddress(sourceChain, "MORPHO");
+        SwapKind[] memory kind = new SwapKind[](5);
         kind[0] = SwapKind.BuyAndSell;
         kind[1] = SwapKind.BuyAndSell;
         kind[2] = SwapKind.Sell;
+        kind[3] = SwapKind.Sell;
+        kind[4] = SwapKind.Sell;
         setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", odosOwnedDecoderAndSanitizer);
         _addOdosOwnedSwapLeafs(leafs, assets, kind);
         setAddress(true, sourceChain, "rawDataDecoderAndSanitizer", oneInchOwnedDecoderAndSanitizer);
@@ -62,13 +66,13 @@ contract CreateSentoraMerkleRootScript is Script, MerkleTreeHelper {
         ERC20[] memory itbTokensUsed = new ERC20[](1);
         itbTokensUsed[0] = getERC20(sourceChain, "LBTC");
         address itbPositionManager = 0x701D7Fc25577602dc77280108a8cef0B72b8F8A7;
-        _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > USDC > RLUSD Supervised Loan");
+        _addLeafsForITBPositionManagerLocal(leafs, itbPositionManager, itbTokensUsed, "LBTC > USDC > RLUSD Supervised Loan");
         itbPositionManager = 0x9B6a57Fda106eff13ffE4ea4Ef2783C547f75cd7;
-        _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > RLUSD > RLUSD Supervised Loan");
+        _addLeafsForITBPositionManagerLocal(leafs, itbPositionManager, itbTokensUsed, "LBTC > RLUSD > RLUSD Supervised Loan");
         itbPositionManager = 0x284D3b0eF51F0A6432948A9cCbCb5cAF30d6EE96;
-        _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > PYUSD > RLUSD Supervised Loan");
+        _addLeafsForITBPositionManagerLocal(leafs, itbPositionManager, itbTokensUsed, "LBTC > PYUSD > RLUSD Supervised Loan");
         itbPositionManager = 0xB4201A579A2cf1d321f04d98bdba2a25bEFD6b0A;
-        _addLeafsForITBPositionManager(leafs, itbPositionManager, itbTokensUsed, "LBTC > PYUSD Supervised Loan");
+        _addLeafsForITBPositionManagerLocal(leafs, itbPositionManager, itbTokensUsed, "LBTC > PYUSD Supervised Loan");
 
         // ========================== Verify ==========================
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);
@@ -80,7 +84,7 @@ contract CreateSentoraMerkleRootScript is Script, MerkleTreeHelper {
         _generateLeafs(filePath, leafs, manageTree[manageTree.length - 1][0], manageTree);
      }
  
-     function _addLeafsForITBPositionManager(
+     function _addLeafsForITBPositionManagerLocal(
          ManageLeaf[] memory leafs,
          address itbPositionManager,
          ERC20[] memory tokensUsed,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it expands the strategist’s permitted token approvals and swap actions (RLUSD/MORPHO) and updates the on-chain authorization Merkle root; a mistake could broaden spend/swap permissions for vault funds.
> 
> **Overview**
> **Expands the Sentora strategist Merkle allowlist** to support `RLUSD` and `MORPHO` alongside `LBTC/WBTC/PYUSD`, adding new approve + swap leaves (including compact swap variants) for both Odos-owned and 1inch-owned swapping flows.
> 
> Regenerates `leafs/Mainnet/SentoraStrategistLeafs.json` (LeafCount `34 → 50`) with a new `ManageRoot` and updated Merkle tree values, and updates the root-generation script to include the two new assets and switch ITB position-manager leaf generation to `_addLeafsForITBPositionManagerLocal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcdab165ddde0ed8ff39bbceffd725b432093ce4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->