### PR TITLE
ci: cap fuzz/invariant runs on PRs, add nightly full-power workflow

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -1,0 +1,45 @@
+name: nightly-fuzz
+
+on:
+  schedule:
+    # 22:00 UTC daily — finishes overnight, results ready by morning.
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: nightly
+
+jobs:
+  fuzz:
+    name: Nightly fuzz + invariant
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    env:
+      MAINNET_RPC_URL: https://mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      ARBITRUM_RPC_URL: https://arbitrum-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      BASE_RPC_URL: https://base-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      AVALANCHE_RPC_URL: https://avalanche-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      OPTIMISM_RPC_URL: https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      LINEA_RPC_URL: https://linea-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      MANTLE_RPC_URL: https://mantle-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      HOLESKY_RPC_URL: https://holesky.infura.io/v3/${{ secrets.INFURA_API_KEY_0 }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge build --skip script
+        id: build
+
+      - name: Run Forge tests
+        run: |
+          forge test -vv --skip SymbioticVaultIntegration --skip CreateTimelockTx
+        id: test

--- a/foundry.toml
+++ b/foundry.toml
@@ -100,3 +100,14 @@ FOUNDRY_FMT_NUMBER_UNDERSCORE = "thousands"
 FOUNDRY_FMT_OVERRIDE_SPACING = true
 FOUNDRY_FMT_WRAP_COMMENTS = false
 FOUNDRY_FMT_IGNORE = []
+
+# CI profile: inherits from default, overrides fuzz/invariant to fit the
+# GitHub Actions 6h job cap. `FOUNDRY_PROFILE=ci` is set in .github/workflows/test.yml.
+[profile.ci.fuzz]
+runs = 256
+seed = "0x0000000000000000000000000000000000000000000000000000000000000002"
+
+[profile.ci.invariant]
+runs = 32
+depth = 100
+fail_on_revert = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -111,3 +111,16 @@ seed = "0x0000000000000000000000000000000000000000000000000000000000000002"
 runs = 32
 depth = 100
 fail_on_revert = false
+
+# Nightly profile: inherits from default, raises fuzz/invariant intensity for
+# the scheduled deep run. `FOUNDRY_PROFILE=nightly` is set in
+# .github/workflows/nightly-fuzz.yml. Tune values against the GitHub Actions
+# 6h job cap.
+[profile.nightly.fuzz]
+runs = 16000
+seed = "0x0000000000000000000000000000000000000000000000000000000000000002"
+
+[profile.nightly.invariant]
+runs = 256
+depth = 500
+fail_on_revert = false


### PR DESCRIPTION
## Summary

Stacked on top of #695. After #695 unblocks `forge test`, the `Foundry project` job hits GitHub Actions' 6h hard cap because `FOUNDRY_PROFILE=ci` is set in `.github/workflows/test.yml` but no `[profile.ci]` section exists in `foundry.toml` — Foundry silently falls back to the default profile, which runs `fuzz.runs = 8000` and Foundry's default invariant settings (runs=256, depth=500) against the new `test/fuzzing/` invariant suite (~50 invariants across two systems).

This PR does two things:

### 1. Add `[profile.ci]` so PR CI fits the time budget

- `fuzz.runs`: 8000 → 256 (Foundry default)
- `invariant.runs`: 32, `depth`: 100, `fail_on_revert`: false
- Seed pinned for determinism

The local `[fuzz]` block (default profile) is untouched, so dev runs keep the 8000-run coverage.

### 2. Add a nightly full-power workflow

To preserve the heavier coverage we're giving up on PRs, add a scheduled GitHub Actions job that runs once a night under a beefier profile:

- New `[profile.nightly]` in `foundry.toml`:
  - `fuzz.runs`: 16000 (2× the default)
  - `invariant.runs`: 256, `depth`: 500, `fail_on_revert`: false
- New `.github/workflows/nightly-fuzz.yml`:
  - `cron: '0 22 * * *'` (22:00 UTC) + `workflow_dispatch`
  - sets `FOUNDRY_PROFILE=nightly`
  - mirrors `test.yml`'s setup (same RPC secrets, same skip flags)
  - `timeout-minutes: 350` (within the 6h cap)

No alerting wired up yet — results are checked manually in the **Actions** tab each morning. Note: GitHub Actions only honors scheduled workflows on the default branch, so the cron trigger starts firing once this PR merges to `main`. Until then, it can be triggered manually via `workflow_dispatch` from the PR branch.

## Test plan

- [x] CI `Foundry project` job completes under 6h
- [ ] `forge test -vv --skip SymbioticVaultIntegration --skip CreateTimelockTx` passes on the PR profile
- [ ] Fuzz and invariant tests are still executed on the PR profile (look for \`[PASS] testFuzz_…\` / \`[PASS] invariant_…\` lines)
- [ ] Manually trigger the nightly workflow via \`workflow_dispatch\` and confirm it runs under the nightly profile within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)