### PR TITLE
contractMetadata: strip deployedAt, creationTx, creationBlock, scopeMatch

### DIFF
--- a/deployments/addresses/Mainnet/AlphaSTETH.json
+++ b/deployments/addresses/Mainnet/AlphaSTETH.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-03-14T20:29:35Z",
-      "creationTx": "0x190213b527cb52a8c07c3fa5e3478e7725e79b9d71dca37da220fad5f87f906a",
-      "creationBlock": 22047510,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-05-07T17:11:11Z",
-      "creationTx": "0x02e1cded337efc57162e357a7206e23993dbb2ea53f82666a31bfb4d880a4f84",
-      "creationBlock": 22433131,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "ab880f1c46f1031d1c228df2509c13a5fd9dff7a"
     }

--- a/deployments/addresses/Mainnet/BTCNDeployment.json
+++ b/deployments/addresses/Mainnet/BTCNDeployment.json
@@ -14,100 +14,64 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
@@ -61,45 +61,29 @@
       "verificationGap": "cbor"
     },
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-09-13T14:31:11Z",
-      "creationTx": "0xdf2da7054508d8350cdccee6486c86a758d387459ce806ac0df5cebb403496f7",
-      "creationBlock": 20742304,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-09-13T14:31:11Z",
-      "creationTx": "0x4f3766166c40204508a53762e0397cdb01334a2e7f3755a1c418d66255860744",
-      "creationBlock": 20742304,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-09-13T14:31:11Z",
-      "creationTx": "0xd43476cfaae2aeb98a85ba5ff7d65852b8d28152cd4fbcd4cfc0b1add82f5ffe",
-      "creationBlock": 20742304,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/EthenaPlasma.json
+++ b/deployments/addresses/Mainnet/EthenaPlasma.json
@@ -14,104 +14,64 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "BoringVault": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d"
     },
     "Lens": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "QueueSolver": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "Timelock": {
-      "deployedAt": "2025-09-12T20:11:23Z",
-      "creationTx": "0x005b656109407ac011ae485ddfba80a6df788012e22747a99b67b8634b3df49c",
-      "creationBlock": 23349288,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     }

--- a/deployments/addresses/Mainnet/EthenaRWA.json
+++ b/deployments/addresses/Mainnet/EthenaRWA.json
@@ -14,95 +14,59 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "BoringVault": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "QueueSolver": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2025-09-17T19:18:11Z",
-      "creationTx": "0x6c03b7181c7cf30b4bf22d91b59e3f74a7b5386985e03c202684a39d9bbdcf5c",
-      "creationBlock": 23384838,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "913a8cb80df7fd2ad9fc2653bc556f2901620b08"
     }

--- a/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
+++ b/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
@@ -59,45 +59,29 @@
       "verificationGap": "cbor"
     },
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-09-27T04:44:35Z",
-      "creationTx": "0xea079dc2dc2d85b13523dfe8b5a94764bb8636266301d1558018c1d253248447",
-      "creationBlock": 20839649,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-09-27T04:44:35Z",
-      "creationTx": "0x80794cfadabc2edad1baea6a7b8ef7b7a0a9e687a566de311e19502d675d3d1a",
-      "creationBlock": 20839649,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-09-27T04:44:35Z",
-      "creationTx": "0xbbce78683c5c92b58b71a5a830442bb69b8ecd077ad226a20c3f38d630168c2d",
-      "creationBlock": 20839649,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/EtherFiLiquidBTC.json
+++ b/deployments/addresses/Mainnet/EtherFiLiquidBTC.json
@@ -12,89 +12,57 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-11-14T23:22:11Z",
-      "creationTx": "0xd20924a23c49d95b99252252a4c475a21f97f39b9034f38e793ca1a9d93000d7",
-      "creationBlock": 21189184,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/GoldenGoose.json
+++ b/deployments/addresses/Mainnet/GoldenGoose.json
@@ -14,99 +14,63 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "f1483e8f8f7c698ccf34f9b72ea0ec62874b320d",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "53cee812d378c7c2f2ce8acaa5355cc7a34dfee2",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "92e1a7af2d550c98bb89adfdd3687862abed7545"
     },
     "QueueSolver": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "f1483e8f8f7c698ccf34f9b72ea0ec62874b320d",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "f1483e8f8f7c698ccf34f9b72ea0ec62874b320d",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-05-22T21:09:23Z",
-      "creationTx": "0xf1eb0cb7931e28b44b0ba6133937063217c5cc6366e5c0eba489844beaa3502d",
-      "creationBlock": 22541007,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "92e1a7af2d550c98bb89adfdd3687862abed7545"
     }

