### PR TITLE
Mainnet bytecode verification: verify 14 LayerZero-teller stragglers

### DIFF
--- a/deployments/addresses/Mainnet/BTCNDeployment.json
+++ b/deployments/addresses/Mainnet/BTCNDeployment.json
@@ -72,8 +72,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Mainnet/InkedUSDTHY.json
+++ b/deployments/addresses/Mainnet/InkedUSDTHY.json
@@ -67,8 +67,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/LBTCvKatanaDeployment.json
+++ b/deployments/addresses/Mainnet/LBTCvKatanaDeployment.json
@@ -66,8 +66,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Mainnet/LiquidBeraBTC.json
+++ b/deployments/addresses/Mainnet/LiquidBeraBTC.json
@@ -72,8 +72,9 @@
     "LayerZeroTellerWithRateLimiting": {
       "auditCommit": null,
       "auditUrl": null,
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/LiquidBeraETH.json
+++ b/deployments/addresses/Mainnet/LiquidBeraETH.json
@@ -72,8 +72,9 @@
     "LayerZeroTellerWithRateLimiting": {
       "auditCommit": null,
       "auditUrl": null,
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/LiquidKatana.json
+++ b/deployments/addresses/Mainnet/LiquidKatana.json
@@ -72,8 +72,9 @@
     "TellerWithLayerZeroRateLimiting": {
       "auditCommit": null,
       "auditUrl": null,
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Mainnet/LtacBTC.json
+++ b/deployments/addresses/Mainnet/LtacBTC.json
@@ -71,8 +71,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "7fb689d55d2a535b4c52388c49736629ff111a82",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/PlasmaUSD.json
+++ b/deployments/addresses/Mainnet/PlasmaUSD.json
@@ -71,8 +71,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/PrimeGoldenGoose.json
+++ b/deployments/addresses/Mainnet/PrimeGoldenGoose.json
@@ -60,8 +60,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Mainnet/SonicETH.json
+++ b/deployments/addresses/Mainnet/SonicETH.json
@@ -72,8 +72,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/SonicUSD.json
+++ b/deployments/addresses/Mainnet/SonicUSD.json
@@ -72,8 +72,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/SteakhouseUSD.json
+++ b/deployments/addresses/Mainnet/SteakhouseUSD.json
@@ -72,8 +72,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,

--- a/deployments/addresses/Mainnet/TacLBTCv.json
+++ b/deployments/addresses/Mainnet/TacLBTCv.json
@@ -67,8 +67,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c48ee76499340cb1cab9e4e5493e441d1088e7d1",
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Mainnet/VedaTestVault.json
+++ b/deployments/addresses/Mainnet/VedaTestVault.json
@@ -66,8 +66,9 @@
     "TellerWithLayerZero": {
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "verification": null,
-      "verifiedCommit": null
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
     },
     "Timelock": {
       "auditCommit": null,


### PR DESCRIPTION
## Summary

All 14 Mainnet contracts that prior campaigns left as `setup_error timeout_submodule_update` now resolve to `full_match` (cbor-gap) via the bundle-anchored verifier.

The build path that blocked these contracts is fixed in [security-scripts #12](https://github.com/Veda-Labs/security-scripts/pull/12) — required for re-running the sweep, but the resulting verifications stand on their own.

## Verified commit map

| Vault | Contract | Verified Commit |
|---|---|---|
| BTCNDeployment | TellerWithLayerZero | `b7ad4066` (sevenSeas-19) |
| InkedUSDTHY | TellerWithLayerZero | `c54949f5` (sevenSeas-47) |
| LBTCvKatanaDeployment | TellerWithLayerZero | `c54949f5` |
| LiquidKatana | TellerWithLayerZeroRateLimiting | `c54949f5` |
| PlasmaUSD | TellerWithLayerZero | `c54949f5` |
| PrimeGoldenGoose | TellerWithLayerZero | `c54949f5` |
| SonicETH | TellerWithLayerZero | `b7ad4066` |
| SonicUSD | TellerWithLayerZero | `b7ad4066` |
| SteakhouseUSD | TellerWithLayerZero | `c54949f5` |
| VedaTestVault | TellerWithLayerZero | `c54949f5` |
| LtacBTC | TellerWithLayerZero | `7fb689d5` (update OAppAuth lib) |
| TacLBTCv | TellerWithLayerZero | `c48ee764` (Deploy tacLBTCv Decoder, Generate Leafs) |
| LiquidBeraBTC | LayerZeroTellerWithRateLimiting | `c9b8b82b` (deploy new LZ tellers for liquidBera vaults) |
| LiquidBeraETH | LayerZeroTellerWithRateLimiting | `c9b8b82b` (same PR) |

10/14 matched the audit-anchored candidate list (`b7ad4066` in-scope for LayerZeroTeller + `c54949f5` from TOP_AUDIT_CANDIDATES). 4 needed a forward-walk past the audit anchors — three to dated deploy PRs, one (LtacBTC) to a submodule pin bump for OAppAuth.

Creation-bytes match at the verified commit pins immutable values via EVM determinism; only CBOR metadata differs across all 14 — the expected build-path drift, harmless under the slim-shape rule (rollup → `full_match` with `verificationGap: "cbor"`).

## Test plan

- [ ] Diff is metadata-only: `contractMetadata.<name>.verification` flips `null → full_match`, `verifiedCommit` filled, `verificationGap: cbor` added.
- [ ] No `contractAddresses` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
