### PR TITLE
NatSpec: document yield-distribution design on vestYield

### DIFF
--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -161,11 +161,12 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
      * @param duration The period over which to vest this yield
      * @notice callable by the STRATEGIST role
      * @dev `yieldAmount` should be denominated in the BASE ASSET
-     * @dev Yield is distributed pro-rata to the share supply at the moment
-     *      vestYield is called. Deposits before vestYield mint at a stale
-     *      rate then share in the streamed gains; withdrawals during vesting
-     *      capture only vested-so-far. Per-event extraction is bounded by
-     *      maxDeviationYield; strategists are expected to pair yield
+     * @dev Yield vests linearly over `duration`; each subsequent
+     *      _updateExchangeRate call moves newly-vested gains into the share
+     *      price against vault.totalSupply() at that moment. Deposits during
+     *      vesting share in remaining gains; withdrawals capture only
+     *      vested-so-far. maxDeviationYield caps the per-day rate, not the
+     *      per-event total. Strategists are expected to pair yield
      *      realization with vestYield.
      */
     function vestYield(uint256 yieldAmount, uint256 duration) external requiresAuth {

--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -161,6 +161,12 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
      * @param duration The period over which to vest this yield
      * @notice callable by the STRATEGIST role
      * @dev `yieldAmount` should be denominated in the BASE ASSET
+     * @dev Yield is distributed pro-rata to the share supply at the moment
+     *      vestYield is called. Deposits before vestYield mint at a stale
+     *      rate then share in the streamed gains; withdrawals during vesting
+     *      capture only vested-so-far. Per-event extraction is bounded by
+     *      maxDeviationYield; strategists are expected to pair yield
+     *      realization with vestYield.
      */
     function vestYield(uint256 yieldAmount, uint256 duration) external requiresAuth {
         if (accountantState.isPaused) revert AccountantWithRateProviders__Paused();


### PR DESCRIPTION
## Summary

Adds a `@dev` block to `vestYield` in `AccountantWithYieldStreaming.sol` documenting the intentional yield-distribution design. Reporters keep filing this as a vulnerability (most recently #78170, #78646); the design choice has been verified by Kevin but has never been codified in source.

Text:

```solidity
/// @dev Yield vests linearly over `duration`; each subsequent
///      _updateExchangeRate call moves newly-vested gains into the share
///      price against vault.totalSupply() at that moment. Deposits during
///      vesting share in remaining gains; withdrawals capture only
///      vested-so-far. maxDeviationYield caps the per-day rate, not the
///      per-event total. Strategists are expected to pair yield
///      realization with vestYield.
```

First of a planned series codifying intentional design choices at the call site so reporters reading the source see the carve-out before filing. PR review is the approval gate for what gets disclaimed publicly — landing these one at a time to keep each one reviewable.

## Test plan

- [ ] NatSpec wording is accurate to the code: linear vesting over `duration`, denominator sampled at each `_updateExchangeRate` call (not at vestYield-time), `maxDeviationYield` is a per-day rate cap (not per-event), atomicity is operational not on-chain.
- [ ] Comments only — no code change. `forge build` should succeed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)