### PR TITLE
Base: contractMetadata for LBTCvBaseAddresses + GoldenGoose

### DIFF
--- a/deployments/addresses/Base/GoldenGoose.json
+++ b/deployments/addresses/Base/GoldenGoose.json
@@ -11,5 +11,104 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-08-22T19:34:53Z",
+      "creationTx": "0x0231f20c7e4b59102a257401d9597ba82d505b1e20609adad1a487114c0bc311",
+      "creationBlock": 34550973,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Base/LBTCvBaseAddresses.json
+++ b/deployments/addresses/Base/LBTCvBaseAddresses.json
@@ -38,5 +38,60 @@
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
     "ShareLockPeriod": 86400
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "verificationGap": "cbor"
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "bcac7f408b96a0054e3edf82155f78d76ad652ec",
+      "verificationGap": "cbor,evm:london"
+    },
+    "DelayedWithdraw": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "bcac7f408b96a0054e3edf82155f78d76ad652ec",
+      "verificationGap": "cbor,evm:london"
+    },
+    "Lens": {
+      "auditCommit": null,
+      "auditUrl": null
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "verificationGap": "cbor"
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Base/LBTCvBaseAddresses.json
+++ b/deployments/addresses/Base/LBTCvBaseAddresses.json
@@ -87,6 +87,9 @@
     "Lens": {
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verification": "full_match",
+      "verifiedCommit": "69fa3837f651ed236b35400b69498b50e48e99e9",
+      "verificationGap": "cbor,evm:london",
       "deployedAt": "2024-07-17T00:21:35Z",
       "creationTx": "0xefdd66791154319a00982c007d00f4bec24ea13e023e14873e48c5fa6dba6318",
       "creationBlock": 17193174,

--- a/deployments/addresses/Base/LBTCvBaseAddresses.json
+++ b/deployments/addresses/Base/LBTCvBaseAddresses.json
@@ -41,57 +41,89 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
       "verification": "full_match",
       "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
-      "verificationGap": "cbor"
+      "verificationGap": "cbor",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0x8385b592bb7b8030744f48e83813b19f2972680910a732396235c6a04bfaea53",
+      "creationBlock": 22113563,
+      "scopeMatch": true
     },
     "BoringVault": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
       "verification": "full_match",
       "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
-      "verificationGap": "cbor"
+      "verificationGap": "cbor",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0x4f88e1efe73fa188c29fbdeb6991d28231fd3e0a1f53ff1c3996c69fba5a7bd2",
+      "creationBlock": 22113563,
+      "scopeMatch": true
     },
     "DecoderAndSanitizer": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
       "verification": "full_match",
       "verifiedCommit": "bcac7f408b96a0054e3edf82155f78d76ad652ec",
-      "verificationGap": "cbor,evm:london"
+      "verificationGap": "cbor,evm:london",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0xd7c29cff6ba9e19bed7a3b754c7b68600c18c74a9f207eccb410ab0e9a490a47",
+      "creationBlock": 22113563,
+      "scopeMatch": true
     },
     "DelayedWithdraw": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
       "verification": "full_match",
       "verifiedCommit": "bcac7f408b96a0054e3edf82155f78d76ad652ec",
-      "verificationGap": "cbor,evm:london"
+      "verificationGap": "cbor,evm:london",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0x3afa9f982c0a07d199572def01837fed749f8f6b24115f1e703044ca30a50838",
+      "creationBlock": 22113563,
+      "scopeMatch": true
     },
     "Lens": {
-      "auditCommit": null,
-      "auditUrl": null
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "deployedAt": "2024-07-17T00:21:35Z",
+      "creationTx": "0xefdd66791154319a00982c007d00f4bec24ea13e023e14873e48c5fa6dba6318",
+      "creationBlock": 17193174,
+      "scopeMatch": true
     },
     "ManagerWithMerkleVerification": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
       "verification": "full_match",
       "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
-      "verificationGap": "cbor"
+      "verificationGap": "cbor",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0x4ee9350684f53f93daf278d745cefdb36acaa98b9f69ad18ea76e375aee2e827",
+      "creationBlock": 22113563,
+      "scopeMatch": true
     },
     "RolesAuthority": {
       "auditCommit": null,
       "auditUrl": null,
       "verification": "full_match",
       "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
-      "verificationGap": "cbor"
+      "verificationGap": "cbor",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0x71cf1964ba5334ebaa7be6721896fbeb9251377c583bbf157885c75dd9d9dfa2",
+      "creationBlock": 22113563,
+      "scopeMatch": null
     },
     "TellerWithMultiAssetSupport": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
       "verification": "full_match",
       "verifiedCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
-      "verificationGap": "cbor"
+      "verificationGap": "cbor",
+      "deployedAt": "2024-11-07T21:54:33Z",
+      "creationTx": "0x3ec7a361844bb3df8956d0e1f0380bca1253dff49cfe58f9534e5f5413fb76b7",
+      "creationBlock": 22113563,
+      "scopeMatch": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- **LBTCvBaseAddresses** (LombardBtc): backfills `deployedAt`/`creationTx`/`creationBlock` into existing `contractMetadata` entries; adds `auditCommit`/`auditUrl`/`scopeMatch`. All 8 contracts verified (`full_match`, cbor gap or cbor+evm:london).
- **GoldenGoose**: new `contractMetadata` block for all 9 non-Timelock contracts. Deployed 2025-08-22 via veda-bundle-create3-v7 txBundler. All 9 `full_match` (cbor gap only).

## Test plan

