### PR TITLE
UniChain: backfill contractMetadata for all 5 vaults (47 contracts)

### DIFF
--- a/deployments/addresses/UniChain/AlphaSTETH.json
+++ b/deployments/addresses/UniChain/AlphaSTETH.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0x8C5Ae128EbFBf700F76FFad9b4634abAf8ED6683",
     "TellerWithLayerZero": "0x9c9944473d7DB901fa32dCf29b6434b4e7AD82e9",
     "Timelock": "0x4419326b1F38aac37635be19e377014869CD78fC"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-04-16T01:36:30Z",
+      "creationTx": "0xe6edf8f27f1af4db4b04dc026c982e9f44c5fc5313a6e6d159066857f2e1d4ce",
+      "creationBlock": 14019031,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-04-16T01:36:30Z",
+      "creationTx": "0xe6edf8f27f1af4db4b04dc026c982e9f44c5fc5313a6e6d159066857f2e1d4ce",
+      "creationBlock": 14019031,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-04-16T01:36:30Z",
+      "creationTx": "0xe6edf8f27f1af4db4b04dc026c982e9f44c5fc5313a6e6d159066857f2e1d4ce",
+      "creationBlock": 14019031,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Lens": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-04-16T01:36:30Z",
+      "creationTx": "0xe6edf8f27f1af4db4b04dc026c982e9f44c5fc5313a6e6d159066857f2e1d4ce",
+      "creationBlock": 14019031,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Pauser": {
+      "deployedAt": "2025-04-16T01:36:34Z",
+      "creationTx": "0xeca8829807516abf5d3204ffba736496b8053ea612cbd3d437ae293536ba9dbe",
+      "creationBlock": 14019035,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-04-16T01:36:34Z",
+      "creationTx": "0xeca8829807516abf5d3204ffba736496b8053ea612cbd3d437ae293536ba9dbe",
+      "creationBlock": 14019035,
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-04-16T01:36:30Z",
+      "creationTx": "0xe6edf8f27f1af4db4b04dc026c982e9f44c5fc5313a6e6d159066857f2e1d4ce",
+      "creationBlock": 14019031,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-04-16T01:36:30Z",
+      "creationTx": "0xe6edf8f27f1af4db4b04dc026c982e9f44c5fc5313a6e6d159066857f2e1d4ce",
+      "creationBlock": 14019031,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "263cf49f4219f285ccbf9f7fe2a800fea19d4c19",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "deployedAt": "2025-05-07T17:21:26Z",
+      "creationTx": "0x8b4ecd3c13c00ec02c53c9060ad1243cb317cf95c9a212b05d5de374de680951",
+      "creationBlock": 15890127,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    }
   }
 }

--- a/deployments/addresses/UniChain/EtherFiLiquidEth.json
+++ b/deployments/addresses/UniChain/EtherFiLiquidEth.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0xd83C1C5050f73bbaaa2036F2e0D73163D180C123",
     "TellerWithLayerZeroRateLimiting": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x43119CE1741bb02E3FC191e04775731537E9f5A9"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-04-16T00:41:33Z",
+      "creationTx": "0xc38c6dc9731e6594729fc91f3a1973353a6a62a0bc7519f2cec7e9ee3fbe472c",
+      "creationBlock": 14015734,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Lens": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Pauser": {
+      "deployedAt": "2025-04-16T00:41:33Z",
+      "creationTx": "0xc38c6dc9731e6594729fc91f3a1973353a6a62a0bc7519f2cec7e9ee3fbe472c",
+      "creationBlock": 14015734,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-04-16T00:41:33Z",
+      "creationTx": "0xc38c6dc9731e6594729fc91f3a1973353a6a62a0bc7519f2cec7e9ee3fbe472c",
+      "creationBlock": 14015734,
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "deployedAt": "2025-04-16T00:41:33Z",
+      "creationTx": "0xc38c6dc9731e6594729fc91f3a1973353a6a62a0bc7519f2cec7e9ee3fbe472c",
+      "creationBlock": 14015734,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    }
   }
 }

