### PR TITLE
HypeEVM bytecode verification

### DIFF
--- a/deployments/addresses/HypeEVM/kHYPE.json
+++ b/deployments/addresses/HypeEVM/kHYPE.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x345BB6a4249419e34a7C750B90178Fc7B2e4c50f",
     "TellerWithMultiAssetSupport": "0x29C0C36eD3788F1549b6a1fd78F40c51F0f73158",
     "Timelock": "0xf86604d4cbc10796522605298C4BD864fCF9d032"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditUrl": "file:audit/certora-boring-vault-1.pdf",
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verification": "full_match",
+      "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "c3dde9653a59ffbb52fd0d3493c5ceaa5850dab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-45",
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Backfills `contractMetadata` into `deployments/addresses/HypeEVM/kHYPE.json`
- 10/10 contracts: `full_match` with `verificationGap: cbor`
- Tool: bundle-anchored creation-bytes verifier (`verify_sonic_bundle.py`)
- All contracts deployed via canonical Veda Deployer `0x5F2F11ad…` + `bundleTxs` in a single bundle at block 8152399 (2025-07-11)

## Verified commits

| Contract | verifiedCommit |
|---|---|
| AccountantWithRateProviders | `568d9467` |
| BoringOnChainQueue | `568d9467` |
| BoringVault | `3c768bd0` |
| Lens | `568d9467` |
| ManagerWithMerkleVerification | `b7ad4066` |
| Pauser | `568d9467` |
| QueueSolver | `568d9467` |
| RolesAuthority | `568d9467` |
| TellerWithMultiAssetSupport | `c54949f5` |
| Timelock | `568d9467` |

`verificationGap: cbor` on all — creation-code bytes matched exactly; CBOR metadata trailer differs (build-path drift only, harmless).

## Test plan

- [ ] JSON is valid and all 10 entries have `"verification": "full_match"`
- [ ] `verifiedCommit` values resolve in boring-vault git history

🤖 Generated with [Claude Code](https://claude.com/claude-code)