--- a/deployments/addresses/Mainnet/HourglassBTC.json
+++ b/deployments/addresses/Mainnet/HourglassBTC.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-01-10T06:47:23Z",
-      "creationTx": "0xc95d4d35d79ed4a50f9cd93371cd2854124ec3ab2365b917825d47f1aeaa814d",
-      "creationBlock": 21592383,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/HybridBTC.json
+++ b/deployments/addresses/Mainnet/HybridBTC.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-12T19:27:35Z",
-      "creationTx": "0x8d6dc4823a932a330868f62a025b6d631e74a3deb01cb4f078ad7a2af34a75d9",
-      "creationBlock": 21832487,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/HyperBTC.json
+++ b/deployments/addresses/Mainnet/HyperBTC.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-18T21:07:23Z",
-      "creationTx": "0x7d7b90cdf7db6791997e928b3c4e1bb351402aec50a9953e7e3e14cec08d8297",
-      "creationBlock": 21875838,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/HyperETH.json
+++ b/deployments/addresses/Mainnet/HyperETH.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-18T20:06:35Z",
-      "creationTx": "0xd2a216a8d5c9f84c77a4ddeccf724ce4edd5838b9abd9b42d3efb3f0f09eecbd",
-      "creationBlock": 21875538,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/HyperUSD.json
+++ b/deployments/addresses/Mainnet/HyperUSD.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-18T19:16:59Z",
-      "creationTx": "0x57b4699923efa3675c60f2c033c77b93e0881557b52ceafe831c46d15c2ae979",
-      "creationBlock": 21875292,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/InkedBTC.json
+++ b/deployments/addresses/Mainnet/InkedBTC.json
@@ -14,109 +14,69 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "55cae33d7f553c5b241778750758500434db6303"
     },
     "QueueSolver": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "55cae33d7f553c5b241778750758500434db6303"
     },
     "Timelock": {
-      "deployedAt": "2025-05-10T01:32:59Z",
-      "creationTx": "0xbe47a3365e70b9b2882da4b906ae063c68914261ec5be783e41b925e75fc8972",
-      "creationBlock": 22449756,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/InkedETH.json
+++ b/deployments/addresses/Mainnet/InkedETH.json
@@ -14,109 +14,69 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "55cae33d7f553c5b241778750758500434db6303"
     },
     "QueueSolver": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "55cae33d7f553c5b241778750758500434db6303"
     },
     "Timelock": {
-      "deployedAt": "2025-05-10T01:26:47Z",
-      "creationTx": "0x5e363ad2fa562a1d3b782b0b9381717bc531cec043285f599b4bf1bdb02c72ad",
-      "creationBlock": 22449725,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/InkedUSDT.json
+++ b/deployments/addresses/Mainnet/InkedUSDT.json
@@ -14,109 +14,69 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-12-05T08:54:47Z",
-      "creationTx": "0xf662970d6fc78773ad0ca660c8f9ed9b937a9a52f5e6d7d8a0ec28735054e7af",
-      "creationBlock": 21335233,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "55cae33d7f553c5b241778750758500434db6303"
     },
     "QueueSolver": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "55cae33d7f553c5b241778750758500434db6303"
     },
     "Timelock": {
-      "deployedAt": "2025-05-10T01:16:47Z",
-      "creationTx": "0x5d35a2e6e8be08d26698b12576370ec0b991f12594f29401efcfdee2de359b8d",
-      "creationBlock": 22449676,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/InkedUSDTHY.json
+++ b/deployments/addresses/Mainnet/InkedUSDTHY.json
@@ -14,106 +14,66 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "BoringVault": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c990c693a85a95f9ae6e2a03c5239dfab95269ba"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "QueueSolver": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-07-02T19:52:35Z",
-      "creationTx": "0x4b202c48bdf5f4cd8c9241c575303f6293f5cff4aeb0e9cad7a0e7873551768e",
-      "creationBlock": 22833745,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     }

--- a/deployments/addresses/Mainnet/LBTCvKatanaDeployment.json
+++ b/deployments/addresses/Mainnet/LBTCvKatanaDeployment.json
@@ -14,94 +14,58 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f"
     },
     "BoringVault": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f"
     },
     "QueueSolver": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-06-12T21:30:23Z",
