### PR TITLE
Bob: backfill contractMetadata for HybridBTC; mark HybridBTC2 + Plume vaults deprecated

### DIFF
--- a/deployments/addresses/Bob/HybridBTC.json
+++ b/deployments/addresses/Bob/HybridBTC.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0xE62e424DbAf17D702cceba939C9427018DBC19C1",
     "TellerWithLayerZero": "0x19ab8c9896728d3A2AE8677711bc852C706616d3",
     "Timelock": "0xDbE09a066f6D42935f702F700b7E0E5F56028Df2"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "verificationGap": "cbor"
+    },
+    "BoringVault": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "cc839daffc0ec970796b8b024333bd7233eafda3",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": "cbor"
+    },
+    "Pauser": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": false,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "QueueSolver": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "verificationGap": "cbor"
+    },
+    "RolesAuthority": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "scopeMatch": true,
+      "verification": "full_match",
+      "verifiedCommit": "cc839daffc0ec970796b8b024333bd7233eafda3",
+      "verificationGap": "cbor"
+    },
+    "Timelock": {
+      "deployedAt": "2025-02-12T19:08:51Z",
+      "creationTx": "0x2c5e23acd5c361891147c14398cd92e6c8348ff1a50cb5b832aff424eb72c2d6",
+      "creationBlock": 13262672,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "verificationGap": "cbor"
+    }
   }
 }

--- a/deployments/addresses/Bob/HybridBTC2.json
+++ b/deployments/addresses/Bob/HybridBTC2.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0x30cc8270b8b2F758CAbf2693efFF5f608EFcd12b",
     "TellerWithLayerZero": "0xfB03E171d11A5baea4d7bfd5992262CE28404201",
     "Timelock": "0xF34BBA863021Db59AD7017A767432F9F048775EA"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "BoringVault": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Lens": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Pauser": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "QueueSolver": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "RolesAuthority": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Timelock": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    }
   }
 }

--- a/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
@@ -32,10 +32,6 @@
     "ShareLockPeriod": 0
   },
   "contractMetadata": {
-    "AccountantWithRateProviders": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
     "BoringVault": {
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
@@ -57,14 +53,6 @@
       "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
       "verificationGap": "cbor"
     },
-    "Lens": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
-    "ManagerWithMerkleVerification": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
     "RolesAuthority": {
       "auditCommit": null,
       "auditUrl": null,
@@ -72,9 +60,49 @@
       "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
       "verificationGap": "cbor"
     },
-    "TellerWithMultiAssetSupport": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2024-09-13T14:31:11Z",
+      "creationTx": "0xdf2da7054508d8350cdccee6486c86a758d387459ce806ac0df5cebb403496f7",
+      "creationBlock": 20742304,
       "auditCommit": null,
-      "auditUrl": null
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2024-04-17T04:08:11Z",
+      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
+      "creationBlock": 19672706,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2024-09-13T14:31:11Z",
+      "creationTx": "0x4f3766166c40204508a53762e0397cdb01334a2e7f3755a1c418d66255860744",
+      "creationBlock": 20742304,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
+      "verificationGap": "cbor"
+    },
+    "TellerWithMultiAssetSupport": {
+      "deployedAt": "2024-09-13T14:31:11Z",
+      "creationTx": "0xd43476cfaae2aeb98a85ba5ff7d65852b8d28152cd4fbcd4cfc0b1add82f5ffe",
+      "creationBlock": 20742304,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
+      "verificationGap": "cbor"
     }
   },
   "contractAddresses": {

--- a/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
@@ -26,16 +26,6 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1000000000000000000
   },
-  "core": {
-    "AccountantWithRateProviders": "0xBA4397B2B1780097eD1B483E3C0717E0Ed4fAAa5",
-    "BoringVault": "0xf8203A33027607D2C82dFd67b46986096257dFA5",
-    "DecoderAndSanitizer": "0x16D377CE4c95F7737Ef4B45F81301A988F62b61a",
-    "DelayedWithdraw": "0xd6DB5f51b00f40C208dE81f04cc397DF13789Abe",
-    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
-    "ManagerWithMerkleVerification": "0x3770E6021d7b2617Ba86E89EF210Cc00A7c9Af95",
-    "RolesAuthority": "0x08a879438BBcF000d07000F564a46EdCF8f9127B",
-    "TellerWithMultiAssetSupport": "0x821EFF4708Ff840a90F5822197418ebba469B232"
-  },
   "depositConfiguration": {
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
@@ -86,5 +76,15 @@
       "auditCommit": null,
       "auditUrl": null
     }
