### PR TITLE
NatSpec: TWAS purpose on vestYield (design choice #18)

### DIFF
--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -169,6 +169,11 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
      *      vested-so-far. maxDeviationYield caps the per-day rate, not the
      *      per-event total. Strategists are expected to pair yield
      *      realization with vestYield.
+     * @dev The dailyYieldBps cap is computed against _getTWAS(), an
+     *      approximate time-weighted average supply manipulable by large
+     *      deposits or withdrawals during the inter-vest window. TWAS was
+     *      introduced for fee calibration; strategist trust is the actual
+     *      anti-inflation primitive.
      */
     function vestYield(uint256 yieldAmount, uint256 duration) external requiresAuth {
         if (accountantState.isPaused) revert AccountantWithRateProviders__Paused();


### PR DESCRIPTION
## Summary

Adds a sibling `@dev` block to `vestYield` clarifying the role of `_getTWAS()` in the daily-rate cap check.

```solidity
/// @dev The dailyYieldBps cap is computed against _getTWAS(), an
///      approximate time-weighted average supply manipulable by large
///      deposits or withdrawals during the inter-vest window. TWAS was
///      introduced for fee calibration; strategist trust is the actual
///      anti-inflation primitive.
```

Surfaced by #78758 (resubmission of #78543) — reporter framed TWAS staleness during withdrawal waves as a critical-severity share-price inflation vector. Will and Kevin confirmed in Slack thread `1779254304.958969` (2026-05-20) that this is an accepted design tradeoff: TWAS is manipulable by definition, was introduced primarily for fee calibration, and a strategist who could manipulate TWAS to bypass the cap could also inflate share price via other strategist-authorised paths regardless.

Recorded as design choice #18 in the internal `bug-report-design-rationale-mining.md` catalog.

## Test plan

- [ ] Wording is accurate: TWAS is approximate (cumulative-supply / elapsed-time, not snapshot); the cap uses it as the denominator for the bps check; manipulation is possible via large deposits/withdrawals during the inter-vest window; strategist-only invocation is the actual security primitive.
- [ ] Comments only — no code change. `forge build` should succeed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)