-      "creationTx": "0x36c464cd80c9f9c9a567e3ea10f2a93fe7549328dd59c5e8b842cbb83fb16b16",
-      "creationBlock": 22691175,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LBTCvSonicDeployment.json
+++ b/deployments/addresses/Mainnet/LBTCvSonicDeployment.json
@@ -14,100 +14,64 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-01-31T20:12:23Z",
-      "creationTx": "0x70ac0cac1369f0c963f3c9de0cfb8860739974dc06c24f3e3cec8380375bbd4a",
-      "creationBlock": 21746815,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c2d11ecb471a0d0a55d1c1a67c90a3fb749c2e42",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LiquidBeraBTC.json
+++ b/deployments/addresses/Mainnet/LiquidBeraBTC.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "LayerZeroTellerWithRateLimiting": {
-      "deployedAt": "2025-04-23T20:57:47Z",
-      "creationTx": "0xe76e98b7db446e3773b9f52ebb8468d9af57310c4a748565c5fec39a1cd26ee4",
-      "creationBlock": 22334242,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2024-12-30T08:49:23Z",
-      "creationTx": "0xae962f5982e86c1fa71bf60cd3aae202660dd1d37e042aff7e821416b364ccb9",
-      "creationBlock": 21514201,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LiquidBeraETH.json
+++ b/deployments/addresses/Mainnet/LiquidBeraETH.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "LayerZeroTellerWithRateLimiting": {
-      "deployedAt": "2025-04-23T21:21:11Z",
-      "creationTx": "0xb61861beb7fdee6e861f49cf82e0d870e6c2da27df529ff7c7fc341d7ad8cc64",
-      "creationBlock": 22334359,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2024-12-30T09:05:59Z",
-      "creationTx": "0xd3a5d9b8421ff7edd2b9dc8f4089816b5be83ee85c993d65336b87aad3859c48",
-      "creationBlock": 21514284,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LiquidKatana.json
+++ b/deployments/addresses/Mainnet/LiquidKatana.json
@@ -14,100 +14,64 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZeroRateLimiting": {
-      "deployedAt": "2025-06-06T13:59:47Z",
-      "creationTx": "0xd6790f60273da0e17c729b80ccb1abfe33cbdc5c651d1393cef5804c1396a3b7",
-      "creationBlock": 22646002,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LiquidMoveETH.json
+++ b/deployments/addresses/Mainnet/LiquidMoveETH.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-01-16T09:09:59Z",
-      "creationTx": "0xb76252c7e0422357dec8d6f1b7f95d516b9e02cc6e1f13566e37bc4aa22f3255",
-      "creationBlock": 21636059,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LoopBTC.json
+++ b/deployments/addresses/Mainnet/LoopBTC.json
@@ -12,89 +12,57 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-11-15T06:24:59Z",
-      "creationTx": "0xa8a9cf27d45ea45b481e1f7e23bf0f2d4e11d6134faf5df3c79f0bcab4dde217",
-      "creationBlock": 21191288,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LtacBTC.json
+++ b/deployments/addresses/Mainnet/LtacBTC.json
@@ -14,110 +14,70 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "e70735426590d83c5673a117e9a8fade09d66d60"
     },
     "QueueSolver": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "7fb689d55d2a535b4c52388c49736629ff111a82",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/LtacETH.json
+++ b/deployments/addresses/Mainnet/LtacETH.json
@@ -14,105 +14,65 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "BoringVault": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "Lens": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "QueueSolver": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "Timelock": {
-      "deployedAt": "2025-04-30T23:47:59Z",
-      "creationTx": "0x23cfe38a72e64c1bc211f1f8c976060fb00197cc620e6f7edb26126bad39908a",
-      "creationBlock": 22385233,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     }

--- a/deployments/addresses/Mainnet/LtacUSD.json
+++ b/deployments/addresses/Mainnet/LtacUSD.json
@@ -14,105 +14,65 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "BoringVault": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "Lens": {
-      "deployedAt": "2025-04-30T23:12:59Z",
-      "creationTx": "0x222351f4029840aaccb9c2e72a34078e6b859725f5914565e7413576c2236a78",
-      "creationBlock": 22385058,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "QueueSolver": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     },
     "Timelock": {
-      "deployedAt": "2025-04-30T23:30:11Z",
-      "creationTx": "0x186ebc8a99553d9193a7e0eb62a5a7646f23ffa283aa81437ab4a7625080115e",
-      "creationBlock": 22385144,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "81c4ef977425572e373133cc7ebfceb7356eb345"
     }

--- a/deployments/addresses/Mainnet/PlasmaUSD.json
+++ b/deployments/addresses/Mainnet/PlasmaUSD.json
@@ -14,110 +14,70 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "92e1a7af2d550c98bb89adfdd3687862abed7545"
     },
     "QueueSolver": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-06-05T15:31:47Z",
