### PR TITLE
Add Certora formal verification suite

### DIFF
--- a/.github/workflows/certoraA.yml
+++ b/.github/workflows/certoraA.yml
@@ -1,0 +1,46 @@
+name: Certora_FV_A
+
+on:
+  - pull_request
+
+env:
+  FOUNDRY_PROFILE: ci
+  CONFIGS: |
+    certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/rentrancy_view.spec" --prover_args "-enableStorageSplitting false"
+    certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/teller_basic.spec"
+    certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/teller_accounting_easyRules.spec"
+    certora/confs/accountantWithRateProviders.conf
+    certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/teller_integrity.spec"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: yarn install
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Certora munge
+        run: certora/scripts/setup.sh A
+
+      - name: run configs
+        uses: Certora/certora-run-action@v2
+        with:
+          configurations: ${{ env.CONFIGS }}
+          solc-versions: 0.8.21
+          solc-remove-version-prefix: "0."
+          job-name: "Verified Rules"
+          certora-key: ${{ secrets.CERTORAKEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/certoraB.yml
+++ b/.github/workflows/certoraB.yml
@@ -1,0 +1,45 @@
+name: Certora_FV_B
+
+on:
+  - pull_request
+
+env:
+  FOUNDRY_PROFILE: ci
+  CONFIGS: |
+    certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/rentrancy_view.spec" --prover_args "-enableStorageSplitting false"
+    certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/teller_basic.spec"
+    certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/teller_accounting_easyRules.spec"
+    certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/teller_integrity.spec"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: yarn install
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Certora munge
+        run: certora/scripts/setup.sh B
+
+      - name: run configs
+        uses: Certora/certora-run-action@v2
+        with:
+          configurations: ${{ env.CONFIGS }}
+          solc-versions: 0.8.21
+          solc-remove-version-prefix: "0."
+          job-name: "Verified Rules"
+          certora-key: ${{ secrets.CERTORAKEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/certoraC.yml
+++ b/.github/workflows/certoraC.yml
@@ -1,0 +1,54 @@
+name: Certora_FV_C
+
+on:
+  - pull_request
+
+env:
+  FOUNDRY_PROFILE: ci
+  CONFIGS: |
+    certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/rentrancy_view.spec" --prover_args "-enableStorageSplitting false" --rule_sanity none
+    certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/teller_basic.spec" --exclude_rule dustFavorsTheHouse
+    certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/teller_accounting_easyRules.spec" --exclude_rule conversionWeakIntegrity_assets --exclude_rule conversionWeakIntegrity_shares --exclude_rule conversionWeakMonotonicity_assets --exclude_rule conversionWeakMonotonicity_shares
+    certora/confs/accountantWithYieldStreaming.conf
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule assetsMoreThanShares
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule sharePriceMoreThanOneAsset
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule sharePriceBoundedUpper
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule sharePriceBoundedLower
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule totalAssetsCovered
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule vaultSolvency_1Asset
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule virtualPriceIsCorrect
+    certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --rule accountantDecimalsCorrect --rule cumulativeSupplyBounded --rule exchangeRateLEqlastSharePrice --rule exchangeRateLEhighwaterMark_unlessPaused --rule exchangeRateEqlastSharePrice --rule integrityOfVestYield --rule lastVestingUpdateNeverDecreases
+    certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/teller_integrity.spec"
+    
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: yarn install
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Certora munge
+        run: certora/scripts/setup.sh C
+
+      - name: run configs
+        uses: Certora/certora-run-action@v2
+        with:
+          configurations: ${{ env.CONFIGS }}
+          solc-versions: 0.8.21
+          solc-remove-version-prefix: "0."
+          job-name: "Verified Rules"
+          certora-key: ${{ secrets.CERTORAKEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/certoraD.yml
+++ b/.github/workflows/certoraD.yml
@@ -1,0 +1,45 @@
+name: Certora_FV_D
+
+on:
+  - pull_request
+
+env:
+  FOUNDRY_PROFILE: ci
+  CONFIGS: |
+    certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/rentrancy_view.spec" --prover_args "-enableStorageSplitting false"
+    certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/teller_basic.spec"
+    certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/teller_accounting_easyRules.spec"
+    certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/teller_integrity.spec"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: yarn install
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Certora munge
+        run: certora/scripts/setup.sh D
+
+      - name: run configs
+        uses: Certora/certora-run-action@v2
+        with:
+          configurations: ${{ env.CONFIGS }}
+          solc-versions: 0.8.21
+          solc-remove-version-prefix: "0."
+          job-name: "Verified Rules"
+          certora-key: ${{ secrets.CERTORAKEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/certoraE.yml
+++ b/.github/workflows/certoraE.yml
@@ -1,0 +1,45 @@
+name: Certora_FV_E
+
+on:
+  - pull_request
+
+env:
+  FOUNDRY_PROFILE: ci
+  CONFIGS: |
+    certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/rentrancy_view.spec" --prover_args "-enableStorageSplitting false"
+    certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/teller_basic.spec"
+    certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/teller_accounting_easyRules.spec"
+    certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/teller_integrity.spec"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: yarn install
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Certora munge
+        run: certora/scripts/setup.sh E
+
+      - name: run configs
+        uses: Certora/certora-run-action@v2
+        with:
+          configurations: ${{ env.CONFIGS }}
+          solc-versions: 0.8.21
+          solc-remove-version-prefix: "0."
+          job-name: "Verified Rules"
+          certora-key: ${{ secrets.CERTORAKEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ flatten.sol
 tools/*
 
 test/limitOrders/*
+
+
+# certora
+.certora_internal/
+.properties-*/
+emv-*-certora-*/
+

--- a/certora/confs/accountantWithRateProviders.conf
+++ b/certora/confs/accountantWithRateProviders.conf
@@ -1,0 +1,60 @@
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/AccountantWithRateProviders.sol",
+        "src/base/Roles/TellerWithMultiAssetSupport.sol",
+        "src/base/BoringVault.sol",
+        "src/helper/GenericRateProviderWithDecimalScaling.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        //"certora/mocks/BeforeTransferHookMock.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithRateProviders:vault=BoringVault",
+        "TellerWithMultiAssetSupport:accountant=AccountantWithRateProviders",
+        "TellerWithMultiAssetSupport:nativeWrapper=WETH",
+        "TellerWithMultiAssetSupport:vault=BoringVault",
+        //"BoringVault:hook=BeforeTransferHookMock",
+        "BoringVault:hook=TellerWithMultiAssetSupport",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        //"@ds-test=lib/forge-std/lib/ds-test/src",
+        //"ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src"
+    ],
+    "parametric_contracts": [
+        "AccountantWithRateProviders", 
+        //"BoringVault", 
+        //"TellerWithMultiAssetSupport",
+        //"ERC20Mock"
+    ],
+    "process": "emv",
+    "prover_args": [
+    ],
+    "server": "production",
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+    "msg": "accountant_base",
+    "verify": "AccountantWithRateProviders:certora/specs/accountant_basic.spec",
+    "exclude_rule": [ 
+        //"exchangeRateLEhighwaterMark_unlessPaused",
+        //"feesCanOnlyDecreaseViaClaimFees",
+        //"highwaterMarkNeverDecreases",
+        //"lastUpdateTimestampNeverDecreases",
+    ],
+
+
+
+
+}

--- a/certora/confs/accountantWithYieldStreaming.conf
+++ b/certora/confs/accountantWithYieldStreaming.conf
@@ -1,0 +1,61 @@
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/AccountantWithYieldStreaming.sol",
+        "src/base/Roles/TellerWithYieldStreaming.sol",
+        "src/base/BoringVault.sol",
+        "src/helper/GenericRateProviderWithDecimalScaling.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        //"certora/mocks/BeforeTransferHookMock.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithYieldStreaming:vault=BoringVault",
+        "TellerWithYieldStreaming:accountant=AccountantWithYieldStreaming",
+        "TellerWithYieldStreaming:nativeWrapper=WETH",
+        "TellerWithYieldStreaming:vault=BoringVault",
+        //"BoringVault:hook=BeforeTransferHookMock",
+        "BoringVault:hook=TellerWithYieldStreaming",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        //"@ds-test=lib/forge-std/lib/ds-test/src",
+        //"ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src"
+    ],
+    "parametric_contracts": [
+        //"AccountantWithYieldStreaming", 
+        //"BoringVault", 
+        "TellerWithYieldStreaming",
+        //"ERC20Mock"
+    ],
+    "rule_sanity": "none",
+    "process": "emv",
+    "prover_args": [
+    ],
+    "server": "production",
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+    "msg": "accountant_base",
+    "verify": "AccountantWithYieldStreaming:certora/specs/accountant_basic.spec",
+    "exclude_rule": [ 
+        //"exchangeRateLEhighwaterMark_unlessPaused",
+        //"feesCanOnlyDecreaseViaClaimFees",
+        //"highwaterMarkNeverDecreases",
+        //"lastUpdateTimestampNeverDecreases",
+    ],
+
+
+
+
+}

--- a/certora/confs/scenarioA.conf
+++ b/certora/confs/scenarioA.conf
@@ -1,0 +1,57 @@
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/AccountantWithRateProviders.sol",
+        "src/base/Roles/TellerWithMultiAssetSupport.sol",
+        "src/base/BoringVault.sol",
+        "src/helper/GenericRateProviderWithDecimalScaling.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        //"certora/mocks/BeforeTransferHookMock.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithRateProviders:vault=BoringVault",
+        "TellerWithMultiAssetSupport:accountant=AccountantWithRateProviders",
+        "TellerWithMultiAssetSupport:nativeWrapper=WETH",
+        "TellerWithMultiAssetSupport:vault=BoringVault",
+        //"BoringVault:hook=BeforeTransferHookMock",
+        "BoringVault:hook=TellerWithMultiAssetSupport",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        //"@ds-test=lib/forge-std/lib/ds-test/src",
+        //"ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src"
+    ],
+    "parametric_contracts": [
+        "AccountantWithRateProviders", 
+        "BoringVault", 
+        "TellerWithMultiAssetSupport",
+        "ERC20Mock"
+    ],
+    "process": "emv",
+    "prover_args": [
+        //"-enableStorageSplitting false" // for the reentrancy rule
+    ],
+    //"prover_version": "master",
+    "server": "production",
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+    "verify": "TellerWithMultiAssetSupport:certora/specs/scenarioA.spec",
+    //"verify": "TellerWithMultiAssetSupport:certora/specs/rentrancy_view.spec",
+    
+    "msg": "scenarioA",
+    
+    "exclude_rule": [
+    ],
+}

--- a/certora/confs/scenarioB.conf
+++ b/certora/confs/scenarioB.conf
@@ -1,0 +1,57 @@
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/AccountantWithRateProviders.sol",
+        "src/base/Roles/TellerWithBuffer.sol",
+        "src/base/BoringVault.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        //"certora/mocks/BeforeTransferHookMock.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/IBufferHelperMock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithRateProviders:vault=BoringVault",
+        "TellerWithBuffer:accountant=AccountantWithRateProviders",
+        "TellerWithBuffer:nativeWrapper=WETH",
+        "TellerWithBuffer:vault=BoringVault",
+        "BoringVault:hook=TellerWithBuffer",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        "@ds-test=lib/forge-std/lib/ds-test/src",
+        "ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src"
+    ],
+    "parametric_contracts": [
+        "AccountantWithRateProviders", "BoringVault", "TellerWithBuffer"
+    ],
+    "process": "emv",
+    "server": "production",
+    "prover_args": [
+    
+    ],
+    
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+    "struct_link": [
+        "TellerWithBuffer:depositBufferHelper=IBufferHelperMock",
+        "TellerWithBuffer:withdrawBufferHelper=IBufferHelperMock",
+    ],
+
+    //"verify": "TellerWithBuffer:certora/specs/scenarioA.spec",
+    //"verify": "TellerWithBuffer:certora/specs/integrity.spec",
+    "verify": "TellerWithBuffer:certora/specs/accounting.spec",
+
+
+    "msg": "scenarioB-accounting",
+}

--- a/certora/confs/scenarioC.conf
+++ b/certora/confs/scenarioC.conf
@@ -1,0 +1,59 @@
+
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/AccountantWithYieldStreaming.sol",
+        "src/base/Roles/TellerWithYieldStreaming.sol",
+        "src/base/BoringVault.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        //"certora/mocks/BeforeTransferHookMock.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/IBufferHelperMock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithYieldStreaming:vault=BoringVault",
+        "TellerWithYieldStreaming:accountant=AccountantWithYieldStreaming",
+        "TellerWithYieldStreaming:nativeWrapper=WETH",
+        "TellerWithYieldStreaming:vault=BoringVault",
+        "BoringVault:hook=TellerWithYieldStreaming",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        "@ds-test=lib/forge-std/lib/ds-test/src",
+        "ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src"
+    ],
+    "parametric_contracts": [
+        "AccountantWithYieldStreaming", "BoringVault", "TellerWithYieldStreaming"
+    ],
+    "process": "emv",
+    "server": "production",
+    "prover_args": [
+    
+    ],
+    
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+    "struct_link": [
+        "TellerWithYieldStreaming:depositBufferHelper=IBufferHelperMock",
+        "TellerWithYieldStreaming:withdrawBufferHelper=IBufferHelperMock",
+    ],
+
+    //"verify": "TellerWithYieldStreaming:certora/specs/scenarioA.spec",
+    //"verify": "TellerWithYieldStreaming:certora/specs/integrity.spec",
+    //"verify": "TellerWithYieldStreaming:certora/specs/accounting.spec",
+    //"verify": "AccountantWithYieldStreaming:certora/specs/accountant.spec",
+    "verify": "AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreming.spec",
+
+    "msg": "accountantWithYieldStreming",
+}