+  },
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0xBA4397B2B1780097eD1B483E3C0717E0Ed4fAAa5",
+    "BoringVault": "0xf8203A33027607D2C82dFd67b46986096257dFA5",
+    "DecoderAndSanitizer": "0x16D377CE4c95F7737Ef4B45F81301A988F62b61a",
+    "DelayedWithdraw": "0xd6DB5f51b00f40C208dE81f04cc397DF13789Abe",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0x3770E6021d7b2617Ba86E89EF210Cc00A7c9Af95",
+    "RolesAuthority": "0x08a879438BBcF000d07000F564a46EdCF8f9127B",
+    "TellerWithMultiAssetSupport": "0x821EFF4708Ff840a90F5822197418ebba469B232"
   }
 }

--- a/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
+++ b/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
@@ -30,10 +30,6 @@
     "ShareLockPeriod": 86400
   },
   "contractMetadata": {
-    "AccountantWithRateProviders": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
     "BoringVault": {
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
@@ -55,14 +51,6 @@
       "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
       "verificationGap": "cbor"
     },
-    "Lens": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
-    "ManagerWithMerkleVerification": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
     "RolesAuthority": {
       "auditCommit": null,
       "auditUrl": null,
@@ -70,9 +58,49 @@
       "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
       "verificationGap": "cbor"
     },
-    "TellerWithMultiAssetSupport": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2024-09-27T04:44:35Z",
+      "creationTx": "0xea079dc2dc2d85b13523dfe8b5a94764bb8636266301d1558018c1d253248447",
+      "creationBlock": 20839649,
       "auditCommit": null,
-      "auditUrl": null
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2024-04-17T04:08:11Z",
+      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
+      "creationBlock": 19672706,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2024-09-27T04:44:35Z",
+      "creationTx": "0x80794cfadabc2edad1baea6a7b8ef7b7a0a9e687a566de311e19502d675d3d1a",
+      "creationBlock": 20839649,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
+      "verificationGap": "cbor"
+    },
+    "TellerWithMultiAssetSupport": {
+      "deployedAt": "2024-09-27T04:44:35Z",
+      "creationTx": "0xbbce78683c5c92b58b71a5a830442bb69b8ecd077ad226a20c3f38d630168c2d",
+      "creationBlock": 20839649,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
+      "verificationGap": "cbor"
     }
   },
   "contractAddresses": {

--- a/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
+++ b/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
@@ -24,16 +24,6 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1000000000000000000
   },
-  "core": {
-    "AccountantWithRateProviders": "0x075e60550C6f77f430B284E76aF699bC31651f75",
-    "BoringVault": "0xE77076518A813616315EaAba6cA8e595E845EeE9",
-    "DecoderAndSanitizer": "0xb7Dd199ABE801cC4985B60B8B1365264Eb31ad26",
-    "DelayedWithdraw": "0xc552Eb7b5892521f55C2a430083B1E5dd63C839a",
-    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
-    "ManagerWithMerkleVerification": "0x354ade0382EEC1BF0a444339ABc82931457C2c0e",
-    "RolesAuthority": "0x1f5D0e8e7eb6390D2eb6024cdC8B38A7faab596E",
-    "TellerWithMultiAssetSupport": "0x63b2B0528376d1B34Ed8c9FF61Bd67ab2C8c2Bb0"
-  },
   "depositConfiguration": {
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": false,
@@ -84,5 +74,15 @@
       "auditCommit": null,
       "auditUrl": null
     }
+  },
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0x075e60550C6f77f430B284E76aF699bC31651f75",
+    "BoringVault": "0xE77076518A813616315EaAba6cA8e595E845EeE9",
+    "DecoderAndSanitizer": "0xb7Dd199ABE801cC4985B60B8B1365264Eb31ad26",
+    "DelayedWithdraw": "0xc552Eb7b5892521f55C2a430083B1E5dd63C839a",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0x354ade0382EEC1BF0a444339ABc82931457C2c0e",
+    "RolesAuthority": "0x1f5D0e8e7eb6390D2eb6024cdC8B38A7faab596E",
+    "TellerWithMultiAssetSupport": "0x63b2B0528376d1B34Ed8c9FF61Bd67ab2C8c2Bb0"
   }
 }

--- a/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
+++ b/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
@@ -44,16 +44,6 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 100000000
   },
