### PR TITLE
deployments: record sevenSeas-1 audit for Deployer.sol

### DIFF
--- a/deployments/addresses/Arbitrum/Deployers.json
+++ b/deployments/addresses/Arbitrum/Deployers.json
@@ -8,14 +8,14 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-arbitrum": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Arbitrum/Deployers.json
+++ b/deployments/addresses/Arbitrum/Deployers.json
@@ -6,15 +6,15 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-arbitrum": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"

--- a/deployments/addresses/Base/Deployers.json
+++ b/deployments/addresses/Base/Deployers.json
@@ -9,14 +9,14 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-base-bsc": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },

--- a/deployments/addresses/Base/Deployers.json
+++ b/deployments/addresses/Base/Deployers.json
@@ -7,22 +7,22 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-base-bsc": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-base-optimism": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2"
     }

--- a/deployments/addresses/BeraChain/Deployers.json
+++ b/deployments/addresses/BeraChain/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/BeraChain/Deployers.json
+++ b/deployments/addresses/BeraChain/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"

--- a/deployments/addresses/BinanceSmartChain/Deployers.json
+++ b/deployments/addresses/BinanceSmartChain/Deployers.json
@@ -6,15 +6,15 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-base-bsc": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"

--- a/deployments/addresses/BinanceSmartChain/Deployers.json
+++ b/deployments/addresses/BinanceSmartChain/Deployers.json
@@ -8,14 +8,14 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-base-bsc": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Bob/Deployers.json
+++ b/deployments/addresses/Bob/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-bundle-create3-bob-mainnet": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"

--- a/deployments/addresses/Bob/Deployers.json
+++ b/deployments/addresses/Bob/Deployers.json
@@ -7,7 +7,7 @@
     "veda-bundle-create3-bob-mainnet": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Fraxtal/Deployers.json
+++ b/deployments/addresses/Fraxtal/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"

--- a/deployments/addresses/Fraxtal/Deployers.json
+++ b/deployments/addresses/Fraxtal/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/HypeEVM/Deployers.json
+++ b/deployments/addresses/HypeEVM/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"

--- a/deployments/addresses/HypeEVM/Deployers.json
+++ b/deployments/addresses/HypeEVM/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Ink/Deployers.json
+++ b/deployments/addresses/Ink/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Ink/Deployers.json
+++ b/deployments/addresses/Ink/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"

--- a/deployments/addresses/Katana/Deployers.json
+++ b/deployments/addresses/Katana/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"

--- a/deployments/addresses/Katana/Deployers.json
+++ b/deployments/addresses/Katana/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Linea/Deployers.json
+++ b/deployments/addresses/Linea/Deployers.json
@@ -8,14 +8,14 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-linea": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Linea/Deployers.json
+++ b/deployments/addresses/Linea/Deployers.json
@@ -6,15 +6,15 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-linea": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -9,36 +9,36 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-bob-mainnet": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-mainnet": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-mainnet-plasma": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     },
     "veda-layerzero-create3-mainnet": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b"
     }

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -11,28 +11,28 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-bob-mainnet": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-mainnet": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-mainnet-plasma": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     },

--- a/deployments/addresses/Mantle/Deployers.json
+++ b/deployments/addresses/Mantle/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"

--- a/deployments/addresses/Mantle/Deployers.json
+++ b/deployments/addresses/Mantle/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Optimism/Deployers.json
+++ b/deployments/addresses/Optimism/Deployers.json
@@ -6,15 +6,15 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-base-optimism": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2"
     }

--- a/deployments/addresses/Optimism/Deployers.json
+++ b/deployments/addresses/Optimism/Deployers.json
@@ -8,7 +8,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
       "verificationGap": "cbor"
     },

--- a/deployments/addresses/Scroll/Deployers.json
+++ b/deployments/addresses/Scroll/Deployers.json
@@ -8,14 +8,14 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-scroll": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/Scroll/Deployers.json
+++ b/deployments/addresses/Scroll/Deployers.json
@@ -6,15 +6,15 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-scroll": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"

--- a/deployments/addresses/SonicMainnet/Deployers.json
+++ b/deployments/addresses/SonicMainnet/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/SonicMainnet/Deployers.json
+++ b/deployments/addresses/SonicMainnet/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"

--- a/deployments/addresses/UniChain/Deployers.json
+++ b/deployments/addresses/UniChain/Deployers.json
@@ -5,8 +5,8 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"

--- a/deployments/addresses/UniChain/Deployers.json
+++ b/deployments/addresses/UniChain/Deployers.json
@@ -7,7 +7,7 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/plasma/Deployers.json
+++ b/deployments/addresses/plasma/Deployers.json
@@ -8,14 +8,14 @@
     "veda-canonical-create3": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-mainnet-plasma": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "partial_match",
+      "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     }

--- a/deployments/addresses/plasma/Deployers.json
+++ b/deployments/addresses/plasma/Deployers.json
@@ -6,15 +6,15 @@
   },
   "contractMetadata": {
     "veda-canonical-create3": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
     },
     "veda-bundle-create3-mainnet-plasma": {
-      "auditCommit": null,
-      "auditUrl": null,
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "partial_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"


### PR DESCRIPTION
## Summary

Two related historical cleanups on the `Deployers.json` files across all chains:

1. **Audit backfill**: sets `auditCommit` + `auditUrl` to [sevenSeas-1](https://macroaudits.com/library/audits/sevenSeas-1) on 29 entries across 17 `Deployers.json` files.
2. **Verdict reclassification**: flips 26 entries from `partial_match` to `full_match` where the only recorded drift was the CBOR metadata tail. Per policy, a CBOR-only difference doesn't downgrade the verdict — the deployed runtime is byte-equal to the local build once the build-path/source-resolution pointer is set aside.

The `verificationGap: "cbor"` field is retained on the reclassified entries as an informational flag — it still describes the observed CBOR drift, it just no longer downgrades the verdict.

The source-level audit annotation on `src/helper/Deployer.sol` and the new mainnet-2 entry both ship in [#710](https://github.com/Veda-Labs/boring-vault/pull/710).

### Partial-coverage caveat

The audited source lives in `cellar-contracts` (boring-vault's predecessor). The CREATE3 deployment math is byte-identical between the two versions, but the `requiresAuth`-based access control and `bundleTxs` are post-audit additions and remain outside any in-scope audit.

### Tooling follow-up

The verification scripts themselves (`verify_eth_getcode.py:601-606`, `verify_via_deployer.py:574-579`, `verify_bundle.py:649-651`) and the `SIDECAR.md` schema still treat CBOR-only drift as `partial_match`. They should be updated to match this policy in a follow-up PR against `security-scripts`.

## Test plan

- [x] `jq . deployments/addresses/*/Deployers.json` — all 17 files parse as valid JSON
- [x] Spot-check a couple of reclassified entries reflect `full_match` with `verificationGap: "cbor"` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)