--- a/certora/confs/scenarioD.conf
+++ b/certora/confs/scenarioD.conf
@@ -1,0 +1,54 @@
+
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol",
+        "src/base/Roles/AccountantWithRateProviders.sol",
+        "src/base/BoringVault.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithRateProviders:vault=BoringVault",
+        "LayerZeroTeller:accountant=AccountantWithRateProviders",
+        "LayerZeroTeller:nativeWrapper=WETH",
+        "LayerZeroTeller:vault=BoringVault",
+        "BoringVault:hook=LayerZeroTeller",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        "@ds-test=lib/forge-std/lib/ds-test/src",
+        "ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src",
+        "@sbu=lib/OAppAuth/lib/solidity-bytes-utils",
+        "@lz-oapp-evm=lib/OAppAuth/lib/LayerZero-V2/packages/layerzero-v2/evm/oapp/contracts/oapp",
+        "@layerzerolabs/lz-evm-protocol-v2=lib/OAppAuth/lib/LayerZero-V2/packages/layerzero-v2/evm/protocol",
+    ],
+    "parametric_contracts": [
+        "AccountantWithRateProviders", "BoringVault", "LayerZeroTeller"
+    ],
+    "process": "emv",
+    "server": "production",
+    "prover_args": [
+    
+    ],
+    
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+
+    //"verify": "LayerZeroTeller:certora/specs/scenarioA.spec",
+    //"verify": "LayerZeroTeller:certora/specs/integrity.spec",
+    "verify": "LayerZeroTeller:certora/specs/accounting.spec",
+    
+    "msg": "scenarioD-accounting",
+}

--- a/certora/confs/scenarioE.conf
+++ b/certora/confs/scenarioE.conf
@@ -1,0 +1,53 @@
+{
+    "assert_autofinder_success": true,
+    "assume_no_casting_overflow": true,
+    "files": [
+        "src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol",
+        "src/base/Roles/AccountantWithRateProviders.sol",
+        "src/base/BoringVault.sol",
+        "lib/solmate/src/tokens/WETH.sol",
+        //"certora/mocks/BeforeTransferHookMock.sol",
+        "certora/mocks/ERC20Mock.sol",
+        "certora/mocks/RateProviderMock.sol",
+    ],
+    "global_timeout": "7200",
+    "smt_timeout": "7200",
+    "link": [
+        "AccountantWithRateProviders:vault=BoringVault",
+        "LayerZeroTellerWithRateLimiting:accountant=AccountantWithRateProviders",
+        "LayerZeroTellerWithRateLimiting:nativeWrapper=WETH",
+        "LayerZeroTellerWithRateLimiting:vault=BoringVault",
+        "BoringVault:hook=LayerZeroTellerWithRateLimiting",
+    ],
+    "loop_iter": "2",
+    "optimistic_loop": true,
+    "packages": [
+        "@solmate=lib/solmate/src",
+        "@forge-std=lib/forge-std/src",
+        "@ds-test=lib/forge-std/lib/ds-test/src",
+        "ds-test=lib/forge-std/lib/ds-test/src",
+        "@openzeppelin=lib/openzeppelin-contracts",
+        "@ccip=lib/ccip",
+        "@oapp-auth=lib/OAppAuth/src",
+        "@sbu=lib/OAppAuth/lib/solidity-bytes-utils",
+        "@lz-oapp-evm=lib/OAppAuth/lib/LayerZero-V2/packages/layerzero-v2/evm/oapp/contracts/oapp",
+        "@layerzerolabs/lz-evm-protocol-v2=lib/OAppAuth/lib/LayerZero-V2/packages/layerzero-v2/evm/protocol",
+    ],
+    "parametric_contracts": [
+        "AccountantWithRateProviders", "BoringVault", "LayerZeroTellerWithRateLimiting"
+    ],
+    "process": "emv",
+    "prover_args": [
+    ],
+    //"prover_version": "master",
+    "server": "production",
+    "solc": "solc8.21",
+    "solc_optimize": "200",
+    "solc_via_ir": false,
+
+    //"verify": "LayerZeroTellerWithRateLimiting:certora/specs/scenarioA.spec",
+    //"verify": "LayerZeroTellerWithRateLimiting:certora/specs/integrity.spec",
+    "verify": "LayerZeroTellerWithRateLimiting:certora/specs/accounting.spec",
+
+    "msg": "scenario E",
+}

--- a/certora/harness/AccountantWithRateProvidersHarness.sol
+++ b/certora/harness/AccountantWithRateProvidersHarness.sol
@@ -1,0 +1,23 @@
+
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+
+contract AccountantWithRateProvidersHarness is AccountantWithRateProviders {
+
+    constructor(
+        address _owner,
+        address _vault,
+        address payoutAddress,
+        uint96 startingExchangeRate,
+        address _base,
+        uint16 allowedExchangeRateChangeUpper,
+        uint16 allowedExchangeRateChangeLower,
+        uint24 minimumUpdateDelayInSeconds,
+        uint16 platformFee,
+        uint16 performanceFee
+    ) AccountantWithRateProviders(_owner, _vault, payoutAddress, startingExchangeRate, _base, allowedExchangeRateChangeUpper, allowedExchangeRateChangeLower, minimumUpdateDelayInSeconds, platformFee, performanceFee)
+    {}
+
+    function isAuthorizedHarness(address user, bytes4 functionSig) public view returns (bool) {
+        return isAuthorized(user, functionSig);
+    }
+}

--- a/certora/harness/TellerWithMultiAssetSupportHarness.sol
+++ b/certora/harness/TellerWithMultiAssetSupportHarness.sol
@@ -1,0 +1,27 @@
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+
+contract TellerWithMultiAssetSupportHarness is TellerWithMultiAssetSupport {
+
+    constructor(address _owner, address _vault, address _accountant, address _weth)
+        TellerWithMultiAssetSupport(_owner, _vault, _accountant, _weth)
+    {}
+
+    function getRateInQuoteSafe(ERC20 quote) external view returns (uint256) {
+        return accountant.getRateInQuoteSafe(quote);
+    }
+
+    function getAssetData(address asset) external view returns (Asset memory) {
+        return assetData[ERC20(asset)];
+    }
+
+    function isAuthorizedHarness(address user, bytes4 functionSig) public view returns (bool) {
+        return isAuthorized(user, functionSig);
+    }
+
+    function callPermit(ERC20 depositAsset, uint256 depositAmount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public
+    {
+        depositAsset.permit(msg.sender, address(vault), depositAmount, deadline, v, r, s);
+    }
+}

--- a/certora/mocks/BeforeTransferHookMock.sol
+++ b/certora/mocks/BeforeTransferHookMock.sol
@@ -1,0 +1,7 @@
+import {BeforeTransferHook} from "src/interfaces/BeforeTransferHook.sol";
+
+contract BeforeTransferHookMock is BeforeTransferHook {
+    function beforeTransfer(address from, address to, address operator) external view {
+        
+    }
+}

--- a/certora/mocks/BytesLibMock.sol
+++ b/certora/mocks/BytesLibMock.sol
@@ -1,0 +1,7 @@
+contract BytesLibMock {
+    function toUint16(bytes memory _bytes, uint256 _start) external pure returns (uint16) {
+        require(_bytes.length >= _start + 2, "toUint16_outOfBounds");
+
+        return uint8(_bytes[_start + 1]) + (uint16(uint8(_bytes[_start])) << 8);
+    }
+}

--- a/certora/mocks/ERC20Mock.sol
+++ b/certora/mocks/ERC20Mock.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.0;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+contract ERC20Mock is ERC20 {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    ) ERC20(_name, _symbol, _decimals) {}
+
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+
+        emit Transfer(msg.sender, to, amount);
+
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) public override returns (bool) {
+        uint256 allowed = allowance[from][msg.sender]; // Saves gas for limited approvals.
+
+        if (allowed != type(uint256).max) allowance[from][msg.sender] = allowed - amount;
+
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+
+        emit Transfer(from, to, amount);
+
+        return true;
+    }
+}

--- a/certora/mocks/IBufferHelperMock.sol
+++ b/certora/mocks/IBufferHelperMock.sol
@@ -1,0 +1,15 @@
+import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";
+
+contract IBufferHelperMock is IBufferHelper {
+    function getDepositManageCall(address asset, uint256 amount)
+        external
+        view
+        returns (address[] memory targets, bytes[] memory data, uint256[] memory values)
+    {}
+
+    function getWithdrawManageCall(address asset, uint256 amount)
+        external
+        view
+        returns (address[] memory targets, bytes[] memory data, uint256[] memory values)
+    {}
+}

--- a/certora/mocks/RateProviderMock.sol
+++ b/certora/mocks/RateProviderMock.sol
@@ -1,0 +1,6 @@
+contract RateProviderMock {
+    uint256 _rate;
+    function getRate(bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32) public view returns (uint256) {
+        return _rate;
+    }
+}

--- a/certora/scripts/headerA.spec
+++ b/certora/scripts/headerA.spec
@@ -1,0 +1,9 @@
+import "setup/dispatching_BoringVault.spec";
+import "setup/snippet_ERC20_Mock.spec";
+import "MathSummaries.spec";
+
+import "setup/dispatching_AccountantWithRateProviders.spec";    // A, B, D, E
+import "setup/dispatching_TellerWithMultiAssetSupport.spec";    // A
+
+using AccountantWithRateProviders as accountant_contract;       // A, B, D, E
+using TellerWithMultiAssetSupport as teller_contract;           // A

--- a/certora/scripts/headerB.spec
+++ b/certora/scripts/headerB.spec
@@ -1,0 +1,9 @@
+import "setup/dispatching_BoringVault.spec";
+import "setup/snippet_ERC20_Mock.spec";
+import "MathSummaries.spec";
+
+import "setup/dispatching_AccountantWithRateProviders.spec";    // A, B, D, E
+import "setup/dispatching_TellerWithBuffer.spec";               // B
+
+using AccountantWithRateProviders as accountant_contract;       // A, B, D, E
+using TellerWithBuffer as teller_contract;                      // B

--- a/certora/scripts/headerC.spec
+++ b/certora/scripts/headerC.spec
@@ -1,0 +1,9 @@
+import "setup/dispatching_BoringVault.spec";
+import "setup/snippet_ERC20_Mock.spec";
+import "MathSummaries.spec";
+
+import "setup/dispatching_AccountantWithYieldStreaming.spec";   // C
+import "setup/dispatching_TellerWithYieldStreaming.spec";       // C
+
+using AccountantWithYieldStreaming as accountant_contract;      // C
+using TellerWithYieldStreaming as teller_contract;              // C

--- a/certora/scripts/headerD.spec
+++ b/certora/scripts/headerD.spec
@@ -1,0 +1,9 @@
+import "setup/dispatching_BoringVault.spec";
+import "setup/snippet_ERC20_Mock.spec"; // B
+import "MathSummaries.spec";
+
+import "setup/dispatching_AccountantWithRateProviders.spec";    // A, B, D, E
+import "setup/dispatching_LayerZeroTeller.spec";                // D
+
+using AccountantWithRateProviders as accountant_contract;       // A, B, D, E
+using LayerZeroTeller as teller_contract;                       // D

