### PR TITLE
deployments: register veda-bundle-create3-mainnet-2

### DIFF
--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -44,8 +44,8 @@
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b"
     },
     "veda-bundle-create3-mainnet-2": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
       "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
       "constructorArgs": {

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -5,7 +5,8 @@
     "veda-bundle-create3-bob-mainnet": "0xF3d0672a91Fd56C9ef04C79ec67d60c34c6148a0",
     "veda-bundle-create3-mainnet": "0x47Cec90FACc9364D7C21A8ab5e2aD9F1f75D740C",
     "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434",
-    "veda-layerzero-create3-mainnet": "0x00bF0B30655a43Af93c1b371Be021Bd4567c51d5"
+    "veda-layerzero-create3-mainnet": "0x00bF0B30655a43Af93c1b371Be021Bd4567c51d5",
+    "veda-bundle-create3-mainnet-2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -41,6 +42,16 @@
       "auditUrl": null,
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b"
+    },
+    "veda-bundle-create3-mainnet-2": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/src/helper/Deployer.sol
+++ b/src/helper/Deployer.sol
@@ -2,6 +2,7 @@
 // Copyright © 2025 Veda Tech Labs
 // Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
 // Licensed under Software Evaluation License, Version 1.0
+// Last audited: cellar-contracts@0a7d659064c9070bd369d5c511ba94c6b01bbab2 — https://macroaudits.com/library/audits/sevenSeas-1
 pragma solidity 0.8.21;
 
 import {Auth, Authority} from "@solmate/auth/Auth.sol";


### PR DESCRIPTION
## Summary

Three tightly-coupled changes for the new mainnet Deployer:

1. **Source-level audit declaration** on `src/helper/Deployer.sol` line 5 — `// Last audited: cellar-contracts@0a7d659064c9070bd369d5c511ba94c6b01bbab2 — https://macroaudits.com/library/audits/sevenSeas-1`. The deploy-time `_parseAuditLine` helper will pick it up for any future deployment.
2. **New Deployer registration** in `deployments/addresses/Mainnet/Deployers.json` — `veda-bundle-create3-mainnet-2` at `0xe80F045fc6F551229f98FA21E0Db35784A590e05`, deployed at block 25148013.
3. **Verification record**: `full_match` against `boring-vault@7dc398f1` (main HEAD), with `sevenSeas-1` as the audit of record.

Constructor args decoded from the creation tx:
- `_owner`: `0xbE8aa5dC6d5a7a0822ad530631580a14a768250a`
- `_auth`: `address(0)`

### Partial-coverage caveat

The audited source lives in `cellar-contracts`, not `boring-vault` — hence the `cellar-contracts@<sha>` form on the annotation. The CREATE3 deployment math is byte-identical between the two versions, but the `requiresAuth`-based access control and `bundleTxs` are post-audit additions and remain outside any in-scope audit.

### Companion PRs

- [#711](https://github.com/Veda-Labs/boring-vault/pull/711) — backfills the same `auditCommit` / `auditUrl` fields on the 29 pre-existing Deployer entries across all 17 `Deployers.json` files
- security-scripts [#37](https://github.com/Veda-Labs/security-scripts/pull/37) — registers the new address in `KNOWN_DEPLOYERS` for sweep tools

## Test plan

- [ ] `forge build` still succeeds with the line-5 annotation
- [ ] `jq . deployments/addresses/Mainnet/Deployers.json` parses cleanly
- [ ] Re-running `verify_via_deployer` against `0xe80f045f…` reproduces `full_match`

🤖 Generated with [Claude Code](https://claude.com/claude-code)