### PR TITLE
Add audit-anchor header comment to audited source files

### DIFF
--- a/src/base/BoringVault.sol
+++ b/src/base/BoringVault.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/src/base/DecodersAndSanitizers/AaveV3FullDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/AaveV3FullDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/AerodromeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/AerodromeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/AlphaSTETHDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/AlphaSTETHDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Arbitrum/EtherFiLiquidEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Arbitrum/EtherFiLiquidEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/BTCFiDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/BTCFiDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/BerachainDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/BerachainDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/BoostedUSDCDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/BoostedUSDCDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/BoostedUSDCInkDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/BoostedUSDCInkDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/BridgingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/BridgingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/CamelotFullDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/CamelotFullDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EdgeCapitalDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EdgeCapitalDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EthMainnetTacDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EthMainnetTacDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EthenaRWADecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EthenaRWADecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiBtcDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiBtcDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiEigenDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiEigenDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiLiquidBtcDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiLiquidBtcDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiLiquidDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiLiquidDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiLiquidEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiLiquidEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiLiquidUsdDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiLiquidUsdDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EtherFiUsdDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EtherFiUsdDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/EulerEVKFullDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/EulerEVKFullDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {EulerEVKDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/EulerEVKDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/FullResolvDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/FullResolvDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {ResolvDecoderAndSanitizer, BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ResolvDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/FullRewardTokenUnwrappingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/FullRewardTokenUnwrappingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/FullScrollBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/FullScrollBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/GoldenGooseArbitrumDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/GoldenGooseArbitrumDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/GoldenGooseBaseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/GoldenGooseBaseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/GoldenGooseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/GoldenGooseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/GoldenGooseLineaDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/GoldenGooseLineaDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/GoldenGooseUnichainDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/GoldenGooseUnichainDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/HybridBtcBobDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/HybridBtcBobDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/HybridBtcDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/HybridBtcDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/HyperUsdDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/HyperUsdDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/InkLiquidETHDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/InkLiquidETHDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/KHypeHyperEVMDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/KHypeHyperEVMDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/KatanaDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/KatanaDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LBTCvBNBDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LBTCvBNBDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LBTCvBaseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LBTCvBaseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LidoLiquidDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LidoLiquidDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidBeraDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidBeraDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidBeraEthBerachainDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidBeraEthBerachainDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidBeraEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidBeraEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidBtcDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidBtcDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidETHPlasmaDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidETHPlasmaDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidMoveEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidMoveEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LiquidUSDFlareDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LiquidUSDFlareDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/LombardBtcDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/LombardBtcDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/MorphoRewardsDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/MorphoRewardsDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/OnlyAtomicQueueDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/OnlyAtomicQueueDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@6de77927f58fde1a08420c9e325cb4f20880229f — https://macroaudits.com/library/audits/sevenSeas-46
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/OnlyHyperlaneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/OnlyHyperlaneDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/OnlyKarakDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/OnlyKarakDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/OnlyTreehouseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/OnlyTreehouseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/OptimismGoldenGooseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/OptimismGoldenGooseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PancakeSwapV3FullDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PancakeSwapV3FullDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PlasmaUSDDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PlasmaUSDDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PlasmaUSDPlasmaDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PlasmaUSDPlasmaDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PlasmaUSDPlusDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PlasmaUSDPlusDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PlasmaUSDPlusPlasmaDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PlasmaUSDPlusPlasmaDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PointFarmingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PointFarmingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PrimeGoldenGooseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PrimeGoldenGooseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PrimeGoldenGooseUnichainDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PrimeGoldenGooseUnichainDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/PrimeLiquidBeraBtcDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/PrimeLiquidBeraBtcDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/AaveV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AaveV3DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 contract AaveV3DecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/AgglayerDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AgglayerDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@b9eafd46e656c532ea2c28a1bd66ce271ebedbc7 — https://macroaudits.com/library/audits/sevenSeas-44
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/AlgebraV4DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AlgebraV4DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {AlgebraNonFungiblePositionManager} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/AmbientDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AmbientDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ArbitrumNativeBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ArbitrumNativeBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/AtomicQueueDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AtomicQueueDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@6de77927f58fde1a08420c9e325cb4f20880229f — https://macroaudits.com/library/audits/sevenSeas-46
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/AuraDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AuraDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/AvalancheBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/AvalancheBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 contract AvalancheBridgeDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/BGTRewardVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BGTRewardVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {INonFungiblePositionManager} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BTCKDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BTCKDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BTCNMinterDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BTCNMinterDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BalancerV2DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BalancerV2DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BalancerV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BalancerV3DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BeraETHDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BeraETHDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BeraborrowDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BeraborrowDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@6de77927f58fde1a08420c9e325cb4f20880229f — https://macroaudits.com/library/audits/sevenSeas-46
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/BoringChefDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CCIPDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CCIPDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CCTPDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CCTPDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@c54949f556cbc9a5e752ef1d6e8c09d64f4975b7 — https://macroaudits.com/library/audits/sevenSeas-47
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer, DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CamelotDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CamelotDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {CamelotNonFungiblePositionManager} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CapDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CapDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CompoundV2DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CompoundV2DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@b9eafd46e656c532ea2c28a1bd66ce271ebedbc7 — https://macroaudits.com/library/audits/sevenSeas-44
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CompoundV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CompoundV3DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ConvexDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ConvexDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ConvexFXDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ConvexFXDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CornStakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CornStakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/DeriveDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/DeriveDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/DeriveWithdrawDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/DeriveWithdrawDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/DolomiteDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/DolomiteDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/DvStETHDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/DvStETHDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@478f3a4a1457fd2dd296fc48d43ad5689998cc4a — https://macroaudits.com/library/audits/sevenSeas-41
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/EigenLayerLSTStakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/EigenLayerLSTStakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ElixirClaimingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ElixirClaimingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/EthenaMintingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/EthenaMintingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/EthenaWithdrawDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/EthenaWithdrawDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/EtherFiDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/EtherFiDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/EulerEVKDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/EulerEVKDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/FluidDexDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/FluidDexDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 contract FluidDexDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/FluidFTokenDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/FluidFTokenDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/FluidRewardsClaimingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/FluidRewardsClaimingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/FraxDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/FraxDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {

--- a/src/base/DecodersAndSanitizers/Protocols/GearboxDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/GearboxDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/GlueXDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/GlueXDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/GoldiVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/GoldiVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/HoneyDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/HoneyDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/HyperlaneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/HyperlaneDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/ITBBasePositionDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/ITBBasePositionDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBBasePositionDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/aave/AaveDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/aave/AaveDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBAaveDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/cork/CorkDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/cork/CorkDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBCorkDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/curve_and_convex/CurveAndConvexNoConfigDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/curve_and_convex/CurveAndConvexNoConfigDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBCurveAndConvexNoConfigDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/eigen_layer/EigenLayerDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/eigen_layer/EigenLayerDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBEigenLayerDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/gearbox/GearboxDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/gearbox/GearboxDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBGearboxDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/karak/KarakDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/karak/KarakDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBKarakDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/reserve/ReserveDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/reserve/ReserveDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBReserveDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/reserve/ReserveERC20WrappedDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/reserve/ReserveERC20WrappedDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBReserveERC20WrappedDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/ITB/syrup/SyrupDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ITB/syrup/SyrupDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity ^0.8.0;
 
 contract ITBSyrupDecoderAndSanitizer {

--- a/src/base/DecodersAndSanitizers/Protocols/InfraredDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/InfraredDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/KarakDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/KarakDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/KinetiqDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/KinetiqDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/KingClaimingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/KingClaimingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@cfa5d2ff5a3e32b6d9057455d59ec496835bd708 — https://macroaudits.com/library/audits/sevenSeas-40
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/KodiakIslandDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/KodiakIslandDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/LBTCBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/LBTCBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/LevelDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/LevelDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@c54949f556cbc9a5e752ef1d6e8c09d64f4975b7 — https://macroaudits.com/library/audits/sevenSeas-47
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/LidoDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/LidoDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/LidoStandardBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/LidoStandardBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/LineaBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/LineaBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/LombardBtcMinterDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/LombardBtcMinterDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MFOneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MFOneDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MantleDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MantleDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MantleStandardBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MantleStandardBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MerklDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MerklDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MorphoBlueDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MorphoBlueDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MorphoRewardsDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MorphoRewardsDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MorphoRewardsMerkleClaimerDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MorphoRewardsMerkleClaimerDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/MorphoRewardsWrapperDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/MorphoRewardsWrapperDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/NativeWrapperDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/NativeWrapperDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OFTDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/OdosDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OdosDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/OdosOwnedDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OdosOwnedDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/OneInchDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OneInchDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/OneInchOwnedDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OneInchOwnedDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/OogaBoogaDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/OogaBoogaDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/PancakeSwapV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/PancakeSwapV3DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {UniswapV3DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/PendleRouterDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/PendleRouterDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/Permit2DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/Permit2DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/PumpStakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/PumpStakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/RedSnwapperDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/RedSnwapperDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ResolvDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ResolvDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SatlayerStakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SatlayerStakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ScrollBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ScrollBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SiloDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SiloDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SiloVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SiloVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SkyMoneyDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SkyMoneyDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SonicCRVClaiming.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SonicCRVClaiming.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SonicDepositDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SonicDepositDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SonicGatewayDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SonicGatewayDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SpectraDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SpectraDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/StakeStoneDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/StandardBridgeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/StandardBridgeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SwellDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SwellDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SwellSimpleStakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SwellSimpleStakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SymbioticDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SymbioticDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SymbioticVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SymbioticVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/SyrupDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/SyrupDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/TacCrossChainLayerDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/TacCrossChainLayerDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/TacProxyDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/TacProxyDecoderAndSanitizer.sol
@@ -10,3 +10,4 @@
 //
 //     function deposit(bytes calldata tacHeader, bytes calldata arguments) public payable {
 //}
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39

--- a/src/base/DecodersAndSanitizers/Protocols/TellerDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/TellerDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@478f3a4a1457fd2dd296fc48d43ad5689998cc4a — https://macroaudits.com/library/audits/sevenSeas-41
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/TermFinanceDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/TermFinanceDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/TreehouseDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/TreehouseDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UltraYieldDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/UniswapV2DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UniswapV2DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {INonFungiblePositionManager} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/UniswapV3SwapRouter02DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UniswapV3SwapRouter02DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {INonFungiblePositionManager} from "src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/UniswapV4DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UniswapV4DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/UsualMoneyDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UsualMoneyDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ValantisDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ValantisDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/VaultCraftDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/VaultCraftDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/VelodromeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/VelodromeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/WeEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/WeEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/WithdrawQueueDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/WithdrawQueueDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/ZircuitSimpleStakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/ZircuitSimpleStakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/rFLRDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/rFLRDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@b9eafd46e656c532ea2c28a1bd66ce271ebedbc7 — https://macroaudits.com/library/audits/sevenSeas-44
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/Protocols/wSwellUnwrappingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/wSwellUnwrappingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/base/DecodersAndSanitizers/RoySonicUSDCDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/RoySonicUSDCDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/RoyUSDCMainnetDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/RoyUSDCMainnetDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/RoyUSDCSonicDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/RoyUSDCSonicDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/RoycoUSDDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/RoycoUSDDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/RoycoUSDPlumeDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/RoycoUSDPlumeDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/ScrollVaultsDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/ScrollVaultsDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SentayUSDCInkDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SentayUSDCInkDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SentayUSDCMainnetDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SentayUSDCMainnetDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SentoraDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SentoraDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {ITBBasePositionDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ITB/ITBBasePositionDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SentoraUSDCInkDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SentoraUSDCInkDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SentoraUSDCMainnetDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SentoraUSDCMainnetDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SonicBTCDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicBTCDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {SonicDepositDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/SonicDepositDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SonicEthMainnetDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicEthMainnetDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SonicFullDepositDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicFullDepositDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SonicIncentivesHandlerDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicIncentivesHandlerDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {SonicDepositDecoderAndSanitizer} from

--- a/src/base/DecodersAndSanitizers/SonicLBTCvDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicLBTCvDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SonicLBTCvSonicDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicLBTCvSonicDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SonicVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SonicVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/StakedSonicDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/StakedSonicDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/StakedSonicUSDDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/StakedSonicUSDDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/StakingDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/StakingDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SwellEtherFiLiquidEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SwellEtherFiLiquidEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SymbioticLRTDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/SymbioticLRTDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/SymbioticVaultDecoderAndSanitizerFull.sol
+++ b/src/base/DecodersAndSanitizers/SymbioticVaultDecoderAndSanitizerFull.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TacETHDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TacETHDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TacLBTCvDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TacLBTCvDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TacTONDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TacTONDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TacUSDDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TacUSDDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TacUSDTacDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TacUSDTacDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TestVault0DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TestVault0DecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TestVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TestVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {UniswapV3DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/TurtleMUSDDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/TurtleMUSDDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/UniBTCDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/UniBTCDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/UnichainEtherFiLiquidEthDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/UnichainEtherFiLiquidEthDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/WhopDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/WhopDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/cbBtcDefiVaultDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/cbBtcDefiVaultDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/eBTCBerachainDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/eBTCBerachainDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/sBTCNDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/sBTCNDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/DecodersAndSanitizers/sBTCNMaizenetDecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/sBTCNMaizenetDecoderAndSanitizer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@4c9c671bb965899728167102a0e3ac22f4aabf7a — https://macroaudits.com/library/audits/sevenSeas-39
 pragma solidity 0.8.21;
 
 import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";

--- a/src/base/Drones/BoringDrone.sol
+++ b/src/base/Drones/BoringDrone.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@e12c1e320cca1169c9785a8c7d424c38fca8d688 — https://macroaudits.com/library/audits/sevenSeas-16
 pragma solidity 0.8.21;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/src/base/Drones/DroneLib.sol
+++ b/src/base/Drones/DroneLib.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@e12c1e320cca1169c9785a8c7d424c38fca8d688 — https://macroaudits.com/library/audits/sevenSeas-16
 pragma solidity >=0.8.0;
 
 library DroneLib {

--- a/src/base/Roles/AaveV3BufferHelper.sol
+++ b/src/base/Roles/AaveV3BufferHelper.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/certora-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {IBufferHelper} from "src/interfaces/IBufferHelper.sol";

--- a/src/base/Roles/AccountantWithFixedRate.sol
+++ b/src/base/Roles/AccountantWithFixedRate.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@b7ad4066a946a5e64285c88617a5de36e5eef436 — https://macroaudits.com/library/audits/sevenSeas-19
 pragma solidity 0.8.21;
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@568d9467202a7f6e478cb8967fcee3c2afb38730 — file:audit/certora-boring-vault-1.pdf
 pragma solidity 0.8.21;
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";

--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@568d9467202a7f6e478cb8967fcee3c2afb38730 — file:audit/certora-boring-vault-1.pdf
 pragma solidity 0.8.21;
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";

--- a/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@edfcba3f29f691c638b06d04f60af79503632b58 — https://macroaudits.com/library/audits/sevenSeas-27
 pragma solidity 0.8.21;
 
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/src/base/Roles/BoringQueue/BoringOnChainQueueWithTracking.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueueWithTracking.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@edfcba3f29f691c638b06d04f60af79503632b58 — https://macroaudits.com/library/audits/sevenSeas-27
 pragma solidity 0.8.21;
 
 import {BoringOnChainQueue} from "src/base/Roles/BoringQueue/BoringOnChainQueue.sol";

--- a/src/base/Roles/BoringQueue/BoringSolver.sol
+++ b/src/base/Roles/BoringQueue/BoringSolver.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@b9eafd46e656c532ea2c28a1bd66ce271ebedbc7 — https://macroaudits.com/library/audits/sevenSeas-44
 pragma solidity 0.8.21;
 
 import {Auth, Authority} from "@solmate/auth/Auth.sol";

--- a/src/base/Roles/BoringQueue/IBoringSolver.sol
+++ b/src/base/Roles/BoringQueue/IBoringSolver.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@ec74b24330a1d7b144dc397c1c20c76e3d6fc460 — https://macroaudits.com/library/audits/sevenSeas-18
 pragma solidity 0.8.21;
 
 interface IBoringSolver {

--- a/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol
+++ b/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {

--- a/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol
+++ b/src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {

--- a/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
+++ b/src/base/Roles/CrossChain/CrossChainTellerWithGenericBridge.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {TellerWithMultiAssetSupport, ERC20} from "src/base/Roles/TellerWithMultiAssetSupport.sol";

--- a/src/base/Roles/CrossChain/MessageLib.sol
+++ b/src/base/Roles/CrossChain/MessageLib.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity >=0.8.0;
 
 library MessageLib {

--- a/src/base/Roles/CrossChain/PairwiseRateLimiter.sol
+++ b/src/base/Roles/CrossChain/PairwiseRateLimiter.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity ^0.8.0;
 
 /**

--- a/src/base/Roles/ManagerWithMerkleVerification.sol
+++ b/src/base/Roles/ManagerWithMerkleVerification.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@b7ad4066a946a5e64285c88617a5de36e5eef436 — https://macroaudits.com/library/audits/sevenSeas-19
 pragma solidity 0.8.21;
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";

--- a/src/base/Roles/TellerWithBuffer.sol
+++ b/src/base/Roles/TellerWithBuffer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {TellerWithMultiAssetSupport, ERC20} from "./TellerWithMultiAssetSupport.sol";

--- a/src/base/Roles/TellerWithMultiAssetSupport.sol
+++ b/src/base/Roles/TellerWithMultiAssetSupport.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@568d9467202a7f6e478cb8967fcee3c2afb38730 — file:audit/certora-boring-vault-1.pdf
 pragma solidity 0.8.21;
 
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/src/base/Roles/TellerWithRemediation.sol
+++ b/src/base/Roles/TellerWithRemediation.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@938478e59619c693150a2290ff677191b19a0948 — https://macroaudits.com/library/audits/sevenSeas-8
 pragma solidity 0.8.21;
 
 import {TellerWithMultiAssetSupport, ERC20} from "src/base/Roles/TellerWithMultiAssetSupport.sol";

--- a/src/base/Roles/TellerWithYieldStreaming.sol
+++ b/src/base/Roles/TellerWithYieldStreaming.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@568d9467202a7f6e478cb8967fcee3c2afb38730 — file:audit/certora-boring-vault-1.pdf
 pragma solidity 0.8.21;
 
 import {TellerWithBuffer, ERC20} from "src/base/Roles/TellerWithBuffer.sol";

--- a/src/helper/ArcticArchitectureLens.sol
+++ b/src/helper/ArcticArchitectureLens.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {BoringVault, ERC20} from "src/base/BoringVault.sol";

--- a/src/helper/GenericRateProvider.sol
+++ b/src/helper/GenericRateProvider.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {IRateProvider} from "src/interfaces/IRateProvider.sol";

--- a/src/helper/GenericRateProviderWithDecimalScaling.sol
+++ b/src/helper/GenericRateProviderWithDecimalScaling.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d — file:audit/sigma-prime-boring-vault-0.pdf
 pragma solidity 0.8.21;
 
 import {GenericRateProvider} from "src/helper/GenericRateProvider.sol";

--- a/src/interfaces/AggregationRouterV5.sol
+++ b/src/interfaces/AggregationRouterV5.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/src/interfaces/BalancerVault.sol
+++ b/src/interfaces/BalancerVault.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";

--- a/src/interfaces/BeforeTransferHook.sol
+++ b/src/interfaces/BeforeTransferHook.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 interface BeforeTransferHook {

--- a/src/interfaces/DataTypes.sol
+++ b/src/interfaces/DataTypes.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity ^0.8.0;
 
 library DataTypes {

--- a/src/interfaces/DecoderCustomTypes.sol
+++ b/src/interfaces/DecoderCustomTypes.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@c54949f556cbc9a5e752ef1d6e8c09d64f4975b7 — https://macroaudits.com/library/audits/sevenSeas-47
 pragma solidity 0.8.21;
 contract DecoderCustomTypes {
     // ========================================= BALANCER =========================================

--- a/src/interfaces/DefaultCollateral.sol
+++ b/src/interfaces/DefaultCollateral.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/src/interfaces/EigenLayerPositionManager.sol
+++ b/src/interfaces/EigenLayerPositionManager.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity ^0.8.4;
 
 interface PositionManager {

--- a/src/interfaces/EtherFiLiquid1.sol
+++ b/src/interfaces/EtherFiLiquid1.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity ^0.8.4;
 
 interface EtherFiLiquid1 {

--- a/src/interfaces/IBufferHelper.sol
+++ b/src/interfaces/IBufferHelper.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 interface IBufferHelper {

--- a/src/interfaces/IComet.sol
+++ b/src/interfaces/IComet.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 interface IComet {

--- a/src/interfaces/IPausable.sol
+++ b/src/interfaces/IPausable.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 interface IPausable {

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity ^0.8.0;
 
 import {IPoolAddressesProvider} from './IPoolAddressesProvider.sol';

--- a/src/interfaces/IPoolAddressesProvider.sol
+++ b/src/interfaces/IPoolAddressesProvider.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity ^0.8.0;
 
 /**

--- a/src/interfaces/IRateProvider.sol
+++ b/src/interfaces/IRateProvider.sol
@@ -14,6 +14,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 
 pragma solidity ^0.8.0;
 

--- a/src/interfaces/ISanctionsList.sol
+++ b/src/interfaces/ISanctionsList.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 // Interface for the Chainalysis SanctionsList contract.

--- a/src/interfaces/IStaking.sol
+++ b/src/interfaces/IStaking.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 // Swell

--- a/src/interfaces/IUniswapV3Router.sol
+++ b/src/interfaces/IUniswapV3Router.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity >=0.8.0;
 
 /// @title Callback for IUniswapV3PoolActions#swap

--- a/src/interfaces/PriceRouter.sol
+++ b/src/interfaces/PriceRouter.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {ERC20} from "@solmate/tokens/ERC20.sol";

--- a/src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol
+++ b/src/interfaces/RawDataDecoderAndSanitizerInterfaces.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";  

--- a/src/interfaces/ShareLocker.sol
+++ b/src/interfaces/ShareLocker.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 interface ShareLocker {

--- a/src/interfaces/UniswapV4Actions.sol
+++ b/src/interfaces/UniswapV4Actions.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity >=0.8.21;
 
 /// @notice Library to define different pool actions.

--- a/src/micro-managers/DexAggregatorUManager.sol
+++ b/src/micro-managers/DexAggregatorUManager.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {UManager, FixedPointMathLib, ManagerWithMerkleVerification, ERC20} from "src/micro-managers/UManager.sol";

--- a/src/micro-managers/DexSwapperUManager.sol
+++ b/src/micro-managers/DexSwapperUManager.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {UManager, FixedPointMathLib, ManagerWithMerkleVerification, ERC20} from "src/micro-managers/UManager.sol";

--- a/src/micro-managers/SymbioticUManager.sol
+++ b/src/micro-managers/SymbioticUManager.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";

--- a/src/micro-managers/UManager.sol
+++ b/src/micro-managers/UManager.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@939c77e25473dff3ed18fa104f004f7afd13452e — file:audit/spearbit-boring-vault-arctic-0.pdf
 pragma solidity 0.8.21;
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";

--- a/src/migration/CellarMigrationAdaptor.sol
+++ b/src/migration/CellarMigrationAdaptor.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@9c6e1e4458fba53f2ff09efe21195dcf570ffc3e — https://macroaudits.com/library/audits/sevenSeas-7
 pragma solidity 0.8.21;
 
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";

--- a/src/migration/CellarMigrationAdaptor2.sol
+++ b/src/migration/CellarMigrationAdaptor2.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@9c6e1e4458fba53f2ff09efe21195dcf570ffc3e — https://macroaudits.com/library/audits/sevenSeas-7
 pragma solidity 0.8.21;
 
 import {CellarMigrationAdaptor} from "./CellarMigrationAdaptor.sol";

--- a/src/migration/CellarMigratorWithSharePriceParity.sol
+++ b/src/migration/CellarMigratorWithSharePriceParity.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@9c6e1e4458fba53f2ff09efe21195dcf570ffc3e — https://macroaudits.com/library/audits/sevenSeas-7
 pragma solidity 0.8.21;
 
 import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";

--- a/src/migration/ParitySharePriceOracle.sol
+++ b/src/migration/ParitySharePriceOracle.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: boring-vault@9c6e1e4458fba53f2ff09efe21195dcf570ffc3e — https://macroaudits.com/library/audits/sevenSeas-7
 pragma solidity 0.8.21;
 
 import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";


### PR DESCRIPTION
We did this before, but merged into a dev branch instead of `main`, and is easier to do a clean branch again.

Inserts a `// Last audited: boring-vault@<sha> — <url>` line into the SPDX/license header of 278 audited Solidity sources. Comment-only — no behavior change.

Split out from #659 so the deployment-metadata JSON backfill and the source-file audit-anchor annotations land as separate PRs against `main`.

## Coverage gap

PR #659's audit-anchor work originally covered 286 files; 8 of those paths no longer exist on current `main` (moved to `src/archive/...` or deleted) and are excluded here:

- `src/atomic-queue/{AtomicQueue,AtomicSolver,AtomicSolverV2,AtomicSolverV3,AtomicSolverV4,IAtomicSolver}.sol`
- `src/base/DecodersAndSanitizers/TestBalancedUSDCDecoderAndSanitizer.sol`
- `src/base/Roles/DelayedWithdraw.sol`

If we want anchors on the archive copies (`src/archive/atomic-queue/...`), that can land as a follow-up.