--- a/certora/scripts/headerE.spec
+++ b/certora/scripts/headerE.spec
@@ -1,0 +1,9 @@
+import "setup/dispatching_BoringVault.spec";
+import "setup/snippet_ERC20_Mock.spec"; // B
+import "MathSummaries.spec";
+
+import "setup/dispatching_AccountantWithRateProviders.spec";      // A, B, D, E
+import "setup/dispatching_LayerZeroTellerWithRateLimiting.spec";  // E
+
+using AccountantWithRateProviders as accountant_contract;         // A, B, D, E
+using LayerZeroTellerWithRateLimiting as teller_contract;         // E

--- a/certora/scripts/run.sh
+++ b/certora/scripts/run.sh
@@ -1,0 +1,46 @@
+# reentrancy: holds
+certora/scripts/setup.sh A && certoraRun certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/rentrancy_view.spec" --msg reentrancy_A --prover_args "-enableStorageSplitting false"
+certora/scripts/setup.sh B && certoraRun certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/rentrancy_view.spec" --msg reentrancy_B --prover_args "-enableStorageSplitting false"
+certora/scripts/setup.sh C && certoraRun certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/rentrancy_view.spec" --msg reentrancy_C --prover_args "-enableStorageSplitting false"
+certora/scripts/setup.sh D && certoraRun certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/rentrancy_view.spec" --msg reentrancy_D --prover_args "-enableStorageSplitting false"
+certora/scripts/setup.sh E && certoraRun certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/rentrancy_view.spec" --msg reentrancy_E --prover_args "-enableStorageSplitting false"
+
+
+# teller basic:
+certora/scripts/setup.sh A && certoraRun certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/teller_basic.spec" --msg teller_basic_A # done
+certora/scripts/setup.sh B && certoraRun certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/teller_basic.spec" --msg teller_basic_B # done
+certora/scripts/setup.sh C && certoraRun certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/teller_basic.spec" --msg teller_basic_C --exclude_rule dustFavorsTheHouse # done
+certora/scripts/setup.sh D && certoraRun certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/teller_basic.spec" --msg teller_basic_D # done
+certora/scripts/setup.sh E && certoraRun certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/teller_basic.spec" --msg teller_basic_E # done
+
+
+##  holds except for AccountantWithYeildStreaming
+
+# teller accounting:
+certora/scripts/setup.sh A && certoraRun certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/teller_accounting_easyRules.spec" --msg accounting_easyRules_A # done
+certora/scripts/setup.sh B && certoraRun certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/teller_accounting_easyRules.spec" --msg accounting_easyRules_B # done
+certora/scripts/setup.sh C && certoraRun certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/teller_accounting_easyRules.spec" --msg accounting_easyRules_C
+certora/scripts/setup.sh D && certoraRun certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/teller_accounting_easyRules.spec" --msg accounting_easyRules_D # done
+certora/scripts/setup.sh E && certoraRun certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/teller_accounting_easyRules.spec" --msg accounting_easyRules_E # done
+
+
+################    DONE
+
+# accountants:
+certora/scripts/setup.sh A && certoraRun certora/confs/accountantWithRateProviders.conf --msg accountant_base_A
+certora/scripts/setup.sh C && certoraRun certora/confs/accountantWithYieldStreaming.conf --msg accountant_base_B
+certora/scripts/setup.sh C && certoraRun certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --msg accountantWithYieldStreaming
+
+# integrity
+certora/scripts/setup.sh A && certoraRun certora/confs/scenarioA.conf --verify "TellerWithMultiAssetSupport:certora/specs/teller_integrity.spec" --msg integrity_TellerWithMultiAssetSupport # done
+certora/scripts/setup.sh B && certoraRun certora/confs/scenarioB.conf --verify "TellerWithBuffer:certora/specs/teller_integrity.spec" --msg integrity_TellerWithBuffer # done
+certora/scripts/setup.sh C && certoraRun certora/confs/scenarioC.conf --verify "TellerWithYieldStreaming:certora/specs/teller_integrity.spec" --msg integrity_TellerWithYieldStreaming  # done
+certora/scripts/setup.sh D && certoraRun certora/confs/scenarioD.conf --verify "LayerZeroTeller:certora/specs/teller_integrity.spec" --msg integrity_LayerZeroTeller # done
+certora/scripts/setup.sh E && certoraRun certora/confs/scenarioE.conf --verify "LayerZeroTellerWithRateLimiting:certora/specs/teller_integrity.spec" --msg integrity_LayerZeroTellerWithRateLimiting # done
+
+
+# for testing
+# certora/scripts/setup.sh C && certoraRun certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --msg accountantWithYieldStreaming_postLoss --rule exchangeRateLEhighwaterMark_unlessPaused_postLoss
+# certora/scripts/setup.sh C && certoraRun certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --msg accountantWithYieldStreaming
+
+# certora/scripts/setup.sh C && certoraRun certora/confs/accountantWithYieldStreaming.conf --verify AccountantWithYieldStreaming:certora/specs/accountantWithYieldStreaming.spec --msg accountantWithYieldStreaming --prover_args "-destructiveOptimizations twostage -mediumTimeout 20 -lowTimeout 20 -tinyTimeout 20 -depth 20" --rule totalAssetsCovered --rule vaultSolvency_1Asset

--- a/certora/scripts/setup.sh
+++ b/certora/scripts/setup.sh
@@ -1,0 +1,14 @@
+
+# Usage: ./setup.sh <letter A|B|C|D|E>
+
+input_file="certora/specs/setup.spec"
+num_lines=9
+
+letter="$1"
+replacement_file="certora/scripts/header${letter}.spec"
+output_file=$input_file
+
+tail_lines=$(tail -n +$((num_lines + 1)) "$input_file" 2>/dev/null || echo "")
+
+cat "$replacement_file" > "$output_file"
+echo "$tail_lines" >> "$output_file"

--- a/certora/specs/MathSummaries.spec
+++ b/certora/specs/MathSummaries.spec
@@ -1,0 +1,46 @@
+// safe summaries to enhance performance
+
+methods {
+    // lib/openzeppelin-contracts/contracts/utils/math/Math.sol
+    function _.mulDivDown(uint256 x, uint256 y, uint256 denominator) internal => cvlMulDivDown(x, y, denominator) expect uint256;
+    function _.mulDivUp(uint256 x, uint256 y, uint256 denominator) internal => cvlMulDivUp(x, y, denominator) expect uint256;
+    function _.sqrt(uint256 a) internal => cvlSqrt(a) expect uint256;
+    function _.average(uint256 a, uint256 b) internal => cvlAverage(a, b) expect uint256;
+    function _.ternary(bool condition, uint256 a, uint256 b) internal => cvlTernary(condition, a, b) expect uint256;
+    function _.zeroFloorSub(uint256 x, uint256 y) internal => cvlZeroFloorSub(x, y) expect (uint256);
+
+}
+
+function cvlZeroFloorSub(uint256 x, uint256 y) returns uint256 {
+    if (x > y) return require_uint256(x - y);
+    else return 0;
+}
+
+function cvlMulDivDown(uint256 x, uint256 y, uint256 denominator) returns uint256 {
+    require denominator > 0;
+    mathint res = x * y / denominator;
+    return require_uint256(res);
+}
+
+function cvlMulDivUp(uint256 x, uint256 y, uint256 denominator) returns uint256 
+{
+    require denominator > 0;
+    return require_uint256((x * y + denominator - 1) / denominator);
+}
+
+function cvlSqrt(uint256 a) returns uint256 {
+    mathint a_mathint = to_mathint(a);
+    uint256 sqrt_a;
+    require
+        sqrt_a * sqrt_a <= a_mathint &&
+        (sqrt_a + 1) * (sqrt_a + 1) > a_mathint;
+    return sqrt_a;
+}
+
+function cvlAverage(uint256 a, uint256 b) returns uint256 {
+    return require_uint256((a + b) / 2);
+}
+
+function cvlTernary(bool condition, uint256 a, uint256 b) returns uint256 {
+    return condition ? a : b;
+}

--- a/certora/specs/accountantWithRateProviders.spec
+++ b/certora/specs/accountantWithRateProviders.spec
@@ -1,0 +1,10 @@
+// rules specific for accountantWithRateProviders
+
+import "accountant_basic.spec";
+
+invariant exchangeRateLEhighwaterMark_unlessPaused()
+    !accountant_contract.accountantState.isPaused => 
+        accountant_contract.accountantState.exchangeRate <= accountant_contract.accountantState.highwaterMark
+    filtered { f -> !ignoredMethod(f)
+        && f.selector != sig:unpause().selector }
+    { preserved { safeAssumptions(); }}

