### PR TITLE
Katana: backfill contractMetadata for 5 vaults (47 contracts, chain 747474)

### DIFF
--- a/deployments/addresses/Katana/GoldenGoose.json
+++ b/deployments/addresses/Katana/GoldenGoose.json
@@ -11,5 +11,106 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "173723dbd84ecd0eb5fe9a2f24c3924fc44f698d",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "173723dbd84ecd0eb5fe9a2f24c3924fc44f698d",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "173723dbd84ecd0eb5fe9a2f24c3924fc44f698d",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-08-22T20:09:07Z",
+      "creationTx": "0x15a0a1d5f66277fda649899c80ade7780863f86bfb6caf639b74eaf7d0022882",
+      "creationBlock": 9150536,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Katana/LBTCvKatanaDeployment.json
+++ b/deployments/addresses/Katana/LBTCvKatanaDeployment.json
@@ -11,5 +11,106 @@
     "RolesAuthority": "0x11BF7551eb78786Ca167Db04B12201004a743606",
     "TellerWithLayerZero": "0x38d4066cC4B42E2B6615aE15cAa6e347114779E2",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-06-30T23:56:39Z",
+      "creationTx": "0x2fdfcf0bce872ce9b174dff47d5d35bfcde2cdec03ae7e08d5d6f9edff5d5b31",
+      "creationBlock": 4584988,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Katana/LiquidETH.json
+++ b/deployments/addresses/Katana/LiquidETH.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0x485Bde66Bb668a51f2372E34e45B1c6226798122",
     "TellerWithLayerZero": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x8ffaf6aF36d3A58Fc0E19dD96f592fC1d22310Be"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "7715fb3b0bc2b8ae922c3f23596e6844971a704a",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-06-30T23:56:35Z",
+      "creationTx": "0x10da92ec36ad808f9e750fa3b4ba4d4fc1df1b93ad392ea1b92aa4af70a7f97a",
+      "creationBlock": 4584984,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "7715fb3b0bc2b8ae922c3f23596e6844971a704a",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "7715fb3b0bc2b8ae922c3f23596e6844971a704a",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "deployedAt": "2025-07-10T19:26:47Z",
+      "creationTx": "0x2ebeeeea1957a4093e7f1078c92339fef1e14731027b5b9078c7aa481337277c",
+      "creationBlock": 5432796,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Katana/LiquidKatana.json
+++ b/deployments/addresses/Katana/LiquidKatana.json
@@ -11,5 +11,106 @@
     "RolesAuthority": "0x1645E0cc24595faB37916a3d57bC51dFf0315Cf7",
     "TellerWithLayerZeroRateLimiting": "0x739A1efFaDDB0b07ef1284598819232df4FD8d16",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-07-01T00:30:18Z",
+      "creationTx": "0x2a771d5147bf9ab987dc38a8d5a43fee71560bca9e6d6b7d5437c0e8eec50216",
+      "creationBlock": 4587007,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "deployedAt": "2025-07-01T00:30:13Z",
+      "creationTx": "0x35ed6a77b916f05dc6f00c63adfa39a4e5654f4c200d578d8fa89adfe1853ee1",
+      "creationBlock": 4587002,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Katana/VedaTestVault.json
+++ b/deployments/addresses/Katana/VedaTestVault.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0x222222bbd7F2E56f1320fa8C9f83992da738b036",
     "TellerWithLayerZero": "0x7777776973bC0869e4d106F1F2Ec8b42228EC8e7",
     "Timelock": "0x333333807Ec1b14A5152c5bB7fC69EC8a817885D"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "7e145668b95f8bbf44cddc0a39257ef576b4ac7b",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "7e145668b95f8bbf44cddc0a39257ef576b4ac7b",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-07-02T16:38:46Z",
+      "creationTx": "0x925863c7957dfb24f842a8db046b2d1a8664a811413279964da228b2481ffa50",
+      "creationBlock": 4731515,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "7e145668b95f8bbf44cddc0a39257ef576b4ac7b",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-07-02T16:38:43Z",
+      "creationTx": "0x0e42cd66ff5d8a7cf1ec90e8546716a3a2552013097ccc4af6366332da3fca0b",
+      "creationBlock": 4731512,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "deployedAt": "2025-07-02T16:38:46Z",
+      "creationTx": "0x925863c7957dfb24f842a8db046b2d1a8664a811413279964da228b2481ffa50",
+      "creationBlock": 4731515,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Backfill `contractMetadata` for all 47 deployed contracts across 5 Katana mainnet vaults (chain id 747474)
- All contracts: `verification: full_match`, `verificationGap: cbor` (CBOR metadata hash differs; runtime bytes verified byte-for-byte)
- Deploy metadata (deployedAt / creationTx / creationBlock) via Etherscan V2 (chainid=747474)

## Verification summary

