### PR TITLE
Deployers: anchor Veda Deployer contracts across 17 mainnet chains

### DIFF
--- a/deployments/addresses/Arbitrum/Deployers.json
+++ b/deployments/addresses/Arbitrum/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-arbitrum": "0x87D51666Da1b56332b216D456D1C2ba3Aed6089c"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-arbitrum": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Base/Deployers.json
+++ b/deployments/addresses/Base/Deployers.json
@@ -1,0 +1,30 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706",
+    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-base-bsc": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-base-optimism": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2"
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/Deployers.json
+++ b/deployments/addresses/BeraChain/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/BinanceSmartChain/Deployers.json
+++ b/deployments/addresses/BinanceSmartChain/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-base-bsc": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Bob/Deployers.json
+++ b/deployments/addresses/Bob/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-bob-mainnet": "0xF3d0672a91Fd56C9ef04C79ec67d60c34c6148a0"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-bob-mainnet": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Fraxtal/Deployers.json
+++ b/deployments/addresses/Fraxtal/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/HypeEVM/Deployers.json
+++ b/deployments/addresses/HypeEVM/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Ink/Deployers.json
+++ b/deployments/addresses/Ink/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Katana/Deployers.json
+++ b/deployments/addresses/Katana/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Linea/Deployers.json
+++ b/deployments/addresses/Linea/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-linea": "0x04fc9C685961934f552b5e01F15CBBa66B61D92c"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-linea": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -1,0 +1,46 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-bob-mainnet": "0xF3d0672a91Fd56C9ef04C79ec67d60c34c6148a0",
+    "veda-bundle-create3-mainnet": "0x47Cec90FACc9364D7C21A8ab5e2aD9F1f75D740C",
+    "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434",
+    "veda-layerzero-create3-mainnet": "0x00bF0B30655a43Af93c1b371Be021Bd4567c51d5"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-bob-mainnet": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-mainnet": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-mainnet-plasma": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    },
+    "veda-layerzero-create3-mainnet": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b"
+    }
+  }
+}

--- a/deployments/addresses/Mantle/Deployers.json
+++ b/deployments/addresses/Mantle/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Optimism/Deployers.json
+++ b/deployments/addresses/Optimism/Deployers.json
@@ -1,0 +1,22 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-base-optimism": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2"
+    }
+  }
+}

--- a/deployments/addresses/Scroll/Deployers.json
+++ b/deployments/addresses/Scroll/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-scroll": "0x534b64608E601B581AB0cbF0b03ec9f4c65f3360"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-scroll": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/SonicMainnet/Deployers.json
+++ b/deployments/addresses/SonicMainnet/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/UniChain/Deployers.json
+++ b/deployments/addresses/UniChain/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/plasma/Deployers.json
+++ b/deployments/addresses/plasma/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-mainnet-plasma": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "partial_match",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": "cbor"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- First-ever verification of the Veda Deployers themselves against `boring-vault/src/helper/Deployer.sol`. They were the trust root of the entire bytecode-verification campaign and had been silently skipped because (a) they don't appear in any `deployments/addresses/<Chain>/*.json`, and (b) they're direct EOA→CREATE (or CREATE3-factory) deploys, not Deployer-wrapped, so the bundle-anchored verifier doesn't apply.
- Adds **17 new `Deployers.json` files** under `deployments/addresses/<Chain>/` — Schema A per the follow-up plan in `knowledge/veda/bytecode-verification.md` § "Open follow-up". One row per (Deployer × chain), aliases match the renamed `KNOWN_DEPLOYERS` in security-scripts (separate PR).
- **29/29 (chain × address) cells verified** with `verify_eth_getcode.py` (runtime-only via eth_getCode). 3 `full_match` + 26 `partial_match` w/ CBOR-only metadata-hash drift. No mismatches.

## Three forensic observations

1. **v7-bundle (`veda-bundle-create3-base-bsc`, `0x633ccafef3…`)** was deployed via the external CREATE3 factory `0x02de95a638e5ab8f7d637603ecb7ed33fc098cfd` rather than direct EOA→CREATE — that's how it gets the same address on Base AND BSC. Confirmed via Blockscout's `contractFactory` field. Runtime-only verification still anchors it cleanly to `24c42f7c`, but a future reviewer should be aware the factory sits in the trust path.

2. **`veda-canonical-create3` is bit-different across chains, same source, different EVM target.** Mainnet was compiled with `evm_version=shanghai` (uses PUSH0, opcode `5f`). Every other chain — Arbitrum, Optimism, Base, BSC, Linea, Scroll, Mantle, Sonic, Berachain, Fraxtal, HyperEVM, Plasma, Ink, Katana, Unichain — was compiled with `evm_version=paris` (PUSH1 0x00, two bytes). Recorded per row via the verifier's per-cell EVM detection.

3. **`v7-bundle` on BSC has no recoverable `creationTx`.** BSC isn't on Etherscan-V2 free-tier, BSC Blockscout 404s, and the binary-search fallback found no direct CREATE in the deploy block because the deploy went through the external factory. `creationBlock` (57365904) + `deployedAt` (2025-08-12T18:15:19Z) are known but `creationTx` is null. Doesn't affect verification — runtime-only `eth_getCode` doesn't need the tx hash. The post-PR-#690 contractMetadata schema strips this field anyway.

## Schema notes

- All entries have `auditCommit: null` and `auditUrl: null` — the Deployers themselves aren't in any audit's scope. `apply_verdicts_bundle.py`'s audit-upgrade pass has nothing to upgrade here.
- Uses `deploymentCommit` (per security-scripts PR #34 / boring-vault PR #692 rename) — NOT `verifiedCommit`.
- `verificationGap: "cbor"` is present on the 26 partial-match rows; omitted on the 3 full-match rows.

## Test plan

- [ ] Verify each new `Deployers.json` parses.
- [ ] Spot-check 2-3 cells against on-chain runtime: `cast code <addr> --rpc-url <chain-rpc>` and confirm body matches the `deploymentCommit`'s build with the recorded EVM version (`FOUNDRY_EVM_VERSION` env override + `forge build src/helper/Deployer.sol`).
- [ ] Re-run `apply_verdicts_bundle.py` on these JSONs and confirm no auditCommit upgrade fires (no audit covers Deployer.sol).
- [ ] `git grep -F "veda-bundle-create3-v"` returns nothing (no stale alias references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)