--- a/certora/specs/accountantWithYieldStreaming.spec
+++ b/certora/specs/accountantWithYieldStreaming.spec
@@ -1,0 +1,277 @@
+// rules specific for accountantWithYieldStreaming
+
+import "accountant_basic.spec";
+
+methods
+{
+    //function vault_contract.decimals() external returns (uint8) envfree;
+    //function accountant_contract.getPendingVestingGains() external returns (uint256) envfree;
+}
+
+// holds
+invariant exchangeRateLEqlastSharePrice()
+    accountant_contract.accountantState.exchangeRate <= 
+        accountant_contract.vestingState.lastSharePrice
+    filtered { f -> !ignoredMethod(f) }
+    { preserved { safeAssumptions(); }
+}
+
+invariant exchangeRateLEhighwaterMark_unlessPaused()
+    !accountant_contract.accountantState.isPaused => 
+        accountant_contract.accountantState.exchangeRate <= accountant_contract.accountantState.highwaterMark
+    filtered { f -> !ignoredMethod(f)
+        && f.selector != sig:accountant_contract.unpause().selector 
+        && f.selector != sig:accountant_contract.postLoss(uint256).selector
+        && f.selector != sig:accountant_contract.vestYield(uint256,uint256).selector
+        }
+    { preserved with(env e) { 
+        safeAssumptions(); 
+        requireInvariant exchangeRateLEqlastSharePrice();
+        requireInvariant cumulativeSupplyBounded();
+        
+        //require accountant_contract.vestingState.lastSharePrice <= 2^90; //unreasonably high value
+        require getPendingVestingGains(e) <= vault_contract.totalSupply();
+        }
+}
+
+rule lastVestingUpdateNeverDecreases(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    uint128 lastVestingUpdate_pre = accountant_contract.vestingState.lastVestingUpdate;
+    require e.block.timestamp >= lastVestingUpdate_pre;
+    require e.block.timestamp <= 2^40;
+    calldataarg args;
+    f(e, args);
+
+    uint128 lastVestingUpdate_post = accountant_contract.vestingState.lastVestingUpdate;
+    assert lastVestingUpdate_post >= lastVestingUpdate_pre;
+}
+
+invariant cumulativeSupplyBounded()
+    accountant_contract.supplyObservation.cumulativeSupplyLast <= 
+        accountant_contract.supplyObservation.cumulativeSupply;
+
+
+rule integrityOfVestYield(env e)
+{
+    safeAssumptions(); 
+    requireInvariant exchangeRateLEqlastSharePrice();
+    require e.block.timestamp < 2^40;
+
+    uint256 yieldAmount; uint256 duration;
+    accountant_contract.vestYield(e, yieldAmount, duration);
+
+    uint64 startTime = accountant_contract.vestingState.startVestingTime;
+    uint64 lastUpdateTimestamp = accountant_contract.lastStrategistUpdateTimestamp;
+    
+    assert startTime == e.block.timestamp 
+        && lastUpdateTimestamp == e.block.timestamp;
+}
+
+invariant accountantDecimalsCorrect(env e)
+    accountant_contract.decimals == accountant_contract.base.decimals(e)
+    filtered { f ->
+        f.selector == sig:accountant_contract.vestYield(uint256,uint256).selector
+}
+
+invariant sharePriceMoreThanOneAsset()
+    accountant_contract.vestingState.lastSharePrice >= 10^vault_contract.decimals
+    
+    filtered 
+    {   f -> !ignoredMethod(f)
+        && f.selector != sig:accountant_contract.postLoss(uint256).selector
+    }
+{   preserved with (env e2) {
+        requireAllInvariants_accountant(e2);
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+    preserved claimFees(address a) with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+    }
+    preserved constructor()
+    {
+        require accountant_contract.vestingState.lastSharePrice >= 10^vault_contract.decimals;
+    }
+}
+
+invariant assetsMoreThanShares(env e)
+    accountant_contract.totalAssets(e) + 1 >= vault_contract.totalSupply()
+    filtered 
+    { f -> !ignoredMethod(f)
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory      
+        && isPublicMethod(f)
+    }
+    {
+    preserved with (env e2) {
+        requireAllInvariants_accountant(e2);
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+    preserved claimFees(address a) with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+    }
+    preserved constructor()
+    {
+        requireFreshStart();
+    }
+}
+
+invariant sharePriceBoundedUpper(env e)
+    accountant_contract.vestingState.lastSharePrice * vault_contract.totalSupply() <= 
+        (accountant_contract.totalAssets(e)+1) * teller_contract.ONE_SHARE
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)
+        //&& f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+        //&& f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+    }
+    {
+    preserved with (env e2) {
+        requireAllInvariants_accountant(e2);
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+    preserved claimFees(address a) with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+    }
+    preserved constructor()
+    {
+        requireFreshStart();
+    }
+}
+
+invariant sharePriceBoundedLower(env e)
+    (accountant_contract.vestingState.lastSharePrice) * vault_contract.totalSupply() >= 
+        (accountant_contract.totalAssets(e)) * teller_contract.ONE_SHARE
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)  //funds could be moved by methods called on the Vault or on the Asset
+        && f.selector != sig:accountant_contract.vestYield(uint256,uint256).selector
+    }
+    {
+    preserved with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+        require e2.block.timestamp == e.block.timestamp;
+        require accountant_contract.getPendingVestingGains(e2) <= vault_contract.totalSupply();
+        nonSceneAddress(e2.msg.sender);
+    }
+    preserved claimFees(address a) with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+        require e2.block.timestamp == e.block.timestamp;
+        require accountant_contract.getPendingVestingGains(e2) <= vault_contract.totalSupply();
+    }
+    preserved constructor()
+    {
+        requireFreshStart();
+    }
+}
+
+invariant totalAssetsCovered(env e)
+    accountant_contract.totalAssets(e) <= userAssets(e, ERC20Mock, vault_contract) 
+    
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+        && f.selector != sig:accountant_contract.vestYield(uint256,uint256).selector
+    }
+    {
+    preserved with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+
+        require e2.block.timestamp == e.block.timestamp;
+        require accountant_contract.getPendingVestingGains(e2) <= vault_contract.totalSupply();
+        require vault_contract.totalSupply() > 0; //the initial state uses the lastSharePrice directly that could be incorrectly initialized
+        require teller_contract.ONE_SHARE == 1000000;
+
+        nonSceneAddress(e2.msg.sender);
+    }
+    preserved constructor()
+    {
+        requireFreshStart();
+    }
+}
+
+invariant vaultSolvency_1Asset(env e)
+    (userAssets(e, ERC20Mock, vault_contract) - accountant_contract.getPendingVestingGains(e)) * teller_contract.ONE_SHARE 
+        >= (vault_contract.totalSupply(e)) * (accountant_contract.getRateInQuoteSafe(e, ERC20Mock)) 
+    
+filtered { f -> !ignoredMethod(f)
+    && (f.contract == teller_contract || f.contract == accountant_contract)
+    && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+    && f.selector != sig:accountant_contract.vestYield(uint256,uint256).selector
+    && f.selector != sig:accountant_contract.postLoss(uint256).selector 
+    && f.selector != sig:accountant_contract.pause().selector 
+}
+{
+    preserved with (env e2) {
+        safeAssumptions();
+        requireAllInvariants_accountant(e2);
+        require e2.block.timestamp == e.block.timestamp;
+        nonSceneAddress(e2.msg.sender);
+    }
+
+    preserved constructor()
+    {
+        requireFreshStart();
+        require accountant_contract.getPendingVestingGains(e) == 0;
+    }
+}
+
+invariant exchangeRateEqlastSharePrice()
+    accountant_contract.accountantState.exchangeRate == 
+        accountant_contract.vestingState.lastSharePrice
+    
+    filtered { f -> !ignoredMethod(f) }
+    { preserved with (env e2) { 
+        requireAllInvariants_accountant(e2);
+        safeAssumptions(); }
+}
+
+invariant virtualPriceIsCorrect()
+    accountant_contract.vestingState.lastSharePrice * 10^27 
+    / accountant_contract.ONE_SHARE == accountant_contract.lastVirtualSharePrice
+    filtered { f -> !ignoredMethod(f) 
+        && f.selector != sig:accountant_contract.postLoss(uint256).selector 
+        }
+    { preserved with(env e) { 
+        safeAssumptions(); 
+        requireAllInvariants_accountant(e);
+    }
+}
+
+function requireAllInvariants_accountant(env e)
+{
+    // these hold
+    requireInvariant exchangeRateLEhighwaterMark_unlessPaused();
+    requireInvariant sharePriceBoundedLower(e);
+    requireInvariant exchangeRateEqlastSharePrice();
+    requireInvariant cumulativeSupplyBounded();
+    requireInvariant sharePriceBoundedUpper(e);
+    requireInvariant sharePriceMoreThanOneAsset();
+    requireInvariant assetsMoreThanShares(e);
+    requireInvariant totalAssetsCovered(e);
+    requireInvariant vaultSolvency_1Asset(e);
+    
+    requireInvariant virtualPriceIsCorrect();
+
+    // holds as an invariant accountantDecimalsCorrect
+    require accountant_contract.decimals == accountant_contract.base.decimals(e); 
+    require accountant_contract.base == ERC20Mock;
+
+    require teller_contract.assetData[ERC20Mock].sharePremium == 0;
+    require accountant_contract.getPendingVestingGains(e) <= vault_contract.totalSupply();
+    
+}
+
+function requireFreshStart()
+{
+    require vault_contract.totalSupply() == 0;
+}

--- a/certora/specs/accountant_basic.spec
+++ b/certora/specs/accountant_basic.spec
@@ -1,0 +1,107 @@
+// rules that apply to both accountants
+
+import "setup.spec";
+
+function safeAssumptions()
+{
+    //require vault_contract.decimals() < 5;
+    require vault_contract.decimals() < 50; //thats more than enough decimals. 10^78 > 2^256
+    require accountant_contract.ONE_SHARE == 10 ^ vault_contract.decimals();
+    require teller_contract.ONE_SHARE == 10 ^ vault_contract.decimals();
+    requireInvariant totalSupplyHolds_BoringVault();
+    requireInvariant totalSupplyHolds_ERC20Mock();
+}
+
+rule accountantDoesntHoldTokens(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    safeAssumptions();
+    if (f.selector != sig:accountant_contract.claimFees(address).selector)
+        nonSceneAddress(e.msg.sender);   // the claimFees can only be called by the Vault so this condidtion would cause vacuity
+
+    address asset; require asset != vault_contract;
+    require accountant_contract.accountantState.payoutAddress != accountant_contract, "otherwise the accountant holds the fees, i.e. does hold tokens";
+
+    uint balanceBefore = asset.balanceOf(e, accountant_contract);
+    calldataarg args;
+    f(e, args);
+
+    uint balanceAfter = asset.balanceOf(e, accountant_contract);
+
+    assert balanceAfter == balanceBefore
+        || f.selector == sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector    // can be a recepient of a refund
+        || f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector                                         // can be a recepient of funds during a withdraw or bulkWithdraw
+        || f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector
+        ;
+
+}
+
+rule accountantPaused_valuesFrozen(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    bool paused = accountant_contract.accountantState.isPaused;
+
+    uint128 feesOwedInBase_pre = accountant_contract.accountantState.feesOwedInBase;
+    uint96 exchangeRate_pre = accountant_contract.accountantState.exchangeRate;
+
+    calldataarg args;
+    f(e, args);
+
+    uint128 feesOwedInBase_post = accountant_contract.accountantState.feesOwedInBase;
+    uint96 exchangeRate_post = accountant_contract.accountantState.exchangeRate;
+    
+    assert paused => (
+        exchangeRate_post == exchangeRate_pre &&
+         (feesOwedInBase_post == feesOwedInBase_pre 
+            || f.selector == sig:accountant_contract.resetHighwaterMark().selector //fees should only be able to change via this method when paused
+         )
+        );
+
+}
+
+invariant allowedExchangeRateChangeUpper_bound()
+    accountant_contract.accountantState.allowedExchangeRateChangeUpper >= 10^4
+    filtered { f -> !ignoredMethod(f) }
+
+invariant allowedExchangeRateChangeLower_bound()
+    accountant_contract.accountantState.allowedExchangeRateChangeLower <= 10^4
+    filtered { f -> !ignoredMethod(f) }
+
+rule feesCanOnlyDecreaseViaClaimFees(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    uint256 fees_pre = accountant_contract.accountantState.feesOwedInBase;
+
+    calldataarg args;
+    f(e, args);
+
+    uint256 fees_post = accountant_contract.accountantState.feesOwedInBase;
+    assert fees_post < fees_pre => f.selector == sig:accountant_contract.claimFees(address).selector;
+}
+
+rule highwaterMarkNeverDecreases(env e, method f)
+    filtered { f -> !ignoredMethod(f) 
+        && f.selector != sig:accountant_contract.resetHighwaterMark().selector
+    }
+{
+    uint96 WM_pre = accountant_contract.accountantState.highwaterMark;
+    calldataarg args;
+    f(e, args);
+
+    uint96 WM_post = accountant_contract.accountantState.highwaterMark;
+    assert WM_post >= WM_pre;
+}
+
+rule lastUpdateTimestampNeverDecreases(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    uint64 timestamp_pre = accountant_contract.accountantState.lastUpdateTimestamp;
+    require timestamp_pre <= e.block.timestamp &&
+        e.block.timestamp <= 2^30;
+
+    calldataarg args;
+    f(e, args);
+
+    uint64 timestamp_post = accountant_contract.accountantState.lastUpdateTimestamp;
+    assert timestamp_post >= timestamp_pre;
+}

--- a/certora/specs/rentrancy_view.spec
+++ b/certora/specs/rentrancy_view.spec
@@ -1,0 +1,90 @@
+import "setup.spec";
+
+methods {
+    function _.balanceOf(address) external => ignoredUintStaticcall() expect(uint256);
+    function _.totalSupply() internal => ignoredUintStaticcall() expect(uint256);
+    function _.isAuthorized(address, bytes4) internal => ignoredBoolStaticcall() expect(bool);
+
+    function _.getRateInQuoteSafe(address) external => ignoredUintStaticcall() expect(uint256);
+    function _.getRateInQuote(address) external => ignoredUintStaticcall() expect(uint256);
+
+}   
+
+function ignoredBoolStaticcall() returns bool {
+    ignoredStaticcall = true;
+    bool value;
+    return value;
+}
+
+function ignoredUintStaticcall() returns uint256 {
+    ignoredStaticcall = true;
+    uint256 value;
+    return value;
+}
+
+persistent ghost bool ignoredStaticcall;
+
+// True when at least one slot was written.
+persistent ghost bool storageChanged;
+
+// True when at least one STATICCALL is executed after a storage change.
+persistent ghost bool staticCallAfterSStore;
+
+// True when at least one slot is changed after a STATICCALL is executed after a storage change.
+persistent ghost bool staticCallUnsafe;
+
+hook ALL_SSTORE(uint slot, uint val) {
+    if (slot != 0x2) //this is fine. It's the reentrancy lock
+    {
+        storageChanged = true;
+    }
+    if (staticCallAfterSStore) {
+        staticCallUnsafe = true;
+    }
+}
+
+hook STATICCALL(uint256 g, address addr, uint256 argsOffset, uint256 argsLength, uint256 retOffset, uint256 retLength) uint256 rc {
+    // address(1) is ignored because it's the ecrecover function.
+    if (!ignoredStaticcall && storageChanged && addr != 0x1 
+        && selector != 404098525    // totalSupply()
+        && selector != 499888400    // getRateInQuote
+        && selector != 2181657562   // getRateInQuoteSafe
+        && selector != 1738207182   // getRate
+        && selector != 3714247998   // allowance(address,address)
+        && selector != 434397065    // RateProviderMock.getRate(bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32)
+        && selector != sig:ERC20Mock.decimals().selector
+        ) {
+        staticCallAfterSStore = true;
+    }
+    ignoredStaticcall = false;
+}
+
+// Check that there are no reentrancy unsafe calls except potentially for balanceOf on the asset, realAssets on the adapters and canReceiveShares, canSendShares, canReceiveAssets and canSendAssets on the gates, and isInRegistry on adapter registry.
+rule reentrancyViewSafe(method f, env e, calldataarg data)
+filtered {
+    f -> 
+    f.selector != 1539645794        // depositAndBridgeWithPermit(CrossChainTellerWithGenericBridge.DepositAndBridgeWithPermitParams).selector // 0x5bc52162
+    && f.selector != 4172789357     // depositAndBridge(address,uint256,uint256,address,bytes,address,uint256,address).selector // 0xf8b7b66d
+    && f.selector != 93460288       // bridge(uint96,address,bytes,address,uint256).selector  // 0x05921740
+    && f.selector != 3611446835     // previewFee(uint96,address,bytes,address).selector  // 0xd7424e33
+
+    && f.selector != sig:withdraw(address,uint256,uint256,address).selector
+    && f.selector != sig:bulkWithdraw(address,uint256,uint256,address).selector
+} 
+{
+    require ignoredStaticcall == false, "setup ghost state";
+    require storageChanged == false, "setup ghost state";
+    require staticCallAfterSStore == false, "setup ghost state";
+    require staticCallUnsafe == false, "setup ghost state";
+
+    f(e, data);
+
+    assert !staticCallUnsafe;
+}
+
+// rule reachability(method f, env e, calldataarg data)
+// {
+//     f(e, data);
+
+//     satisfy true;
+// }