-  "core": {
-    "AccountantWithRateProviders": "0x1c217f17d57d3CCD1CB3d8CB16B21e8f0b544156",
-    "BoringVault": "0x42A03534DBe07077d705311854E3B6933dD6Af85",
-    "DecoderAndSanitizer": "0xA6b52921652A828Da445b457442F8cA10638a4Bb",
-    "DelayedWithdraw": "0x4BD82657D0B2a437eaa72295bc5Dce9FdAadc7ad",
-    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
-    "ManagerWithMerkleVerification": "0xcb4647c77688489655F45bB5bac42E14a0b05F85",
-    "RolesAuthority": "0x01D68fBb5518Ea87895c5B1aA05d8A86EB9d04D8",
-    "TellerWithMultiAssetSupport": "0x66B912f197D9810d7b74E43d55bBbFC60034E98a"
-  },
   "depositConfiguration": {
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": false,
@@ -104,5 +94,15 @@
       "auditCommit": null,
       "auditUrl": null
     }
+  },
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0x1c217f17d57d3CCD1CB3d8CB16B21e8f0b544156",
+    "BoringVault": "0x42A03534DBe07077d705311854E3B6933dD6Af85",
+    "DecoderAndSanitizer": "0xA6b52921652A828Da445b457442F8cA10638a4Bb",
+    "DelayedWithdraw": "0x4BD82657D0B2a437eaa72295bc5Dce9FdAadc7ad",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0xcb4647c77688489655F45bB5bac42E14a0b05F85",
+    "RolesAuthority": "0x01D68fBb5518Ea87895c5B1aA05d8A86EB9d04D8",
+    "TellerWithMultiAssetSupport": "0x66B912f197D9810d7b74E43d55bBbFC60034E98a"
   }
 }

--- a/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
+++ b/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
@@ -50,10 +50,6 @@
     "ShareLockPeriod": 86400
   },
   "contractMetadata": {
-    "AccountantWithRateProviders": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
     "BoringVault": {
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
@@ -75,14 +71,6 @@
       "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
       "verificationGap": "cbor"
     },
-    "Lens": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
-    "ManagerWithMerkleVerification": {
-      "auditCommit": null,
-      "auditUrl": null
-    },
     "RolesAuthority": {
       "auditCommit": null,
       "auditUrl": null,
@@ -90,9 +78,49 @@
       "verifiedCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
       "verificationGap": "cbor"
     },
-    "TellerWithMultiAssetSupport": {
+    "AccountantWithRateProviders": {
+      "deployedAt": "2024-09-12T20:24:35Z",
+      "creationTx": "0x97fcc57fc7d89cf93eb3f4023545cc57b48831b1961d77ce8166a5a34cc16469",
+      "creationBlock": 20736899,
       "auditCommit": null,
-      "auditUrl": null
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
+      "verificationGap": "cbor"
+    },
+    "Lens": {
+      "deployedAt": "2024-04-17T04:08:11Z",
+      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
+      "creationBlock": 19672706,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
+      "verificationGap": "cbor"
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": "2024-09-12T20:24:35Z",
+      "creationTx": "0xe3befd355a93f6897131e81c44c4eaa396523df6b8b5f7f2a4699b7b3bd21925",
+      "creationBlock": 20736899,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
+      "verificationGap": "cbor"
+    },
+    "TellerWithMultiAssetSupport": {
+      "deployedAt": "2024-09-12T20:24:35Z",
+      "creationTx": "0x04240140ef4d4c2fd21d47db06acc2102af3c852873b22b6179dac8db0afab96",
+      "creationBlock": 20736899,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "full_match",
+      "verifiedCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
+      "verificationGap": "cbor"
     }
   },
   "contractAddresses": {

--- a/deployments/addresses/plume/royPlumeUSDC.json
+++ b/deployments/addresses/plume/royPlumeUSDC.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0x8dA85FC312fD0fa30d4bF0FB53Fd1228dB63a1c0",
     "TellerWithMultiAssetSupport": "0x4Fc294112fD0b7226ecA095FEE9909E30882Cb11",
     "Timelock": "0x438B11b5215F87cb4E45c6b6B4A29c08247397C1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "BoringVault": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Lens": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Pauser": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "QueueSolver": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "RolesAuthority": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "TellerWithMultiAssetSupport": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Timelock": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    }
   }
 }