-      "creationTx": "0x8a68ac7a5264d8fc8d5af1aac25852a8cce1e57e57cd13b1b3d24764a760a2de",
-      "creationBlock": 22639317,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/PrimeGoldenGoose.json
+++ b/deployments/addresses/Mainnet/PrimeGoldenGoose.json
@@ -14,84 +14,52 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f"
     },
     "BoringVault": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6b0b1ea7287258d8e77dbcca41ca409c620c50d0"
     },
     "Lens": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-06-25T03:56:59Z",
-      "creationTx": "0x7f094b8555ee825be0e8e8538d85976aed260e972b49c2e0d33036dcdf3c1de0",
-      "creationBlock": 22778909,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/SonicBTC.json
+++ b/deployments/addresses/Mainnet/SonicBTC.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithFixedRate": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-05T07:15:47Z",
-      "creationTx": "0xaf7cf13991e0fe5ee462a322c6c44902abef6a1d1454e1d9b14565ca9f715c0c",
-      "creationBlock": 21778738,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/SonicETH.json
+++ b/deployments/addresses/Mainnet/SonicETH.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithFixedRate": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2024-12-09T06:47:47Z",
-      "creationTx": "0x81020392166186fd8998098e5a78003e58736ece38db2549d9a8a09eb2af813b",
-      "creationBlock": 21363247,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/SonicUSD.json
+++ b/deployments/addresses/Mainnet/SonicUSD.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithFixedRate": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2024-12-09T06:20:35Z",
-      "creationTx": "0x3c69f8130e7e43c90fa302b769898dc13993b62d6430d2707edc17b061b87e5d",
-      "creationBlock": 21363111,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/SteakhouseUSD.json
+++ b/deployments/addresses/Mainnet/SteakhouseUSD.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "63b9a02facfdcce70b487fc26afdab56f068e0b2",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-07-22T23:54:35Z",
-      "creationTx": "0x20a01d3b4ebaa3ec94127fbe46728903f87328b329845c159fba70a4ad6cfdca",
-      "creationBlock": 22978122,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/TacLBTCv.json
+++ b/deployments/addresses/Mainnet/TacLBTCv.json
@@ -14,95 +14,59 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "da108c32e06dba782679802c4edaed6300460704"
     },
     "BoringVault": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "da108c32e06dba782679802c4edaed6300460704"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "da108c32e06dba782679802c4edaed6300460704"
     },
     "QueueSolver": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-04-08T23:30:35Z",
-      "creationTx": "0x832ba680d8f92135cec9f8e34f67810eba45794a7184563e66f721326c88ac03",
-      "creationBlock": 22227479,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "da108c32e06dba782679802c4edaed6300460704"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-04-09T00:31:59Z",
-      "creationTx": "0x301dd047248f371f2c31741d38d89012cd7a65a6a20184e1a8022a100673ae6d",
-      "creationBlock": 22227784,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c48ee76499340cb1cab9e4e5493e441d1088e7d1",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/TestPlasmaUSD.json
+++ b/deployments/addresses/Mainnet/TestPlasmaUSD.json
@@ -14,98 +14,62 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "d13c47c3ded2bcfe651471cf3e4b8021bf4b481a"
     },
     "QueueSolver": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-04-16T23:21:23Z",
-      "creationTx": "0x5ca133a7eb40dbed8fbc5775229869a1170fa17f5b246a74bc66ac68dccfee0a",
-      "creationBlock": 22284803,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/TurleTACETH.json
+++ b/deployments/addresses/Mainnet/TurleTACETH.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-19T19:51:23Z",
-      "creationTx": "0x73855cd1b882db7e6be0b880fa12e00a10112a1dd88b89590a73d24bf1476320",
-      "creationBlock": 21882619,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/TurtleTACBTC.json
+++ b/deployments/addresses/Mainnet/TurtleTACBTC.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-19T20:08:23Z",
-      "creationTx": "0x727d63ca6c415fb8751c788c072f82adbcdfa0ab22097ff3a6783646f1d8e65b",
-      "creationBlock": 21882703,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/TurtleTACUSD.json
+++ b/deployments/addresses/Mainnet/TurtleTACUSD.json
@@ -14,111 +14,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-02-19T20:12:59Z",
-      "creationTx": "0x6e3ef5b5d1b2baf0f20cdad5dfebff0bfef9ab714da1b5db13b811f8a4872ada",
-      "creationBlock": 21882726,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/UltraUSD.json
+++ b/deployments/addresses/Mainnet/UltraUSD.json
@@ -16,111 +16,71 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2024-12-06T03:31:47Z",
-      "creationTx": "0xd658ca5191543357397cb6e5aff3e59251aeb5148dc94b380d78027d860f6da5",
-      "creationBlock": 21340787,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/UsualBera.json
+++ b/deployments/addresses/Mainnet/UsualBera.json
@@ -14,89 +14,57 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-12-30T22:25:47Z",
-      "creationTx": "0xe80eeb8ee3960fae08063a7d5b9245ce45aa12fee8af6d2b3ab7de64a1dad6fb",
-      "creationBlock": 21518264,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/VedaTestVault.json
+++ b/deployments/addresses/Mainnet/VedaTestVault.json
@@ -14,105 +14,65 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "BoringVault": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "Lens": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "QueueSolver": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     },
     "TellerWithLayerZero": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
       "verificationGap": "cbor"
     },
     "Timelock": {
-      "deployedAt": "2025-07-02T07:22:35Z",
-      "creationTx": "0xf31e182acedbc97a2fc531c705fc1a24dfcb21b3dba87d91e1e551f71495cad3",
-      "creationBlock": 22830020,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866"
     }