--- a/certora/specs/setup.spec
+++ b/certora/specs/setup.spec
@@ -1,0 +1,67 @@
+import "setup/dispatching_BoringVault.spec";
+import "setup/snippet_ERC20_Mock.spec";
+import "MathSummaries.spec";
+
+import "setup/dispatching_AccountantWithYieldStreaming.spec";   // C
+import "setup/dispatching_TellerWithYieldStreaming.spec";       // C
+
+using AccountantWithYieldStreaming as accountant_contract;      // C
+using TellerWithYieldStreaming as teller_contract;              // C
+
+using BoringVault as vault_contract;
+using WETH as WETH;
+
+methods
+{
+    // summarising vault.manage to empty method to avoid global havoc through functionCallWithValue();
+    function vault_contract.manage(address,bytes,uint256) external returns (bytes)  => emptyManage1();
+    function vault_contract.manage(address[],bytes[],uint256[]) external returns (bytes[]) => emptyManage2();
+}
+
+function emptyManage1() returns (bytes)
+{
+    bytes results;
+    return results;
+}
+
+function emptyManage2() returns (bytes[])
+{
+    bytes[] results;
+    return results;
+}
+
+function userAssets(env e, address asset, address user) returns uint256
+{
+    return asset.balanceOf(e, user);
+}
+
+// Method that can be called by non-priveleged addresses
+definition isPublicMethod(method f) returns bool = 
+    f.selector == sig:teller_contract.deposit(address,uint256,uint256,address).selector ||
+    f.selector == sig:teller_contract.bulkDeposit(address,uint256,uint256,address).selector ||
+    f.selector == sig:teller_contract.depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector ||
+    f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector ||
+    f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector;
+
+
+definition ignoredMethod(method f) returns bool =
+    f.selector == sig:vault_contract.manage(address[],bytes[],uint256[]).selector
+    || f.selector == sig:vault_contract.manage(address,bytes,uint256).selector
+    || f.isView;
+
+function nonSceneAddress(address sender)
+{
+    require sender != teller_contract 
+        && sender != vault_contract
+        && sender != accountant_contract
+        && sender != WETH;
+
+    env e;
+    bytes4 signature_enter = to_bytes4(sig:vault_contract.enter(address,address,uint256,address,uint256).selector);
+    bytes4 signature_exit = to_bytes4(sig:vault_contract.exit(address,address,uint256,address,uint256).selector);
+    
+    require 
+        !vault_contract.isAuthorized(e, sender, signature_enter)
+        && !vault_contract.isAuthorized(e, sender, signature_exit)
+        ;
+}

--- a/certora/specs/setup/dispatching_AccountantWithRateProviders.spec
+++ b/certora/specs/setup/dispatching_AccountantWithRateProviders.spec
@@ -1,0 +1,5 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_RateProvider.spec";
+
+methods {}

--- a/certora/specs/setup/dispatching_AccountantWithYieldStreaming.spec
+++ b/certora/specs/setup/dispatching_AccountantWithYieldStreaming.spec
@@ -1,0 +1,31 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_RateProvider.spec";
+
+function getAccountant_summary() returns address
+{
+    return accountant_contract;
+}
+
+function updateExchangeRate_summary(env e)
+{
+    accountant_contract.updateExchangeRate(e);
+}
+
+function lastVirtualSharePrice_summary(env e) returns uint256
+{
+    return accountant_contract.lastVirtualSharePrice(e);
+}
+
+function setFirstDepositTimestamp_summary(env e) {
+    accountant_contract.setFirstDepositTimestamp(e);
+}
+
+methods
+{
+    //function vault_contract.decimals() external returns (uint8) envfree;
+    function TellerWithYieldStreaming._getAccountant() internal returns address => getAccountant_summary();
+    function _.updateExchangeRate() external with (env e) => updateExchangeRate_summary(e) expect void;
+    function _.lastVirtualSharePrice() external with (env e) => lastVirtualSharePrice_summary(e) expect uint256;
+    function _.setFirstDepositTimestamp() external with (env e) => setFirstDepositTimestamp_summary(e) expect void;
+}

--- a/certora/specs/setup/dispatching_BoringVault.spec
+++ b/certora/specs/setup/dispatching_BoringVault.spec
@@ -1,0 +1,5 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_ERC20_BoringVault.spec";
+
+methods {}

--- a/certora/specs/setup/dispatching_LayerZeroTeller.spec
+++ b/certora/specs/setup/dispatching_LayerZeroTeller.spec
@@ -1,0 +1,38 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_RateProvider.spec";
+
+methods {
+
+    function OAppAuthSender._quote(uint32 _dstEid, bytes memory _message, bytes memory _options, bool _payInLzToken) internal returns (LayerZeroTeller.MessagingFee memory)
+        => CVL_quote();
+
+    function OAppAuthSender._lzSend(
+        uint32 _dstEid,
+        bytes memory _message,
+        bytes memory _options,
+        LayerZeroTeller.MessagingFee memory _fee,
+        address _refundAddress
+    ) internal returns (LayerZeroTeller.MessagingReceipt memory)
+        => CVL_lzSend();
+
+    function _.setDelegate(address) external => NONDET;
+
+    function _.addExecutorLzReceiveOption(bytes memory, uint128, uint128) internal
+        => CVL_nondetbytes() expect (bytes memory);
+}
+
+function CVL_quote() returns LayerZeroTeller.MessagingFee {
+    LayerZeroTeller.MessagingFee res;
+    return res;
+}
+
+function CVL_lzSend() returns LayerZeroTeller.MessagingReceipt {
+    LayerZeroTeller.MessagingReceipt res;
+    return res;
+}
+
+function CVL_nondetbytes() returns bytes {
+    bytes res;
+    return res;
+}

--- a/certora/specs/setup/dispatching_LayerZeroTellerWithRateLimiting.spec
+++ b/certora/specs/setup/dispatching_LayerZeroTellerWithRateLimiting.spec
@@ -1,0 +1,38 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_RateProvider.spec";
+
+methods {
+
+    function OAppAuthSender._quote(uint32 _dstEid, bytes memory _message, bytes memory _options, bool _payInLzToken) internal returns (LayerZeroTellerWithRateLimiting.MessagingFee memory)
+        => CVL_quote();
+
+    function OAppAuthSender._lzSend(
+        uint32 _dstEid,
+        bytes memory _message,
+        bytes memory _options,
+        LayerZeroTellerWithRateLimiting.MessagingFee memory _fee,
+        address _refundAddress
+    ) internal returns (LayerZeroTellerWithRateLimiting.MessagingReceipt memory)
+        => CVL_lzSend();
+
+    function _.setDelegate(address) external => NONDET;
+
+    function _.addExecutorLzReceiveOption(bytes memory, uint128, uint128) internal
+        => CVL_nondetbytes() expect (bytes memory);
+}
+
+function CVL_quote() returns LayerZeroTellerWithRateLimiting.MessagingFee {
+    LayerZeroTellerWithRateLimiting.MessagingFee res;
+    return res;
+}
+
+function CVL_lzSend() returns LayerZeroTellerWithRateLimiting.MessagingReceipt {
+    LayerZeroTellerWithRateLimiting.MessagingReceipt res;
+    return res;
+}
+
+function CVL_nondetbytes() returns bytes {
+    bytes res;
+    return res;
+}

--- a/certora/specs/setup/dispatching_TellerWithBuffer.spec
+++ b/certora/specs/setup/dispatching_TellerWithBuffer.spec
@@ -1,0 +1,5 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_RateProvider.spec";
+
+methods {}

--- a/certora/specs/setup/dispatching_TellerWithMultiAssetSupport.spec
+++ b/certora/specs/setup/dispatching_TellerWithMultiAssetSupport.spec
@@ -1,0 +1,7 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_ERC20_BoringVault.spec";
+import "snippet_ERC20_Mock.spec";
+import "snippet_RateProvider.spec";
+
+methods {}

--- a/certora/specs/setup/dispatching_TellerWithYieldStreaming.spec
+++ b/certora/specs/setup/dispatching_TellerWithYieldStreaming.spec
@@ -1,0 +1,5 @@
+import "snippet_Authority.spec";
+import "snippet_ERC20.spec";
+import "snippet_RateProvider.spec";
+
+methods {}

--- a/certora/specs/setup/snippet_Authority.spec
+++ b/certora/specs/setup/snippet_Authority.spec
@@ -1,0 +1,13 @@
+methods {
+    function _.canCall(
+        address user,
+        address target,
+        bytes4 functionSig
+    ) external => CVL_canCall(user, target, functionSig) expect bool;
+}
+
+ghost mapping(address => mapping(address => mapping(bytes4 => bool))) ghost_canCall;
+
+function CVL_canCall(address user, address target, bytes4 functionSig) returns bool {
+    return ghost_canCall[user][target][functionSig];
+}

--- a/certora/specs/setup/snippet_ERC20.spec
+++ b/certora/specs/setup/snippet_ERC20.spec
@@ -1,0 +1,18 @@
+using ERC20Mock as ERC20Mock;
+
+methods {
+    function _.allowance(address,address) external
+        => DISPATCH(optimistic=true) [ ERC20Mock.allowance(address,address) ];
+    function _.approve(address,uint256) external
+        => DISPATCH(optimistic=true) [ ERC20Mock.approve(address,uint256) ];
+    function _.decimals() external
+        => DISPATCH(optimistic=true) [ ERC20Mock.decimals() ];
+    function _.transfer(address,uint256) external
+        => DISPATCH(optimistic=true) [ ERC20Mock.transfer(address,uint256) ];
+    function _.transferFrom(address,address,uint256) external
+        => DISPATCH(optimistic=true) [ ERC20Mock.transferFrom(address,address,uint256) ];
+    function _.permit(address,address,uint256,uint256,uint8,bytes32,bytes32) external
+        => DISPATCH(optimistic=true) [ ERC20Mock.permit(address,address,uint256,uint256,uint8,bytes32,bytes32) ];
+    function _.totalSupply() external
+        => DISPATCH(optimistic=true) [ ERC20Mock.totalSupply() ];
+}

--- a/certora/specs/setup/snippet_ERC20_BoringVault.spec
+++ b/certora/specs/setup/snippet_ERC20_BoringVault.spec
@@ -1,0 +1,19 @@
+using BoringVault as BoringVault;
+
+methods {
+    function BoringVault.totalSupply() external returns uint256 envfree;
+    function BoringVault.balanceOf(address) external returns uint256 envfree;
+    function BoringVault.decimals() external returns uint8 envfree;
+}
+
+ghost mapping(address => uint256) ERC20_balance_BoringVault;
+
+hook Sstore BoringVault.balanceOf[KEY address addr] uint256 balance (uint256 before) {
+    ERC20_balance_BoringVault[addr] = balance;
+}
+hook Sload uint256 balance BoringVault.balanceOf[KEY address addr] {
+    require(ERC20_balance_BoringVault[addr] == balance);
+}
+
+invariant totalSupplyHolds_BoringVault()
+    BoringVault.totalSupply() >= (usum address a. ERC20_balance_BoringVault[a]);