| Contract group | verifiedCommit | auditCommit | Vaults |
|---|---|---|---|
| AWRP, BV, MwMV, Pauser, RA, Timelock | `dd7b8b54` | various | all 5 |
| BOCQ, Lens, QueueSolver | per-vault deploy commit | various | all 5 |
| TellerWithLayerZero | `c54949f5` | `b7ad4066` | GoldenGoose, LBTCvKatana, LiquidETH, VedaTestVault |
| TellerWithLayerZeroRateLimiting | `c54949f5` | none | LiquidKatana |

## Forensic notes: AccountantWithRateProviders @ dd7b8b54

Deploy date: 2025-06-30 (LBTCvKatana/LiquidKatana), 2025-07-10 (LiquidETH), 2025-07-02 (VedaTestVault), 2025-08-22 (GoldenGoose). Audit anchor `b7ad4066` (2024-11-07) does not match deployed bytecode — source is byte-for-byte identical between `b7ad4066` and `dd7b8b54` (`git diff b7ad4066 dd7b8b54 -- src/base/Roles/AccountantWithRateProviders.sol` is empty), but a library dependency update between Nov 2024 and Dec 2024 changed the compiled output. `dd7b8b54` (2024-12-18, Merge PR #16 root/btcn-maizenet) produces runtime bytes that match all 5 deployed instances (partial_match cbor; CBOR metadata hash differs due to build-environment metadata). All 5 vaults verified at this commit.

## Forensic notes: ManagerWithMerkleVerification @ dd7b8b54

Same story as AccountantWithRateProviders above. Source file unchanged from `b7ad4066` through `dd7b8b54`; dependency change shifted the compiled output. All 5 vaults verified at `dd7b8b54`.

## Forensic notes: BoringVault @ dd7b8b54

Deploy date: 2025-06-30 to 2025-08-22. Audit anchor `9c6e1e44` (2024-05-20) mismatches. Two commits modified BoringVault between the audit anchor and `dd7b8b54`: `4538ccf7` (Update licensing) and `a07a61fb` (Add operator to beforeTransferHook). The deployed BoringVault matches `dd7b8b54` (2024-12-18), which includes both changes. Runtime bytes verified; CBOR metadata differs.

## Forensic notes: BoringOnChainQueue @ per-vault deploy commit

Deploy dates: LBTCvKatana/LiquidKatana 2025-06-30 (`2477eb57`), LiquidETH 2025-07-10 (`7715fb3b`), VedaTestVault 2025-07-02 (`7e145668`), GoldenGoose 2025-08-22 (`173723db`). Audit anchor `edfcba3f` predates source changes: `9b0ceb76` (Fix event naming issue) and `78830766` (Add new capacity logic to queue). Each vault's BOCQ verifies at its own deploy commit. Runtime bytes verified; CBOR metadata differs.

## Forensic notes: Lens (ArcticArchitectureLens) @ per-vault deploy commit

Deploy dates: same as BOCQ above per vault. Audit anchor `939c77e2` (2024 era) predates significant Lens source evolution: commits `6064f06f` (missing natspec), `69fa3837` (delayed withdraw functions), `e13b98a3` (AssetData struct), `51e6d8b2` (permissioned transfers), `68852042` (fmt). LBTCvKatana and LiquidETH share Lens address `0x5232bc0F5999f8dA604c42E1748A13a170F94A1B` (CREATE3 reuse, first deployed with LBTCvKatana 2025-06-30). All 4 distinct Lens addresses on Katana measure 7503 bytes; each verifies at its vault's deploy commit. Runtime bytes verified; CBOR metadata differs.

## Forensic notes: QueueSolver @ per-vault deploy commit

Deploy dates: same as BOCQ above per vault. Audit anchor `b9eafd46` predates source changes: `e3c65f63` (add flag to solver) and `61e918c6` (fmt). Each vault's QueueSolver verifies at its own deploy commit. Runtime bytes verified; CBOR metadata differs.

## Forensic notes: TellerWithLayerZero @ c54949f5

Deploy dates: GoldenGoose 2025-08-22, LBTCvKatana 2025-06-30, LiquidETH 2025-07-10, VedaTestVault 2025-07-02. Audit anchor `b7ad4066` (2024-11-07) does not match deployed bytecode. Source file `LayerZeroTeller.sol` is byte-for-byte identical at `b7ad4066` and `c54949f5` (same blob hash `fa302af7`), but LayerZero dependency updates between Nov 2024 and Jun 2025 shifted the compiled output. `c54949f5` (2025-06-04 "compiling") is a direct ancestor of all 4 deploy commits and produces runtime bytes that match all 4 deployed instances. Runtime bytes verified; CBOR metadata differs. TellerWithLayerZeroRateLimiting (LiquidKatana) similarly verified at `c54949f5`; no audit anchor (contract did not exist at the audit commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)