- [ ] Both JSONs parse cleanly
- [ ] GoldenGoose: 9 entries all have `verification: full_match`, `verifiedCommit` non-null
- [ ] LBTCvBaseAddresses: 8 entries have `verification: full_match`
- [ ] `verificationGap: cbor,evm:london` on LBTCv DAS + DW + Lens reflects the known CLI evm override

---

## Forensic notes

### LBTCvBaseAddresses (deployed 2024-11-07, block 22113563; Lens deployed 2024-07-17, block 17193174)

**AccountantWithRateProviders @ `10a0dae5` (2025-02-06)**
Deploy date: 2024-11-07. auditCommit `b7ad4066` (sevenSeas-19, 2024-11-07) also matches this bytecode body — source was unchanged between Nov 2024 and Feb 2025. Sweep hit the later commit first because `auditCommit` was not pre-seeded before running. No genuine source drift; auditCommit is equally valid.

**BoringVault @ `10a0dae5` (2025-02-06)**
Same as AccountantWithRateProviders above. auditCommit `9c6e1e44` (sevenSeas-7, 2024-05-20) predates the deploy by 6 months; source was stable from at least Nov 2024 to Feb 2025 at `10a0dae5`. Sweep picked later commit.

**DecoderAndSanitizer @ `bcac7f40` (2024-11-07, evm:london)**
auditCommit `ec74b243` (sevenSeas-18, 2024-10-09). Deployed with `--evm-version london` (foundry.toml says cancun at that commit). `bcac7f40` is a deploy-script commit from the same day as the LBTCv bundle deploy; the LombardBtcDecoderAndSanitizer source is identical at both commits. verificationGap: `cbor,evm:london` captures the CLI override.

**DelayedWithdraw @ `bcac7f40` (2024-11-07, evm:london)**
auditCommit `938478e5` (sevenSeas-8, 2024-05-27). Same london-override situation as DAS. Source unchanged between May 2024 audit and Nov 2024 deploy. verificationGap: `cbor,evm:london`.

**Lens (ArcticArchitectureLens) @ `69fa3837` (2024-06-14, evm:london)**
auditCommit `939c77e2` (sevenSeas-4, 2024-03-28). Deployed separately 2024-07-17 at block 17193174, via veda-canonical-create3 direct `deployContract`, bundle name `"Arctic Architecture Lens V0.0"`. Audit anchor doesn't match because the deploy is 1 month after the last pre-deploy source modification (`69fa3837`, 2024-06-14 "Update lens for better delayed withdraw functions"); the next source change (`e13b98a3`, 2024-09-24) is 2 months *after* deploy — deploy used the `69fa3837` source unchanged. Why `evm:london`: Basescan's verified compiler settings show `EVMVersion: london`, `solc v0.8.21`, optimizer 200 runs. foundry.toml at `69fa3837` defaults to `shanghai`, so the deploy script passed `--evm-version london` at the CLI. Why cbor differs: Basescan submission has one extra trailing `\n` vs git blob, shifting only the IPFS hash in the CBOR footer; body bytes are identical (7399 B post-cbor-strip). verificationGap: `cbor,evm:london`.

**ManagerWithMerkleVerification @ `10a0dae5` (2025-02-06)**
Same as AccountantWithRateProviders. auditCommit `b7ad4066` (sevenSeas-19) also matches.

**TellerWithMultiAssetSupport @ `10a0dae5` (2025-02-06)**
auditCommit `b7ad4066` (sevenSeas-19, 2024-11-07) also matches. Sweep picked later commit; no genuine drift.

---

### GoldenGoose (deployed 2025-08-22, block 34550973)

Build config at deploy: `solc 0.8.21`, `optimizer=true runs=200`, `evm_version=cancun` (foundry.toml at deploy era). All mismatches are cbor-only.

**AccountantWithRateProviders @ `b7ad4066` (2024-11-07)**
auditCommit == verifiedCommit (`b7ad4066`, sevenSeas-19). No divergence.

**BoringOnChainQueue @ `568d9467` (2025-12-17)**
auditCommit `edfcba3f` (sevenSeas-27, 2025-01-10). Source evolved between the Jan 2025 audit and the Aug 2025 deploy. `568d9467` post-dates the deploy (Dec 2025); source was stable from Aug 2025 onward through that commit.

**BoringVault @ `dd7b8b54` (2024-12-18)**
auditCommit `9c6e1e44` (sevenSeas-7, 2024-05-20). Source evolved between May 2024 audit and Aug 2025 deploy. `dd7b8b54` is from Dec 2024, well before the deploy; source was at this version at deploy time.

**Lens @ `568d9467` (2025-12-17)**
auditCommit `939c77e2` (sevenSeas-4, 2024-03-28). At `939c77e2` the helper file was `BoringVaultV0Lens.sol` — the contract was renamed and substantially rewritten as `ArcticArchitectureLens.sol` by Mar 29 2024. Significant source evolution between audit and Aug 2025 deploy. `568d9467` post-dates deploy; source stable from Aug 2025 onward.

**ManagerWithMerkleVerification @ `b7ad4066` (2024-11-07)**
auditCommit == verifiedCommit (`b7ad4066`, sevenSeas-19). No divergence.

**QueueSolver @ `568d9467` (2025-12-17)**
auditCommit `b9eafd46` (sevenSeas-44, 2025-05-14). Source evolved between May 2025 audit and Aug 2025 deploy. `568d9467` post-dates deploy; source stable from Aug 2025 onward.

**TellerWithLayerZero @ `c54949f5` (2025-06-04)**
auditCommit `b7ad4066` (sevenSeas-19, 2024-11-07). Source evolved between Nov 2024 audit and Aug 2025 deploy. `c54949f5` is from Jun 2025, ~2 months before the Aug 2025 deploy; this is the source version in use at deploy time.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)