--- a/certora/specs/setup/snippet_ERC20_Mock.spec
+++ b/certora/specs/setup/snippet_ERC20_Mock.spec
@@ -1,0 +1,17 @@
+//import "erc20cvl.spec";
+
+methods {
+    function ERC20Mock.totalSupply() external returns uint256 envfree;
+}
+
+ghost mapping(address => uint256) ERC20_balance_ERC20Mock;
+
+hook Sstore ERC20Mock.balanceOf[KEY address addr] uint256 balance (uint256 before) {
+    ERC20_balance_ERC20Mock[addr] = balance;
+}
+hook Sload uint256 balance ERC20Mock.balanceOf[KEY address addr] {
+    require(ERC20_balance_ERC20Mock[addr] == balance);
+}
+
+invariant totalSupplyHolds_ERC20Mock()
+    ERC20Mock.totalSupply() >= (usum address a. ERC20_balance_ERC20Mock[a]);

--- a/certora/specs/setup/snippet_RateProvider.spec
+++ b/certora/specs/setup/snippet_RateProvider.spec
@@ -1,0 +1,11 @@
+using RateProviderMock as RateProviderMock;
+
+methods {
+
+    function _.getRate() external => DISPATCHER(true);
+
+    unresolved external in GenericRateProvider.getRate() => 
+        DISPATCH(optimistic=true) [RateProviderMock.getRate(bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32)];
+    unresolved external in GenericRateProviderWithDecimalScaling.getRate() => 
+        DISPATCH(optimistic=true) [RateProviderMock.getRate(bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32,bytes32)];
+}

--- a/certora/specs/teller_accounting_easyRules.spec
+++ b/certora/specs/teller_accounting_easyRules.spec
@@ -1,0 +1,163 @@
+import "teller_basic.spec";
+
+persistent ghost bool callMade;
+persistent ghost bool delegatecallMade;
+
+hook CALL(uint g, address addr, uint value, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    if (addr != vault_contract
+        && addr != accountant_contract
+        && addr != ERC20Mock) 
+    {
+        // TODO whitelist the asset.. e.g whenever the asset is passed to deposit, e.g.) {
+        callMade = true;
+    }
+}
+
+hook DELEGATECALL(uint g, address addr, uint argsOffset, uint argsLength, uint retOffset, uint retLength) uint rc {
+    delegatecallMade = true;
+}
+
+/*
+This rule proves there are no instances in the code in which the user can act as the contract.
+By proving this rule we can safely assume in our spec that e.msg.sender != currentContract.
+*/
+rule noDynamicCalls(env e, method f)
+    filtered { f -> !ignoredMethod(f) 
+        && f.selector != 3395204577 // LayerZeroTellerWithRateLimiting.setDelegate(address) //allowed to call on endpoint
+    }
+{
+    require !callMade && !delegatecallMade;
+
+    calldataarg args;
+    f(e, args);
+
+    assert !callMade && !delegatecallMade;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////           #  asset-to-shares mathematical properties                  /////
+////////////////////////////////////////////////////////////////////////////////
+
+rule conversionOfZero {
+    address asset;
+    storage init = lastStorage;
+    uint256 amount;
+    uint256 convertZeroShares = convertToAssets(init, amount, asset);
+    uint256 convertZeroAssets = convertToShares(init, amount, asset);
+
+    assert amount == 0 => convertZeroShares == 0,
+        "converting zero shares must return zero assets";
+    assert amount == 0 => convertZeroAssets == 0,
+        "converting zero assets must return zero shares";
+}
+
+rule conversionWeakMonotonicity_assets {
+    safeAssumptions();
+    uint256 smallerAssets; uint256 largerAssets;
+    storage init = lastStorage; address asset;
+
+    uint256 smallerShares = convertToShares(init, smallerAssets, asset); 
+    uint256 largerShares = convertToShares(init, largerAssets, asset);
+
+    assert smallerAssets < largerAssets => smallerShares <= largerShares,
+        "converting more assets must yield equal or greater shares";
+}
+
+rule conversionWeakMonotonicity_shares {
+    safeAssumptions();
+    uint256 smallerShares; uint256 largerShares;
+    storage init = lastStorage; address asset;
+
+    uint256 smallerAssets = convertToAssets(init, smallerShares, asset); 
+    uint256 largerAssets = convertToAssets(init, largerShares, asset); 
+    
+    assert smallerShares < largerShares => smallerAssets <= largerAssets,
+        "converting more shares must yield equal or greater assets";
+}
+
+rule conversionWeakIntegrity_shares() {
+    safeAssumptions();
+    uint256 shares_pre; address asset;
+    uint assets = convertToAssets(lastStorage, shares_pre, asset);
+    uint shares_post = convertToShares(lastStorage, assets, asset);
+    assert shares_post <= shares_pre,
+        "converting shares to assets then back to shares must return shares less than or equal to the original amount";
+}
+
+rule conversionWeakIntegrity_assets() {
+    safeAssumptions();
+    uint256 assets_pre; address asset;
+    uint shares = convertToShares(lastStorage, assets_pre, asset);
+    uint assets_post = convertToAssets(lastStorage, shares, asset);
+
+    assert assets_post <= assets_pre,
+        "converting assets to shares then back to assets must return assets less than or equal to the original amount";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////                       #   Risk Analysis                           /////////
+////////////////////////////////////////////////////////////////////////////////
+
+// Runs on teller only
+// There are other ways to set allowance directly on the vault
+invariant zeroAllowanceOnAssets(env e, address user, address asset)
+    asset.allowance(e, currentContract, user) == 0
+filtered { f -> f.contract == teller_contract } 
+{
+    preserved with (env e2) {
+        nonSceneAddress(e2.msg.sender);
+    }
+    preserved constructor() 
+    {
+        // we assume the allowance was not present before calling the constructor
+        // i.e. we're checking that it's not set by the constructor
+        require asset.allowance(e, currentContract, user) == 0;
+    }
+}
+
+rule onlyContributionMethodsReduceAssets(env e, method f) 
+    filtered { f -> f.contract == teller_contract }
+{
+    safeAssumptions();
+    address user; nonSceneAddress(user);
+    address asset; require asset != vault_contract;
+    uint256 userAssetsBefore = userAssets(e, asset, user);
+
+    calldataarg args;
+    f(e, args);
+
+    uint256 userAssetsAfter = userAssets(e, asset, user);
+
+    assert userAssetsBefore > userAssetsAfter =>
+        (f.selector == sig:deposit(address, uint256, uint256,address).selector 
+        || f.selector == sig:depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
+        || f.selector == sig:bulkDeposit(address,uint256,uint256,address).selector
+        || f.selector == 4172789357 // sig:depositAndBridge(..).selector
+        || f.selector == 1539645794 // sig:depositAndBridgeWithPermit(..).selector
+),
+        "a user's assets must not go down except on calls to contribution methods or calls directly to the asset.";
+}
+
+rule withdrawingProducesAssets(env e)
+{
+    uint256 shares; address asset;
+    address receiver; address owner = e.msg.sender;
+    uint256 minimumAssets;
+    require currentContract != e.msg.sender
+         && currentContract != receiver
+         && currentContract != owner
+         && minimumAssets > 0  //otherwise it's possible to loose dust shares and not receive any asset because of rounding
+         && receiver != vault_contract;
+
+    uint256 ownerSharesBefore = vault_contract.balanceOf(owner);
+    uint256 receiverAssetsBefore = userAssets(e, asset, receiver);
+
+    uint256 assetsReceived = withdraw(e, asset, shares, minimumAssets, receiver);
+
+    uint256 ownerSharesAfter = vault_contract.balanceOf(owner);
+    uint256 receiverAssetsAfter = userAssets(e, asset, receiver);
+
+    assert ownerSharesBefore > ownerSharesAfter <=> receiverAssetsBefore < receiverAssetsAfter,
+        "an owner's shares must decrease if and only if the receiver's assets increase";
+}
+

--- a/certora/specs/teller_accounting_hardRules.spec
+++ b/certora/specs/teller_accounting_hardRules.spec
@@ -1,0 +1,374 @@
+import "teller_basic.spec";
+
+rule convertToAssetsWeakAdditivity() {
+    uint256 sharesA; uint256 sharesB; uint256 assetsA; uint256 assetsB;
+    uint sharesAPlusB = require_uint256(sharesA + sharesB); uint256 assetsAPlusB;
+    storage init = lastStorage; address asset;
+    assetsA = convertToAssets(init, sharesA, asset);
+    assetsB = convertToAssets(init, sharesB, asset);
+    assetsAPlusB = convertToAssets(init, sharesAPlusB, asset);
+
+    require sharesA + sharesB < max_uint128
+         && assetsA + assetsB < max_uint256
+         && assetsAPlusB < max_uint256;
+
+    assert assetsA + assetsB <= assetsAPlusB,
+        "converting sharesA and sharesB to assets then summing them must yield a smaller or equal result to summing them then converting";
+}
+
+rule convertToSharesWeakAdditivity() {
+    uint256 assetsA; uint256 assetsB; uint256 sharesA; uint256 sharesB;
+    uint assetsAPlusB = require_uint256(assetsA + assetsB); uint256 sharesAPlusB;
+
+    storage init = lastStorage; address asset;
+    sharesA = convertToShares(init, assetsA, asset);
+    sharesB = convertToShares(init, assetsB, asset);
+    sharesAPlusB = convertToShares(init, assetsAPlusB, asset);
+
+    require sharesA + sharesB < max_uint128
+         && assetsA + assetsB < max_uint256
+         && sharesAPlusB < max_uint256;
+
+    assert sharesA + sharesB <= sharesAPlusB,
+        "converting assetsA and assetsB to shares then summing them must yield a smaller or equal result to summing them then converting";
+}
+
+
+// total value of all asset the Vault holds must be greater or equal to total value of all shares
+// where valueOf(shares) = shares * rate(asset) / ONE_SHARE
+function isSolvent(env e) returns bool
+{
+    //assets1 * oneShare / rate(asset1) + assets2 * oneShare / rate(asset2)  >= totalShares
+
+    //without division:
+    //assets1 * oneShare * rate(asset2) + assets2 * oneShare * rate(asset1) >= totalShares * rate(asset1) * rate(asset2)
+    //(assets1 * rate(asset2) + assets2 * rate(asset1)) * oneShare >= totalShares * rate(asset1) * rate(asset2)
+    
+    mathint rate1 = accountant_contract.getRateInQuoteSafe(e, ERC20Mock);
+    mathint rate2 = accountant_contract.getRateInQuoteSafe(e, WETH);
+
+    mathint value = userAssets(e, ERC20Mock, vault_contract) * rate2
+                  + userAssets(e, WETH, vault_contract) * rate1;
+    return value * teller_contract.ONE_SHARE >= vault_contract.totalSupply(e) * rate1 * rate2;
+}
+
+invariant vaultSolvency(address asset, env e)
+    isSolvent(e)
+filtered { f -> !ignoredMethod(f)
+    && f.contract == teller_contract  //funds could be moved by methods called on the Vault or on the Asset
+    && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the refunder is the vault
+}
+{
+    preserved with (env e2) {
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+}
+
+invariant assetsMoreThanShares(env e)
+    accountant_contract.totalAssets(e) + 1 >= vault_contract.totalSupply()
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+        && isPublicMethod(f)
+    }
+    {
+    preserved with (env e2) {
+        requireAllInvariants(e2);
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+
+        //requireSmallNumbers_Unsafe(e2);
+    }
+}
+
+invariant sharePriceBoundedUpper(env e)
+    accountant_contract.vestingState.lastSharePrice * vault_contract.totalSupply() <= 
+        (accountant_contract.totalAssets(e)+1) * teller_contract.ONE_SHARE
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)
+        //&& f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+        //&& f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+    }
+    {
+    preserved with (env e2) {
+        requireAllInvariants(e2);
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+}
+
+invariant sharePriceBoundedUpper_strict(env e)
+    accountant_contract.vestingState.lastSharePrice * vault_contract.totalSupply() <= 
+        (accountant_contract.totalAssets(e)) * teller_contract.ONE_SHARE
+filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+        && (
+            f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+            || f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+        )
+        
+    }
+    {
+    preserved with (env e2) {
+        requireAllInvariants(e2);
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+        
+        requireSmallNumbers_Unsafe(e2);
+        //require vault_contract.totalSupply() > 0;
+    }
+    preserved deposit(address add, uint256 amount, uint256 minShares, address ref) with (env e2) {
+            requireAllInvariants(e2);
+            safeAssumptions();
+            nonSceneAddress(e2.msg.sender);
+            requireSmallNumbers_Unsafe(e2);
+            //require vault_contract.totalSupply() > 0;
+            require amount < 1000;
+        }
+
+}
+
+invariant sharePriceBoundedLower(env e)
+    (accountant_contract.vestingState.lastSharePrice) * vault_contract.totalSupply() >= 
+        (accountant_contract.totalAssets(e)) * teller_contract.ONE_SHARE
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract)  //funds could be moved by methods called on the Vault or on the Asset
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+        //&& f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+        //&& f.selector == sig:teller_contract.depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
+        //&& f.selector == sig:teller_contract.bulkDeposit(address,uint256,uint256,address).selector
+        //&& f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+        //&& f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector
+        //&& !isPublicMethod(f)
+}
+    {
+    preserved with (env e2) {
+        //require accountant_contract.supplyObservation.cumulativeSupply <= vault_contract.totalSupply();
+
+        requireAllInvariants(e2);
+
+        require e2.block.timestamp == e.block.timestamp;
+        require accountant_contract.getPendingVestingGains(e2) <= vault_contract.totalSupply();
+        //require vault_contract.totalSupply() > 0; //the initial state uses the lastSharePrice directly that could be incorrectly initialized
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+}
+
+invariant sharePriceMoreThanOneAsset()
+    accountant_contract.vestingState.lastSharePrice >= 10^vault_contract.decimals
+    
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract)  //funds could be moved by methods called on the Vault or on the Asset
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+        //&& f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+        //&& f.selector == sig:teller_contract.depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
+        //&& f.selector == sig:teller_contract.bulkDeposit(address,uint256,uint256,address).selector
+        //&& f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+        //&& f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector
+        //&& !isPublicMethod(f)
+    }
+{ preserved with (env e2) {
+        requireAllInvariants(e2);
+
+        require accountant_contract.getPendingVestingGains(e2) <= vault_contract.totalSupply();
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+    }
+}
+
+invariant totalAssetsCovered(env e)
+    accountant_contract.totalAssets(e) <= userAssets(e, ERC20Mock, vault_contract) 
+    
+    filtered 
+    { f -> !ignoredMethod(f)
+        && (f.contract == teller_contract || f.contract == accountant_contract)
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+        //&& f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+        //&& f.selector == sig:teller_contract.depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
+        //&& f.selector == sig:teller_contract.bulkDeposit(address,uint256,uint256,address).selector
+        //&& f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+        //&& f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector
+        //&& !isPublicMethod(f)
+}
+    {
+    preserved with (env e2) {
+        //require accountant_contract.supplyObservation.cumulativeSupply <= vault_contract.totalSupply();
+
+        requireAllInvariants(e2);
+
+        require e2.block.timestamp == e.block.timestamp;
+        require accountant_contract.getPendingVestingGains(e2) <= vault_contract.totalSupply();
+        require vault_contract.totalSupply() > 0; //the initial state uses the lastSharePrice directly that could be incorrectly initialized
+        require teller_contract.ONE_SHARE == 1000000;
+
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+
+    }
+}
+
+invariant vaultSolvency_1Asset(env e)
+    (userAssets(e, ERC20Mock, vault_contract) - accountant_contract.getPendingVestingGains(e)) * teller_contract.ONE_SHARE 
+        >= (vault_contract.totalSupply(e)) * (accountant_contract.getRateInQuoteSafe(e, ERC20Mock)) 
+    
+filtered { f -> !ignoredMethod(f)
+    && (f.contract == teller_contract || f.contract == accountant_contract)
+    && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector // can break if the sharesAmount is too low. This can happen since we don't really track the sum of deposits and their shares in publicDepositHistory
+
+    //&& f.selector == sig:teller_contract.deposit(address, uint256, uint256,address).selector 
+    //&& f.selector == sig:teller_contract.depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
+    //&& f.selector == sig:teller_contract.bulkDeposit(address,uint256,uint256,address).selector
+    //&& f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector
+    //&& f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector
+    //&& isPublicMethod(f)
+}
+{
+    preserved with (env e2) {
+        requireAllInvariants(e2);
+        
+        require e2.block.timestamp == e.block.timestamp;
+
+        safeAssumptions();
+        nonSceneAddress(e2.msg.sender);
+        //require vault_contract.totalSupply() > 0;
+        //requireSmallNumbers_Unsafe(e2);
+        //require accountant_contract.getPendingVestingGains(e) == 0;
+    }
+    preserved constructor()
+    {
+        require accountant_contract.getPendingVestingGains(e) == 0;
+    }
+}
+
+invariant exchangeRateEqlastSharePrice()
+    accountant_contract.accountantState.exchangeRate == 
+        accountant_contract.vestingState.lastSharePrice
+    
+    filtered { f -> !ignoredMethod(f) }
+    { preserved with (env e2) { 
+        requireAllInvariants(e2);
+        safeAssumptions(); }
+}
+
+invariant cumulativeSupplyBounded()
+    accountant_contract.supplyObservation.cumulativeSupplyLast <= 
+        accountant_contract.supplyObservation.cumulativeSupply
+    filtered { f -> !ignoredMethod(f)
+}
+
+invariant exchangeRateLEhighwaterMark_unlessPaused()
+    (!accountant_contract.accountantState.isPaused => 
+        accountant_contract.accountantState.exchangeRate <= accountant_contract.accountantState.highwaterMark)
+    
+    filtered { f -> !ignoredMethod(f)
+        && f.selector != sig:accountant_contract.unpause().selector 
+        //&& f.selector == sig:accountant_contract.postLoss(uint256).selector
+        }
+    { preserved with(env e) { 
+        safeAssumptions(); 
+        requireInvariant exchangeRateEqlastSharePrice();
+        
+        //require accountant_contract.getPendingVestingGains(e) * accountant_contract.ONE_SHARE <= (max_uint96 - accountant_contract.vestingState.lastSharePrice) * vault_contract.totalSupply();
+        //require getPendingVestingGains(e) <= vault_contract.totalSupply();
+        }
+        preserved constructor() {
+            require accountant_contract.accountantState.highwaterMark ==
+                accountant_contract.accountantState.exchangeRate;
+        }
+}
+
+invariant virtualPriceIsCorrect()
+    accountant_contract.vestingState.lastSharePrice == 
+    accountant_contract.lastVirtualSharePrice * accountant_contract.ONE_SHARE / 10^27
+    { preserved with(env e) { 
+        safeAssumptions(); 
+        requireAllInvariants(e);
+    }
+}
+
+rule noFreeAssets(env e)
+{
+    safeAssumptions();
+    requireAllInvariants(e);
+    nonSceneAddress(e.msg.sender);
+    
+    //requireSmallNumbers_Unsafe(e);
+
+    address asset; uint256 assetsAmount;
+    //require assetsAmount < 10^6;
+    //require accountant_contract.vestingState.vestingGains > 0;
+    //uint shares = deposit(e, asset, assetsAmount, minShares, e.msg.sender); 
+    uint shares = bulkDeposit(e, asset, assetsAmount, 0, e.msg.sender); 
+    
+    //uint assetsReceived = withdraw(e, asset,shares,minAssets,e.msg.sender);
+    uint assetsReceived = bulkWithdraw(e,asset,shares, 0 ,e.msg.sender);
+
+    //satisfy assetsReceived > assetsAmount + 1 * teller_contract.ONE_SHARE;
+    //satisfy assetsReceived > assetsAmount;
+    assert assetsReceived <= assetsAmount;
+}
+
+function requireAllInvariants(env e)
+{
+    // these hold
+    requireInvariant exchangeRateLEhighwaterMark_unlessPaused();
+    requireInvariant sharePriceBoundedLower(e);
+    requireInvariant exchangeRateEqlastSharePrice();
+    requireInvariant cumulativeSupplyBounded();
+    requireInvariant sharePriceBoundedUpper(e);
+    requireInvariant sharePriceMoreThanOneAsset(); // doesnt hold after the constructor
+    requireInvariant assetsMoreThanShares(e);
+    requireInvariant totalAssetsCovered(e);
+    requireInvariant vaultSolvency_1Asset(e);
+    
+    requireInvariant virtualPriceIsCorrect();
+
+    // holds as an invariant accountantDecimalsCorrect
+    require accountant_contract.decimals == accountant_contract.base.decimals(e); 
+    require accountant_contract.base == ERC20Mock;
+
+    require teller_contract.assetData[ERC20Mock].sharePremium == 0;    
+}
+
+function requireSmallNumbers_Unsafe(env e)
+{
+    require teller_contract.ONE_SHARE == 1000;
+    require accountant_contract.vestingState.lastSharePrice <= 100000; 
+
+    require userAssets(e, ERC20Mock, vault_contract) < 10000000;
+    require userAssets(e, ERC20Mock, vault_contract) > 1000;
+
+    require vault_contract.totalSupply(e) < 10000000;
+    require vault_contract.totalSupply(e) > 10000;
+
+    //require accountant_contract.vestingState.vestingGains == 0;
+}
+
+
+rule vaultSolvency_1Asset_test(env e)
+{
+    safeAssumptions();
+    nonSceneAddress(e.msg.sender);
+    require (userAssets(e, ERC20Mock, vault_contract) - accountant_contract.getPendingVestingGains(e)) * teller_contract.ONE_SHARE 
+        >= (vault_contract.totalSupply(e)) * (accountant_contract.getRateInQuoteSafe(e, ERC20Mock)); 
+
+    require accountant_contract.totalAssets(e) == 12000000002;
+    require vault_contract.totalSupply(e) == 10000000002;
+
+    require accountant_contract.getRateInQuoteSafe(e, ERC20Mock) == 1199999;
+
+    uint256 assetsAmount = 21000000;
+    uint shares = deposit(e, ERC20Mock, assetsAmount, 0, e.msg.sender); 
+
+    assert (userAssets(e, ERC20Mock, vault_contract) - accountant_contract.getPendingVestingGains(e)) * teller_contract.ONE_SHARE 
+        >= (vault_contract.totalSupply(e)) * (accountant_contract.getRateInQuoteSafe(e, ERC20Mock)); 
+    
+}