--- a/deployments/addresses/UniChain/EtherFiLiquidUsd.json
+++ b/deployments/addresses/UniChain/EtherFiLiquidUsd.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0xaBA6bA1E95E0926a6A6b917FE4E2f19ceaE4FF2e",
     "TellerWithLayerZeroRateLimiting": "0x4DE413a26fC24c3FC27Cc983be70aA9c5C299387",
     "Timelock": "0x48b4158b0100B4e69D4a448db6BBe74DE94ee177"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-04-16T01:01:58Z",
+      "creationTx": "0x8f7c199d9ffc5f1dd2aa9d8bf45f895a21a2ce170d8f1bbed56f2741f19c8a0c",
+      "creationBlock": 14016959,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-04-16T01:01:58Z",
+      "creationTx": "0x8f7c199d9ffc5f1dd2aa9d8bf45f895a21a2ce170d8f1bbed56f2741f19c8a0c",
+      "creationBlock": 14016959,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-04-16T01:01:58Z",
+      "creationTx": "0x8f7c199d9ffc5f1dd2aa9d8bf45f895a21a2ce170d8f1bbed56f2741f19c8a0c",
+      "creationBlock": 14016959,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Lens": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-04-16T01:01:58Z",
+      "creationTx": "0x8f7c199d9ffc5f1dd2aa9d8bf45f895a21a2ce170d8f1bbed56f2741f19c8a0c",
+      "creationBlock": 14016959,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Pauser": {
+      "deployedAt": "2025-04-16T01:02:03Z",
+      "creationTx": "0xe742a6079ff99040e87edef0b51a186ab49ddfd09070fb28b3e17502460e211d",
+      "creationBlock": 14016964,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-04-16T01:02:03Z",
+      "creationTx": "0xe742a6079ff99040e87edef0b51a186ab49ddfd09070fb28b3e17502460e211d",
+      "creationBlock": 14016964,
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-04-16T01:01:58Z",
+      "creationTx": "0x8f7c199d9ffc5f1dd2aa9d8bf45f895a21a2ce170d8f1bbed56f2741f19c8a0c",
+      "creationBlock": 14016959,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "deployedAt": "2025-04-16T01:01:58Z",
+      "creationTx": "0x8f7c199d9ffc5f1dd2aa9d8bf45f895a21a2ce170d8f1bbed56f2741f19c8a0c",
+      "creationBlock": 14016959,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "deployedAt": "2025-04-16T01:02:03Z",
+      "creationTx": "0xe742a6079ff99040e87edef0b51a186ab49ddfd09070fb28b3e17502460e211d",
+      "creationBlock": 14016964,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    }
   }
 }

--- a/deployments/addresses/UniChain/GoldenGoose.json
+++ b/deployments/addresses/UniChain/GoldenGoose.json
@@ -11,5 +11,106 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-05-22T21:25:37Z",
+      "creationTx": "0xce9093aea21e53d5aa7b8c656d73367e61393067dfea943d4d484f572f4626bb",
+      "creationBlock": 17200778,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-05-22T21:25:37Z",
+      "creationTx": "0xce9093aea21e53d5aa7b8c656d73367e61393067dfea943d4d484f572f4626bb",
+      "creationBlock": 17200778,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-05-22T21:25:37Z",
+      "creationTx": "0xce9093aea21e53d5aa7b8c656d73367e61393067dfea943d4d484f572f4626bb",
+      "creationBlock": 17200778,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Lens": {
+      "deployedAt": "2025-04-16T00:41:29Z",
+      "creationTx": "0x08116eb4eaf960e4e6523d059e428391643583a8c400da5f562b4bf3150338be",
+      "creationBlock": 14015730,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-05-22T21:25:37Z",
+      "creationTx": "0xce9093aea21e53d5aa7b8c656d73367e61393067dfea943d4d484f572f4626bb",
+      "creationBlock": 17200778,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Pauser": {
+      "deployedAt": "2025-05-22T21:25:43Z",
+      "creationTx": "0x2fc6829c361f4d89968dc55f24e83d4c934be315f175ce802ab54c6e543f70d3",
+      "creationBlock": 17200784,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-05-22T21:25:43Z",
+      "creationTx": "0x2fc6829c361f4d89968dc55f24e83d4c934be315f175ce802ab54c6e543f70d3",
+      "creationBlock": 17200784,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-05-22T21:25:37Z",
+      "creationTx": "0xce9093aea21e53d5aa7b8c656d73367e61393067dfea943d4d484f572f4626bb",
+      "creationBlock": 17200778,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-05-22T21:25:37Z",
+      "creationTx": "0xce9093aea21e53d5aa7b8c656d73367e61393067dfea943d4d484f572f4626bb",
+      "creationBlock": 17200778,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "36c1a1a0a337bcc0063bcf2156cde76bcdab6ac5",
+      "verificationGap": "cbor,evm:shanghai"
+    }
   }
 }

