### PR TITLE
NatSpec: three user-facing design choices (queue rate-lock, deny-list freeze, perf fees netted)

### DIFF
--- a/src/base/Roles/AccountantWithYieldStreaming.sol
+++ b/src/base/Roles/AccountantWithYieldStreaming.sol
@@ -177,6 +177,9 @@ contract AccountantWithYieldStreaming is AccountantWithRateProviders {
      *      deposits or withdrawals during the inter-vest window. TWAS was
      *      introduced for fee calibration; strategist trust is the actual
      *      anti-inflation primitive.
+     * @dev yieldAmount is expected to be net of any performance fee. The
+     *      accountant does not re-charge fees against streaming yield;
+     *      fee accounting happens off-chain before vestYield is called.
      */
     function vestYield(uint256 yieldAmount, uint256 duration) external requiresAuth {
         if (accountantState.isPaused) revert AccountantWithRateProviders__Paused();

--- a/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
@@ -361,6 +361,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @dev amountOfAssets is the rate-locked entitlement at request time.
      *      Rate appreciation between request and solve accrues to the solver,
      *      not the requester. To refresh the rate, cancel and re-request.
+     * @dev Deny-listed users cannot complete or cancel active requests, so
+     *      shares held by the queue for a deny-listed user remain locked
+     *      until the admin removes the deny-list status.
      */
     function requestOnChainWithdraw(address assetOut, uint128 amountOfShares, uint16 discount, uint24 secondsToDeadline)
         external
@@ -399,6 +402,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @dev amountOfAssets is the rate-locked entitlement at request time.
      *      Rate appreciation between request and solve accrues to the solver,
      *      not the requester. To refresh the rate, cancel and re-request.
+     * @dev Deny-listed users cannot complete or cancel active requests, so
+     *      shares held by the queue for a deny-listed user remain locked
+     *      until the admin removes the deny-list status.
      */
     function requestOnChainWithdrawWithPermit(
         address assetOut,
@@ -438,6 +444,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      *      and must be retained off-chain (event indexer or tx receipt) to cancel
      *      or solve. No on-chain requestId → struct mapping; recovery is
      *      event-indexer responsibility by design.
+     * @dev Deny-listed users cannot complete or cancel active requests, so
+     *      shares held by the queue for a deny-listed user remain locked
+     *      until the admin removes the deny-list status.
      */
     function cancelOnChainWithdraw(OnChainWithdraw memory request)
         external
@@ -463,6 +472,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      * @dev amountOfAssets is the rate-locked entitlement at request time.
      *      Rate appreciation between request and solve accrues to the solver,
      *      not the requester. To refresh the rate, cancel and re-request.
+     * @dev Deny-listed users cannot complete or cancel active requests, so
+     *      shares held by the queue for a deny-listed user remain locked
+     *      until the admin removes the deny-list status.
      */
     function replaceOnChainWithdraw(OnChainWithdraw memory oldRequest, uint16 discount, uint24 secondsToDeadline)
         external
@@ -486,6 +498,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      *      and must be retained off-chain (event indexer or tx receipt) to cancel
      *      or solve. No on-chain requestId → struct mapping; recovery is
      *      event-indexer responsibility by design.
+     * @dev Deny-listed users cannot complete or cancel active requests, so
+     *      shares held by the queue for a deny-listed user remain locked
+     *      until the admin removes the deny-list status.
      */
     function solveOnChainWithdraws(OnChainWithdraw[] calldata requests, bytes calldata solveData, address solver)
         external

--- a/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
@@ -358,6 +358,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      *      and must be retained off-chain (event indexer or tx receipt) to cancel
      *      or solve. No on-chain requestId → struct mapping; recovery is
      *      event-indexer responsibility by design.
+     * @dev amountOfAssets is the rate-locked entitlement at request time.
+     *      Rate appreciation between request and solve accrues to the solver,
+     *      not the requester. To refresh the rate, cancel and re-request.
      */
     function requestOnChainWithdraw(address assetOut, uint128 amountOfShares, uint16 discount, uint24 secondsToDeadline)
         external
@@ -393,6 +396,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      *      and must be retained off-chain (event indexer or tx receipt) to cancel
      *      or solve. No on-chain requestId → struct mapping; recovery is
      *      event-indexer responsibility by design.
+     * @dev amountOfAssets is the rate-locked entitlement at request time.
+     *      Rate appreciation between request and solve accrues to the solver,
+     *      not the requester. To refresh the rate, cancel and re-request.
      */
     function requestOnChainWithdrawWithPermit(
         address assetOut,
@@ -454,6 +460,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      *      and must be retained off-chain (event indexer or tx receipt) to cancel
      *      or solve. No on-chain requestId → struct mapping; recovery is
      *      event-indexer responsibility by design.
+     * @dev amountOfAssets is the rate-locked entitlement at request time.
+     *      Rate appreciation between request and solve accrues to the solver,
+     *      not the requester. To refresh the rate, cancel and re-request.
      */
     function replaceOnChainWithdraw(OnChainWithdraw memory oldRequest, uint16 discount, uint24 secondsToDeadline)
         external
@@ -537,6 +546,9 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
 
     /**
      * @notice Preview assets out from a withdraw request.
+     * @dev amountOfAssets is the rate-locked entitlement at request time.
+     *      Rate appreciation between request and solve accrues to the solver,
+     *      not the requester. To refresh the rate, cancel and re-request.
      */
     function previewAssetsOut(address assetOut, uint128 amountOfShares, uint16 discount)
         public

--- a/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
+++ b/src/base/Roles/BoringQueue/BoringOnChainQueue.sol
@@ -469,9 +469,10 @@ contract BoringOnChainQueue is Auth, ReentrancyGuard, IPausable {
      *      and must be retained off-chain (event indexer or tx receipt) to cancel
      *      or solve. No on-chain requestId → struct mapping; recovery is
      *      event-indexer responsibility by design.
-     * @dev amountOfAssets is the rate-locked entitlement at request time.
-     *      Rate appreciation between request and solve accrues to the solver,
-     *      not the requester. To refresh the rate, cancel and re-request.
+     * @dev replaceOnChainWithdraw atomically cancels the old request and queues
+     *      a new one with amountOfAssets locked at the current rate. Rate
+     *      appreciation between the new request and solve accrues to the
+     *      solver, not the requester.
      * @dev Deny-listed users cannot complete or cancel active requests, so
      *      shares held by the queue for a deny-listed user remain locked
      *      until the admin removes the deny-list status.


### PR DESCRIPTION
## Summary

Three `@dev` blocks covering user-facing design choices from the Veda rationale catalog. Selected as the safe subset (no exploitable attack surface disclosed).

### #7 — Queue rate-lock at request time
`BoringOnChainQueue.sol` — `requestOnChainWithdraw`, `requestOnChainWithdrawWithPermit`, `replaceOnChainWithdraw`, `previewAssetsOut`

`amountOfAssets` is the rate-locked entitlement at request time. Rate appreciation between request and solve accrues to the solver, not the requester. To refresh the rate, cancel and re-request.

### #8 — Deny-list freezes queued shares (admin-reversible)
`BoringOnChainQueue.sol` — all five request-lifecycle entrypoints (`requestOnChainWithdraw`, `requestOnChainWithdrawWithPermit`, `cancelOnChainWithdraw`, `replaceOnChainWithdraw`, `solveOnChainWithdraws`)

Deny-listed users cannot complete or cancel active requests; shares stay locked until the admin removes the deny-list status. Wording reflects Will's 2026-05-18 correction: the freeze is admin-reversible, not permanent.

### #10 — Performance fees netted off-chain
`AccountantWithYieldStreaming.sol` — `vestYield` (fourth `@dev` block, sequential to the three from PRs #703 / #706 / #708)

`yieldAmount` is expected net of any performance fee. The accountant does not re-charge fees against streaming yield; fee accounting happens off-chain before `vestYield` is called.

## Rationale references

- Entry #7: `knowledge/veda/bug-report-design-rationale-mining.md` — "The withdrawal queue locks the rate at request time, by design" (confirmed Kevin, Notion 2026-05-15)
- Entry #8: same doc — "Deny-listed users keep their queued shares frozen — that is the deny-list semantic" (confirmed Will, Notion 2026-05-18, with admin-reversible correction)
- Entry #10: same doc — "Performance fees are netted inside the yield stream" (already on Immunefi Information page; report IDs #66253, #67125, #77075)

## Base branch note

Based on `feat/natspec-twas-purpose` (PR #708, not yet merged) so the fourth `@dev` block on `vestYield` lands after the three existing ones in chronological order.

## Test plan

- [ ] Review each `@dev` block for accuracy against the code path it annotates
- [ ] Confirm deny-list wording says "until the admin removes the deny-list status" (not "permanent" — matches Will's correction)
- [ ] Confirm rate-lock wording covers all four entrypoints that exercise the snapshot: the two request functions, `replaceOnChainWithdraw`, and `previewAssetsOut`
- [ ] Confirm deny-list wording covers all five lifecycle entrypoints
- [ ] Confirm `vestYield` now has four sequential `@dev` blocks with no gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)