--- a/certora/specs/teller_basic.spec
+++ b/certora/specs/teller_basic.spec
@@ -1,0 +1,206 @@
+import "setup.spec";
+import "accountant_basic.spec";
+
+// refundDeposit is whitelisted: denied user can still be refunded. E.g. user deposits, then gets denied, then gets refunded.
+// denied users can still withdraw
+rule deniedUsers_balanceNonDecreasing(env e, method f)
+    filtered { f -> !ignoredMethod(f) 
+        && f.selector != sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector
+        && f.selector != sig:teller_contract.withdraw(address,uint256,uint256,address).selector 
+        && f.selector != sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector
+        && f.contract != vault_contract }
+{
+    safeAssumptions();
+    if (f.selector != sig:accountant_contract.claimFees(address).selector)
+        nonSceneAddress(e.msg.sender);   // the claimFees can only be called by the Vault so this condidtion would cause vacuity
+
+    address user; nonSceneAddress(user);
+    bool isDeniedFrom = teller_contract.beforeTransferData[user].denyFrom;
+    uint balance_pre = vault_contract.balanceOf(e, user);
+
+    calldataarg args;
+    f(e, args);
+
+    uint balance_post = vault_contract.balanceOf(e, user);
+    assert isDeniedFrom => balance_post >= balance_pre;
+}
+
+rule deniedUsers_balanceNonIncreasing(env e, method f)
+    filtered { f -> !ignoredMethod(f)
+        && f.selector != 320044389 // lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes) // 0x13137d65 // the method is allowed to break this
+        && f.contract != vault_contract }
+{
+    safeAssumptions();
+    if (f.selector != sig:accountant_contract.claimFees(address).selector)
+        nonSceneAddress(e.msg.sender);   // the claimFees can only be called by the Vault so this condidtion would cause vacuity
+
+    address user; require user != 0;
+    bool isDeniedTo = teller_contract.beforeTransferData[user].denyTo;
+    uint balance_pre = vault_contract.balanceOf(e, user);
+
+    calldataarg args;
+    f(e, args);
+    uint balance_post = vault_contract.balanceOf(e, user);
+    assert isDeniedTo => balance_post <= balance_pre;
+}
+
+invariant totalSupplyLEqCap()
+    vault_contract.totalSupply() <= teller_contract.depositCap
+        || teller_contract.depositCap == 2^112 - 1  // max uint112 means the cap is not applied
+    filtered { f -> !ignoredMethod(f)
+        && f.selector != sig:teller_contract.setDepositCap(uint112).selector // setting the cap bellow current supply is used by admins to disable further deposits
+        && f.selector != sig:vault_contract.enter(address,address,uint256,address,uint256).selector // other tellers could operate the vault and increase its totalSupply
+        // && f.selector != sig:vault_contract.exit(address,address,uint256,address,uint256).selector  // not to be called directly
+        && f.selector != 320044389 // lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes) // 0x13137d65 // the method is allowed to break this
+        }
+    { preserved { safeAssumptions();} }
+
+rule depositNonceNeverGoesDown(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    uint64 depositNonce_pre = teller_contract.depositNonce;
+
+    calldataarg args;
+    f(e, args);
+
+    uint64 depositNonce_post = teller_contract.depositNonce;
+    assert depositNonce_post >= depositNonce_pre;
+}
+
+rule dustFavorsTheHouse(uint assetsIn, env e)
+{
+    safeAssumptions();
+    //require e.msg.sender != currentContract;
+    //uint256 totalSupplyBefore = totalSupply();
+    address asset; uint minimumShares; uint minimumAssets; address referral;
+
+    uint balanceBefore = asset.balanceOf(e, vault_contract);
+
+    uint shares = deposit(e, asset, assetsIn, minimumShares, referral);
+    uint assetsOut = withdraw(e, asset, shares, minimumAssets, e.msg.sender);
+
+    uint balanceAfter = asset.balanceOf(e, vault_contract);
+
+    assert balanceAfter >= balanceBefore;
+}
+
+rule tellerDoesntHoldTokens(env e, method f)
+    filtered { f -> !ignoredMethod(f)
+        && f.contract != ERC20Mock 
+        && f.contract != vault_contract }
+{
+    safeAssumptions();
+    if (f.selector != sig:accountant_contract.claimFees(address).selector)
+        nonSceneAddress(e.msg.sender);   // the claimFees can only be called by the Vault so this condidtion would cause vacuity
+
+    address asset; require asset != vault_contract;
+    address receiver; nonSceneAddress(receiver);
+    
+    require accountant_contract.accountantState.payoutAddress != teller_contract, "otherwise the teller holds the fees, i.e. does hold tokens";
+    // todo require that the teller contract is not the target of the funds.
+
+    uint balanceBefore = asset.balanceOf(e, teller_contract);
+    callMethodWithReceiver(e, f, receiver);
+
+    uint balanceAfter = asset.balanceOf(e, teller_contract);
+
+    assert balanceAfter == balanceBefore;
+}
+
+
+rule tellerPaused_valuesFrozen(env e, method f)
+    filtered { f -> !ignoredMethod(f) &&
+        !isPublicMethod(f) // we proved that public methods revert when paused so they would just be vacuous here 
+        }
+{
+    bool paused = teller_contract.isPaused;
+    uint64 depositNonce_pre = teller_contract.depositNonce;
+    
+    uint256 historyKey;
+    bytes32 historyItem_pre = teller_contract.publicDepositHistory[historyKey];
+    // TODO add more here
+
+    calldataarg args;
+    f(e, args);
+
+    uint64 depositNonce_post = teller_contract.depositNonce;
+    bytes32 historyItem_post = teller_contract.publicDepositHistory[historyKey];
+
+    assert paused => (
+        depositNonce_post == depositNonce_pre
+        && (historyItem_post == historyItem_pre 
+            || f.selector == sig:teller_contract.refundDeposit(uint256,address,address,uint256,uint256,uint256,uint256,address).selector) //refunds are allowed during a pause
+        );
+}
+
+// public methods should revert when paused
+rule tellerPaused_methodsRevert(env e, method f)
+    filtered { f -> isPublicMethod(f) }
+{
+    require teller_contract.isPaused;
+    
+    calldataarg args;
+    f@withrevert(e, args);
+
+    assert lastReverted;
+}
+
+rule vaultCannotChange(env e, method f)
+    filtered { f -> !ignoredMethod(f) }
+{
+    address vault_pre = teller_contract.vault;
+
+    calldataarg args;
+    f(e, args);
+
+    address vault_post = teller_contract.vault;
+    assert vault_pre == vault_post;
+}
+
+
+function callMethodWithReceiver(env e, method f, address receiver)
+{
+    if (f.selector == sig:teller_contract.refundDeposit(
+        uint256,address,address,uint256,uint256,uint256,uint256,address).selector)
+    {
+        uint256 nonce; address depositAsset; uint256 depositAmount; 
+        uint256 shareAmount; uint256 depositTimestamp; 
+        uint256 shareLockUpPeriodAtTimeOfDeposit; address referral;
+        teller_contract.refundDeposit(e, nonce, receiver, depositAsset, depositAmount,
+            shareAmount, depositTimestamp, shareLockUpPeriodAtTimeOfDeposit, referral);
+    }
+    else if (f.selector == sig:teller_contract.withdraw(address,uint256,uint256,address).selector)
+    {
+        address withdrawAsset; uint256 shareAmount; uint256 minimumAssets;
+        teller_contract.withdraw(e, withdrawAsset, shareAmount, minimumAssets, receiver);
+    }
+    else if (f.selector == sig:teller_contract.bulkWithdraw(address,uint256,uint256,address).selector)
+    {
+        address withdrawAsset; uint256 shareAmount; uint256 minimumAssets;
+        teller_contract.bulkWithdraw(e, withdrawAsset, shareAmount, minimumAssets, receiver);
+    }
+    else 
+    {
+        calldataarg args;
+        f(e, args);
+    }
+}
+
+// This resembles the convertToShares method.
+function convertToShares(storage init, uint256 assets, address asset_contract) returns uint256
+{
+    env e;
+    uint256 minimumMint; address referral;
+    uint256 shares = teller_contract.deposit(e, asset_contract, assets, minimumMint, referral) at init;
+    return shares;
+}
+
+// This resembles the convertToAssets method.
+function convertToAssets(storage init, uint256 shares, address asset_contract) returns uint256
+{
+    env e;
+    uint256 minimumAssets;
+    address receiver;
+    uint256 assets = teller_contract.withdraw(e, asset_contract, shares, minimumAssets, receiver) at init;
+    return assets;
+}