--- a/deployments/addresses/UniChain/PrimeGoldenGoose.json
+++ b/deployments/addresses/UniChain/PrimeGoldenGoose.json
@@ -11,5 +11,95 @@
     "RolesAuthority": "0x25863400F4541543a47E97c6a7b1FD226B234723",
     "TellerWithLayerZero": "0x4ecC202775678F7bCfF8350894e2F2E3167Cc3Df",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-06-25T04:05:02Z",
+      "creationTx": "0x6408fdfc345a004ea0e9953b527fd9dc5bd2c2ae7b55f2ad389f0f7105321521",
+      "creationBlock": 20075943,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-06-25T04:05:10Z",
+      "creationTx": "0x59043857cb4111ae5f6e22fd44bf4fa85426a298dab6ffc00ae27c2b31bdc297",
+      "creationBlock": 20075951,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-06-25T04:05:02Z",
+      "creationTx": "0x6408fdfc345a004ea0e9953b527fd9dc5bd2c2ae7b55f2ad389f0f7105321521",
+      "creationBlock": 20075943,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "Lens": {
+      "deployedAt": "2025-06-25T04:05:02Z",
+      "creationTx": "0x6408fdfc345a004ea0e9953b527fd9dc5bd2c2ae7b55f2ad389f0f7105321521",
+      "creationBlock": 20075943,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-06-25T04:05:02Z",
+      "creationTx": "0x6408fdfc345a004ea0e9953b527fd9dc5bd2c2ae7b55f2ad389f0f7105321521",
+      "creationBlock": 20075943,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-06-25T04:05:10Z",
+      "creationTx": "0x59043857cb4111ae5f6e22fd44bf4fa85426a298dab6ffc00ae27c2b31bdc297",
+      "creationBlock": 20075951,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-06-25T04:05:02Z",
+      "creationTx": "0x6408fdfc345a004ea0e9953b527fd9dc5bd2c2ae7b55f2ad389f0f7105321521",
+      "creationBlock": 20075943,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor,evm:shanghai"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-06-25T04:05:02Z",
+      "creationTx": "0x6408fdfc345a004ea0e9953b527fd9dc5bd2c2ae7b55f2ad389f0f7105321521",
+      "creationBlock": 20075943,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor,evm:shanghai"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Backfills `contractMetadata` for all 5 Unichain mainnet vaults: AlphaSTETH, EtherFiLiquidEth, EtherFiLiquidUsd, GoldenGoose, PrimeGoldenGoose
- 47 non-zero-address contracts across all vaults (GoldenGoose Timelock, PrimeGoldenGoose Pauser+Timelock are zero address — skipped)
- All 47: `verification=full_match`, `verificationGap=cbor` or `cbor,evm:shanghai`
- Explorer-confirmed compiler settings: `v0.8.21+commit.d9974bed`, `evm=shanghai`, `optimizer=200 runs` (Etherscan V2 / chain id 130)
- QueueSolver (AlphaSTETH / EtherFiLiquidEth / EtherFiLiquidUsd): `verifiedCommit == auditCommit` (2e1aefc9) — clean match

## verificationGap key

- `cbor` — creation bytecode matches except CBOR metadata blob; runtime identical
- `cbor,evm:shanghai` — same as `cbor`, plus foundry.toml at the verified commit defaults to `cancun` but deploy used `evm=shanghai` (per Etherscan). All Unichain contracts deployed with `evm=shanghai` regardless of foundry.toml default.

## Forensic notes: most core contracts @ dd7b8b54

Deploy dates: 2025-04-16 (AlphaSTETH/EtherFiLiquidEth/EtherFiLiquidUsd), 2025-05-22 (GoldenGoose), 2025-06-25 (PrimeGoldenGoose). Audit anchors (b7ad4066 "Merge PR #162 Sep-2024", 9c6e1e44 "Add natspec") predate deployment by months. Verified commit dd7b8b54 ("Merge pull request #16 from Veda-Labs/root/btcn-maizenet") is a later merge that incorporated post-audit source changes. Runtime bytecode is identical to the audit commit (cbor-only delta), confirming no bytecode-affecting changes between audit and deployment. Affects: AccountantWithRateProviders, BoringVault, ManagerWithMerkleVerification, Pauser, RolesAuthority, Timelock (all 5 vaults).

## Forensic notes: Lens @ dd7b8b54 / 568d9467

Deploy date: 2025-04-16 (shared address 0x5232bc0F…, 4 vaults) and 2025-06-25 (PrimeGoldenGoose 0xE0eFE93…). Audit commit 939c77e2 ("Merge PR #17 feat/lido-support") is the era when `src/helper/` held `BoringVaultV0Lens.sol:BoringVaultV0Lens` — a ~321-byte stub. Deployed contract is `ArcticArchitectureLens` (7356 bytes runtime). The auditCommit is therefore misassigned by the audit index — the deployed contract class postdates that audit. Verified at dd7b8b54 (shared Lens, 4 vaults) and 568d9467 (PrimeGoldenGoose unique Lens). Runtime-identical to verified commit; cbor delta only.

## Forensic notes: BoringOnChainQueue @ 568d9467

Deploy dates: 2025-04-16 to 2025-06-25. Audit commit edfcba3f ("Update address to newer deployment, add rewards claiming logic to decoder") predates deployment. Verified at 568d9467 ("update last virtual share price with highest possible precision") — source changed post-audit (higher precision virtual share calculation). Runtime bytecode matches cbor-only; no security-relevant difference.

## Forensic notes: QueueSolver (GoldenGoose / PrimeGoldenGoose) @ 568d9467

Deploy dates: 2025-05-22 (GoldenGoose), 2025-06-25 (PrimeGoldenGoose). Audit commit b9eafd46 ("fmt compoundv2") predates deploy. Verified at 568d9467. Runtime identical; cbor gap only. Note: AlphaSTETH/EtherFiLiquidEth/EtherFiLiquidUsd QueueSolver verified at auditCommit 2e1aefc9 — exact audit alignment for those three vaults.

## Forensic notes: TellerWithLayerZero @ AlphaSTETH (263cf49f)

Deploy date: 2025-04-16. Audit commit b7ad4066 ("Merge PR #162 Sep-2024") predates by ~6 months. Verified at deploy-era commit 263cf49f ("deploy alphasteth unichain") using `evm=shanghai` (foundry.toml at 263cf49f already specifies shanghai — no evm gap). Runtime matches cbor-only.

## Forensic notes: TellerWithLayerZeroRateLimiting @ EtherFiLiquidEth / EtherFiLiquidUsd (15ea1839)

Deploy date: 2025-04-16. No auditCommit assigned (scopeMatch=False — teller variant not in scope of indexed audits). Verified at deploy-era commit 15ea1839 ("deploy liquidUSD and liquidETH unichain") using `evm=shanghai` (foundry.toml at 15ea1839 specifies shanghai). Runtime matches cbor-only.

## Forensic notes: TellerWithLayerZero @ GoldenGoose (36c1a1a0)

Deploy date: 2025-05-22. Audit commit b7ad4066 predates by ~8 months. Verified at deploy-era commit 36c1a1a0 ("deploy golden goose vaults"). foundry.toml at 36c1a1a0 defaults to `cancun` but deploy used `evm=shanghai` per Etherscan — hence `cbor,evm:shanghai` gap. Runtime matches cbor-only.

## Forensic notes: TellerWithLayerZero @ PrimeGoldenGoose (c54949f5)

Deploy date: 2025-06-25. Audit commit b7ad4066 predates by ~9 months. Verified at c54949f5 ("compiling") — a small intermediate commit closest to the deploy. foundry.toml at c54949f5 defaults to `cancun` but deploy used `evm=shanghai` per Etherscan — hence `cbor,evm:shanghai` gap. Runtime matches cbor-only.

## Test plan

- [ ] Confirm `contractMetadata` present on all 5 JSON files with no null `verifiedCommit`
- [ ] Spot-check creationTx against Unichain explorer for 2-3 contracts
- [ ] Verify zero-address contracts (GoldenGoose Timelock, PrimeGoldenGoose Pauser+Timelock) are absent from metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)