--- a/deployments/addresses/plume/royUSDCPlumeUSD.json
+++ b/deployments/addresses/plume/royUSDCPlumeUSD.json
@@ -11,5 +11,117 @@
     "RolesAuthority": "0x754213aFB8ecb6D15F169bfD378Fb685f5cB0d4A",
     "TellerWithLayerZero": "0x60EBb5d1454Bb99aa35F63F609E79179b342B0b8",
     "Timelock": "0x6504cdedbB50f3cB848b4A496bA1eDBB116331a1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "BoringOnChainQueue": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "BoringVault": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Lens": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "ManagerWithMerkleVerification": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Pauser": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "QueueSolver": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "RolesAuthority": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "TellerWithLayerZero": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    },
+    "Timelock": {
+      "deployedAt": null,
+      "creationTx": null,
+      "creationBlock": null,
+      "auditCommit": null,
+      "auditUrl": null,
+      "scopeMatch": null,
+      "verification": "deprecated",
+      "verifiedCommit": null,
+      "verificationGap": null
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **HybridBTC (Bob 60808)**: full `contractMetadata` backfill for all 10 contracts — `deployedAt`, `creationTx`, `creationBlock`, `auditCommit`, `auditUrl`, `scopeMatch`, `verifiedCommit`, `verification`, `verificationGap`
- **HybridBTC2 (Bob)**: marked `verification: "deprecated"` (exclusion-listed: "not deployed")
- **royPlumeUSDC + royUSDCPlumeUSD (Plume)**: marked `verification: "deprecated"` (exclusion-listed: ~$0 TVL)

Companion tooling PR: Veda-Labs/security-scripts#31

## HybridBTC results (10/10 full_match + verificationGap=cbor)

All 10 contracts deployed at block 13262672, 2025-02-12T19:08:51Z in a single tx (`0x2c5e23ac...`).

| Contract | verifiedCommit | auditCommit | Notes |
|---|---|---|---|
| AccountantWithRateProviders | `b7ad4066` | `b7ad4066` | exact audit match |
| BoringOnChainQueue | `edfcba3f` | `edfcba3f` | exact audit match |
| BoringVault | `cc839daf` | `9c6e1e44` | 2 post-audit changes: `4538ccf7` (licensing) + `a07a61fb` (Add operator to beforeTransferHook) |
| Lens | `dd7b8b54` | `939c77e2` | auditCommit pre-ArcticArchitectureLens refactor; deployed class is `ArcticArchitectureLens` |
| ManagerWithMerkleVerification | `b7ad4066` | `b7ad4066` | exact audit match |
| Pauser | `dd7b8b54` | — | no audit entry |
| QueueSolver | `2e1aefc9` | `2e1aefc9` | sevenSeas-38; original audit commit `c94d843a` not in repo |
| RolesAuthority | `dd7b8b54` | — | no audit entry (solmate lib) |
| TellerWithLayerZero | `cc839daf` | `b7ad4066` | deploy-era anchor per LZ teller policy; no source changes between commits |
| Timelock | `dd7b8b54` | — | no audit entry (OZ lib) |

## Forensic notes

**BoringVault (9c6e1e44 → cc839daf):** `cc839daf` is 57 min before on-chain deploy. Two post-audit source changes — `4538ccf7` (license update) and `a07a61fb` (Add operator to beforeTransferHook) — added ~6 bytes to bytecode. sevenSeas-7 audit predates these by ~9 months.

**Lens (939c77e2 → dd7b8b54):** `939c77e2` (Spearbit audit) is pre-ArcticArchitectureLens refactor; the deployed contract is `ArcticArchitectureLens`, not `BoringVaultV0Lens`. `dd7b8b54` (2024-12-18) is the correct post-refactor anchor.

**TellerWithLayerZero (b7ad4066 → cc839daf):** No changes to `LayerZeroTeller.sol` between the two commits (`git log b7ad4066..cc839daf` returns empty for that path). Deploy-era commit is canonical per LZ teller policy. OAppAuth submodule (5beb4df2) initialized for build.

**QueueSolver:** Original `auditCommit=c94d843a` (sevenSeas-25) not resolvable in repo. Sweep matched `2e1aefc9` (sevenSeas-38, 2025-03-25). `apply_verdicts_bundle.py` correctly upgraded `auditCommit` to sevenSeas-38 since that audit covers BoringSolver at the matched commit.

## Test plan

- [ ] `deployedAt` / `creationTx` / `creationBlock` populated for all 10 HybridBTC contracts
- [ ] `verification=full_match` + `verificationGap=cbor` for all 10
- [ ] HybridBTC2, royPlumeUSDC, royUSDCPlumeUSD show `verification="deprecated"` on all contracts
- [ ] Tooling PR Veda-Labs/security-scripts#31 merged before this lands (backfill script needs Bob in CHAIN_IDS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)