--- a/certora/specs/teller_integrity.spec
+++ b/certora/specs/teller_integrity.spec
@@ -1,0 +1,96 @@
+import "teller_basic.spec";
+
+rule integrityOfDeposit(env e)
+{
+    safeAssumptions();
+    nonSceneAddress(e.msg.sender);
+    address asset; uint256 depositAmount; uint256 minimumMint; address referral;
+    mathint assetsBefore = userAssets(e, asset, e.msg.sender);
+    mathint sharesBefore = userAssets(e, vault_contract, e.msg.sender);
+
+    mathint shares = deposit(e, asset, depositAmount, minimumMint, referral);
+    
+    mathint assetsAfter = userAssets(e, asset, e.msg.sender);
+    mathint sharesAfter = userAssets(e, vault_contract, e.msg.sender);
+
+    assert shares >= minimumMint;
+    assert assetsBefore - depositAmount == assetsAfter;
+    assert sharesBefore + shares == sharesAfter;
+}
+
+rule integrityOfDepositWithPermit(env e)
+{
+    safeAssumptions();
+    nonSceneAddress(e.msg.sender);
+    address asset; uint256 depositAmount; uint256 minimumMint;
+    uint256 deadline; uint8 v; bytes32 r; bytes32 s; address referral;
+
+    mathint assetsBefore = userAssets(e, asset, e.msg.sender);
+    mathint sharesBefore = userAssets(e, vault_contract, e.msg.sender);
+
+    mathint shares = depositWithPermit(e, asset, depositAmount, minimumMint,
+        deadline, v, r, s, referral);
+    
+    mathint assetsAfter = userAssets(e, asset, e.msg.sender);
+    mathint sharesAfter = userAssets(e, vault_contract, e.msg.sender);
+
+    assert shares >= minimumMint;
+    assert assetsBefore - depositAmount == assetsAfter;
+    assert sharesBefore + shares == sharesAfter;
+}
+
+rule integrityOfBulkDeposit(env e)
+{
+    safeAssumptions();
+    nonSceneAddress(e.msg.sender);
+    address asset; uint256 depositAmount; uint256 minimumMint; address receiver;
+    mathint assetsBefore = userAssets(e, asset, e.msg.sender);
+    mathint sharesBefore = userAssets(e, vault_contract, receiver);
+
+    mathint shares = bulkDeposit(e, asset, depositAmount, minimumMint, receiver);
+    
+    mathint assetsAfter = userAssets(e, asset, e.msg.sender);
+    mathint sharesAfter = userAssets(e, vault_contract, receiver);
+
+    assert shares >= minimumMint;
+    assert assetsBefore - depositAmount == assetsAfter;
+    assert sharesBefore + shares == sharesAfter;
+}
+
+rule integrityOfWithdraw(env e)
+{
+    safeAssumptions();
+    nonSceneAddress(e.msg.sender);
+    address asset; uint256 sharesAmount; uint256 minimumAssets; address receiver;
+    require asset != vault_contract && receiver != vault_contract;
+    mathint sharesBefore = userAssets(e, vault_contract, e.msg.sender);
+    mathint assetsBefore = userAssets(e, asset, receiver);
+
+    mathint assets = withdraw(e, asset, sharesAmount, minimumAssets, receiver);
+    
+    mathint sharesAfter = userAssets(e, vault_contract, e.msg.sender);
+    mathint assetsAfter = userAssets(e, asset, receiver);
+
+    assert assets >= minimumAssets;
+    assert sharesBefore - sharesAmount == sharesAfter;
+    assert assetsBefore + assets == assetsAfter;
+}
+
+rule integrityOfBulkWithdraw(env e)
+{
+    safeAssumptions();
+    nonSceneAddress(e.msg.sender);
+    address asset; uint256 sharesAmount; uint256 minimumAssets; address receiver;
+    require asset != vault_contract && receiver != vault_contract;
+    mathint sharesBefore = userAssets(e, vault_contract, e.msg.sender);
+    mathint assetsBefore = userAssets(e, asset, receiver);
+
+    mathint assets = bulkWithdraw(e, asset, sharesAmount, minimumAssets, receiver);
+    
+    mathint sharesAfter = userAssets(e, vault_contract, e.msg.sender);
+    mathint assetsAfter = userAssets(e, asset, receiver);
+
+    assert assets >= minimumAssets;
+    assert sharesBefore - sharesAmount == sharesAfter;
+    assert assetsBefore + assets == assetsAfter;
+}


### PR DESCRIPTION
## Summary

Adds the Certora formal verification work performed against `dev/oct-2025`. All FV artifacts live under a new `certora/` directory; CI is wired up via per-scenario workflow files.

## Scope (5 verification scenarios)

| Scenario | Contract under verification |
|---|---|
| A | `TellerWithMultiAssetSupport` |
| B | `TellerWithBuffer` |
| C | `TellerWithYieldStreaming` + `AccountantWithYieldStreaming` |
| D | `LayerZeroTeller` |
| E | `LayerZeroTellerWithRateLimiting` |

Plus standalone verification of `AccountantWithRateProviders`.

## What's included

- **`certora/`** — confs, harnesses, mocks, scripts, and specs for the five scenarios.
- **`.github/workflows/certoraA.yml` … `certoraE.yml`** — PR-triggered Certora Prover runs (one per scenario).
- **`.gitignore`** — ignore Certora artifacts (`.certora_internal/`, `.properties-*/`, `emv-*-certora-*/`).

## What's intentionally not included

- No changes to existing Veda contracts, deployment scripts, leafs, or tests.

## Required to run CI

The new workflows call the [`Certora/certora-run-action`](https://github.com/Certora/certora-run-action) and require a repo secret named **`CERTORAKEY`** to be set on `Veda-Labs/boring-vault`. Without it the Certora_FV_* checks will fail to authenticate against the Prover.

## Local run

```bash
certora/scripts/setup.sh <A|B|C|D|E>   # munge for the chosen scenario
certora/scripts/run.sh                 # run a config locally
```

## Source

Certora work was performed on `Certora/veda-boring-vault-private` branch `certora`. This PR rebases that work cleanly onto current `dev/oct-2025` as a single commit (50 files, +2520 lines, no deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)