### PR TITLE
NatSpec: three more design choices (vestYield =, queue hash, UniV3 fee-tier)

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol
@@ -27,6 +27,15 @@ contract UniswapV3DecoderAndSanitizer {
 
     //============================== UNISWAP V3 ===============================
 
+    /**
+     * @dev The path walk packs the 20-byte token addresses but not the 3-byte
+     *      fee tier between hops, and amountIn / amountOutMinimum are not
+     *      bound. By design, decoder leaves authorize swap shapes (which
+     *      tokens, which receiver) rather than specific values (which pool,
+     *      what slippage). A strategist with an authored leaf for a token
+     *      pair may route through any fee-tier pool of that pair, with any
+     *      slippage floor.
+     */
     function exactInput(DecoderCustomTypes.ExactInputParams calldata params)
         external
         pure

--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -169,6 +169,9 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
      *      vested-so-far. maxDeviationYield caps the per-day rate, not the
      *      per-event total. Strategists are expected to pair yield
      *      realization with vestYield.
+     * @dev vestYield overwrites any active vest; strategists must include any
+     *      unvested remainder in yieldAmount. The `=` semantic (vs `+=`) is
+     *      deliberate, to allow mid-stream adjustments after PnL events.
      */
     function vestYield(uint256 yieldAmount, uint256 duration) external requiresAuth {
         if (accountantState.isPaused) revert AccountantWithRateProviders__Paused();

--- a/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
@@ -353,6 +353,11 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @param discount The discount to apply to the withdraw in bps.
      * @param secondsToDeadline The time in seconds the request is valid for.
      * @return requestId The request Id.
+     * @dev Requests are stored as keccak256(abi.encode(OnChainWithdraw)) only.
+     *      The full struct is emitted in OnChainWithdrawRequested at request time
+     *      and must be retained off-chain (event indexer or tx receipt) to cancel
+     *      or solve. No on-chain requestId → struct mapping; recovery is
+     *      event-indexer responsibility by design.
      */
     function requestOnChainWithdraw(address assetOut, uint128 amountOfShares, uint16 discount, uint24 secondsToDeadline)
         external
@@ -417,6 +422,11 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @notice Cancel an on-chain withdraw.
      * @param request The request to cancel.
      * @return requestId The request Id.
+     * @dev Requests are stored as keccak256(abi.encode(OnChainWithdraw)) only.
+     *      The full struct is emitted in OnChainWithdrawRequested at request time
+     *      and must be retained off-chain (event indexer or tx receipt) to cancel
+     *      or solve. No on-chain requestId → struct mapping; recovery is
+     *      event-indexer responsibility by design.
      */
     function cancelOnChainWithdraw(OnChainWithdraw memory request)
         external
@@ -452,6 +462,11 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @param requests The requests to solve.
      * @param solveData The data to use to solve the requests.
      * @param solver The address of the solver.
+     * @dev Requests are stored as keccak256(abi.encode(OnChainWithdraw)) only.
+     *      The full struct is emitted in OnChainWithdrawRequested at request time
+     *      and must be retained off-chain (event indexer or tx receipt) to cancel
+     *      or solve. No on-chain requestId → struct mapping; recovery is
+     *      event-indexer responsibility by design.
      */
     function solveOnChainWithdraws(OnChainWithdraw[] calldata requests, bytes calldata solveData, address solver)
         external

--- a/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
@@ -388,6 +388,11 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @param r The r value of the permit signature.
      * @param s The s value of the permit signature.
      * @return requestId The request Id.
+     * @dev Requests are stored as keccak256(abi.encode(OnChainWithdraw)) only.
+     *      The full struct is emitted in OnChainWithdrawRequested at request time
+     *      and must be retained off-chain (event indexer or tx receipt) to cancel
+     *      or solve. No on-chain requestId → struct mapping; recovery is
+     *      event-indexer responsibility by design.
      */
     function requestOnChainWithdrawWithPermit(
         address assetOut,
@@ -444,6 +449,11 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @param secondsToDeadline The time in seconds the new withdraw request is valid for.
      * @return oldRequestId The request Id of the old withdraw request.
      * @return newRequestId The request Id of the new withdraw request.
+     * @dev Requests are stored as keccak256(abi.encode(OnChainWithdraw)) only.
+     *      The full struct is emitted in OnChainWithdrawRequested at request time
+     *      and must be retained off-chain (event indexer or tx receipt) to cancel
+     *      or solve. No on-chain requestId → struct mapping; recovery is
+     *      event-indexer responsibility by design.
      */
     function replaceOnChainWithdraw(OnChainWithdraw memory oldRequest, uint16 discount, uint24 secondsToDeadline)
         external

--- a/src/base/Roles/ManagerWithMerkleVerification.sol
+++ b/src/base/Roles/ManagerWithMerkleVerification.sol
@@ -189,6 +189,10 @@ contract ManagerWithMerkleVerification is Auth, IPausable {
      * @dev userData can optionally have salt encoded at the end of it, in order to change the intentHash,
      *      if a flash loan is exact userData is being repeated, and their is fear of 3rd parties
      *      front-running the rebalance.
+     * @dev Post-flashloan ops use manageRoot[address(manager)], a shared root
+     *      curated by the admin role, not the calling strategist's per-strategist
+     *      root. Per-strategist permission isolation does not extend through this
+     *      callback by design.
      */
     function receiveFlashLoan(
         address[] calldata tokens,

--- a/src/base/Roles/ManagerWithMerkleVerification.sol
+++ b/src/base/Roles/ManagerWithMerkleVerification.sol
@@ -189,10 +189,6 @@ contract ManagerWithMerkleVerification is Auth, IPausable {
      * @dev userData can optionally have salt encoded at the end of it, in order to change the intentHash,
      *      if a flash loan is exact userData is being repeated, and their is fear of 3rd parties
      *      front-running the rebalance.
-     * @dev Post-flashloan ops use manageRoot[address(manager)], a shared root
-     *      curated by the admin role, not the calling strategist's per-strategist
-     *      root. Per-strategist permission isolation does not extend through this
-     *      callback by design.
      */
     function receiveFlashLoan(
         address[] calldata tokens,


### PR DESCRIPTION
## Summary

Second batch in the design-choice codification series, following #703. Three intentional design choices that have generated recent reports, now documented at their respective call sites. Comments only, no behavior change.

### 1. `vestYield` overwrites unvested by design (`AccountantWithYieldStreaming.sol`)

```solidity
/// @dev vestYield overwrites any active vest; strategists must include any
///      unvested remainder in yieldAmount. The `=` semantic (vs `+=`) is
///      deliberate, to allow mid-stream adjustments after PnL events.
```

Verified by Kevin (Notion, 2026-05-15). Recent report: #78646. Added as a sibling `@dev` to the yield-distribution block that landed in #703.

### 2. Queue requests committed by hash (`BoringOnChainQueue.sol`)

```solidity
/// @dev Requests are stored as keccak256(abi.encode(OnChainWithdraw)) only.
///      The full struct is emitted in OnChainWithdrawRequested at request time
///      and must be retained off-chain (event indexer or tx receipt) to cancel
///      or solve. No on-chain requestId → struct mapping; recovery is
///      event-indexer responsibility by design.
```

Verified by Kevin (Slack, 2026-05-15) and Will (Notion, 2026-05-18). Recent report: #78241. Annotated on all five entrypoints (`requestOnChainWithdraw`, `requestOnChainWithdrawWithPermit`, `cancelOnChainWithdraw`, `replaceOnChainWithdraw`, `solveOnChainWithdraws`) so reporters arriving via any path hit the explanation. Per-function placement chosen for discoverability after Greptile review.

### 3. UniswapV3 path fee-tier latitude (`UniswapV3DecoderAndSanitizer.sol`)

```solidity
/// @dev The path walk packs the 20-byte token addresses but not the 3-byte
///      fee tier between hops, and amountIn / amountOutMinimum are not
///      bound. By design, decoder leaves authorize swap shapes (which
///      tokens, which receiver) rather than specific values (which pool,
///      what slippage). A strategist with an authored leaf for a token
///      pair may route through any fee-tier pool of that pair, with any
///      slippage floor.
```

Internally documented as finding UNI-2 (Tier 2 strategist-rogue surface) in the team threat-model repo before the recent report came in. Recent report: #78993.

### What changed from earlier revisions

Previously this PR also included a NatSpec block on `ManagerWithMerkleVerification.receiveFlashLoan` documenting the flashloan shared-root design (related to closed report #78291). That block has been removed in favour of the UniV3 NatSpec, which addresses an active report. The flashloan shared-root NatSpec can land in a follow-up PR.

## Test plan

- [ ] All three snippets are accurate to the code and don't make operational commitments the contract can't enforce.
- [ ] Comments only — no code change. `forge build` should succeed locally.
- [ ] PR review is the approval gate before each design choice gets disclaimed publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)