--- a/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
+++ b/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
@@ -79,45 +79,29 @@
       "verificationGap": "cbor"
     },
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-09-12T20:24:35Z",
-      "creationTx": "0x97fcc57fc7d89cf93eb3f4023545cc57b48831b1961d77ce8166a5a34cc16469",
-      "creationBlock": 20736899,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-09-12T20:24:35Z",
-      "creationTx": "0xe3befd355a93f6897131e81c44c4eaa396523df6b8b5f7f2a4699b7b3bd21925",
-      "creationBlock": 20736899,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-09-12T20:24:35Z",
-      "creationTx": "0x04240140ef4d4c2fd21d47db06acc2102af3c852873b22b6179dac8db0afab96",
-      "creationBlock": 20736899,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/sLBTCDeployment.json
+++ b/deployments/addresses/Mainnet/sLBTCDeployment.json
@@ -14,95 +14,59 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3"
     },
     "BoringVault": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3c768bd068af856b5de3def86b1940676847eb9d"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "Pauser": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": false,
       "verification": "full_match",
       "verifiedCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3"
     },
     "QueueSolver": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3"
     },
     "RolesAuthority": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2025-09-11T00:23:59Z",
-      "creationTx": "0xdfefd47463693d0898bb96ae4011e14b28a3f25904be4172464214faf4a6e68b",
-      "creationBlock": 23336223,
       "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
       "auditUrl": "file:audit/certora-boring-vault-0.pdf",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "913a8cb80df7fd2ad9fc2653bc556f2901620b08"
     }

--- a/deployments/addresses/Mainnet/uniBTCv.json
+++ b/deployments/addresses/Mainnet/uniBTCv.json
@@ -12,89 +12,57 @@
   },
   "contractMetadata": {
     "AccountantWithRateProviders": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "BoringOnChainQueue": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "verificationGap": "cbor"
     },
     "BoringVault": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "Lens": {
-      "deployedAt": "2024-04-17T04:08:11Z",
-      "creationTx": "0xfe6e52cf43a2410bed6f9305fb70abb559104b267798e65353823df4aff95c35",
-      "creationBlock": 19672706,
       "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
       "verificationGap": "cbor"
     },
     "ManagerWithMerkleVerification": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"
     },
     "QueueSolver": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "RolesAuthority": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": null,
       "auditUrl": null,
-      "scopeMatch": null,
       "verification": "full_match",
       "verifiedCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
       "verificationGap": "cbor"
     },
     "TellerWithMultiAssetSupport": {
-      "deployedAt": "2024-11-15T06:34:11Z",
-      "creationTx": "0xca9d58284199bcd329dfae74c68a2083dd68594cb8defa56a36d3a149eec4634",
-      "creationBlock": 21191334,
       "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
-      "scopeMatch": true,
       "verification": "full_match",
       "verifiedCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
       "verificationGap": "cbor"


### PR DESCRIPTION
## Summary

- Removes four fields from every `contractMetadata` entry across all 44 deployment JSONs (1612 deletions):
  - `deployedAt` — derivable on-chain from the address
  - `creationTx` — same
  - `creationBlock` — same
  - `scopeMatch` — implied by whether `auditCommit` is set

- Remaining fields: `auditCommit`, `auditUrl`, `verification`, `verifiedCommit`, `verificationGap`

Companion PR in security-scripts stops `backfill_deployment_metadata.py` from writing these fields.

## Test plan
- [ ] Spot-check a few JSON files — only `auditCommit`, `auditUrl`, `verification`, `verifiedCommit`, `verificationGap` remain in `contractMetadata` entries
- [ ] `backfill_deployment_metadata.py` re-run on any vault produces only `auditCommit: null, auditUrl: null` stub entries (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)