### PR TITLE
ci: wire missing chain RPC secrets into test workflows

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -23,6 +23,19 @@ jobs:
       LINEA_RPC_URL: https://linea-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
       MANTLE_RPC_URL: https://mantle-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
       HOLESKY_RPC_URL: https://holesky.infura.io/v3/${{ secrets.INFURA_API_KEY_0 }}
+      BERA_CHAIN_RPC_URL: ${{ secrets.BERA_CHAIN_RPC_URL }}
+      BOB_RPC_URL: ${{ secrets.BOB_RPC_URL }}
+      DERIVE_RPC_URL: ${{ secrets.DERIVE_RPC_URL }}
+      FLARE_RPC_URL: ${{ secrets.FLARE_RPC_URL }}
+      HYPER_EVM_RPC_URL: ${{ secrets.HYPER_EVM_RPC_URL }}
+      KATANA_RPC_URL: ${{ secrets.KATANA_RPC_URL }}
+      PLASMA_RPC_URL: ${{ secrets.PLASMA_RPC_URL }}
+      PLUME_RPC_URL: ${{ secrets.PLUME_RPC_URL }}
+      SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
+      SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+      SONIC_MAINNET_RPC_URL: ${{ secrets.SONIC_MAINNET_RPC_URL }}
+      SWELL_CHAIN_RPC_URL: ${{ secrets.SWELL_CHAIN_RPC_URL }}
+      TAC_RPC_URL: ${{ secrets.TAC_RPC_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,19 @@ jobs:
       LINEA_RPC_URL: https://linea-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
       MANTLE_RPC_URL: https://mantle-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
       HOLESKY_RPC_URL: https://holesky.infura.io/v3/${{ secrets.INFURA_API_KEY_0 }}
+      BERA_CHAIN_RPC_URL: ${{ secrets.BERA_CHAIN_RPC_URL }}
+      BOB_RPC_URL: ${{ secrets.BOB_RPC_URL }}
+      DERIVE_RPC_URL: ${{ secrets.DERIVE_RPC_URL }}
+      FLARE_RPC_URL: ${{ secrets.FLARE_RPC_URL }}
+      HYPER_EVM_RPC_URL: ${{ secrets.HYPER_EVM_RPC_URL }}
+      KATANA_RPC_URL: ${{ secrets.KATANA_RPC_URL }}
+      PLASMA_RPC_URL: ${{ secrets.PLASMA_RPC_URL }}
+      PLUME_RPC_URL: ${{ secrets.PLUME_RPC_URL }}
+      SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
+      SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+      SONIC_MAINNET_RPC_URL: ${{ secrets.SONIC_MAINNET_RPC_URL }}
+      SWELL_CHAIN_RPC_URL: ${{ secrets.SWELL_CHAIN_RPC_URL }}
+      TAC_RPC_URL: ${{ secrets.TAC_RPC_URL }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

The boring-vault test suite forks 15+ chains, but `test.yml` only declares RPC env vars for 8 (mainnet, arbitrum, base, avalanche, optimism, linea, mantle, holesky). Every other chain's suite fails at `setUp()` with:

```
vm.envString: environment variable "<CHAIN>_RPC_URL" not found
```

148 such failures in the latest PR run alone.

**13 of the 14 missing chains already have `<CHAIN>_RPC_URL` secrets configured in repo settings** (created 2026-03-10) — they just aren't being exposed to the test job. This PR wires them into both `test.yml` and `nightly-fuzz.yml`:

`BERA_CHAIN`, `BOB`, `DERIVE`, `FLARE`, `HYPER_EVM`, `KATANA`, `PLASMA`, `PLUME`, `SCROLL`, `SEPOLIA`, `SONIC_MAINNET`, `SWELL_CHAIN`, `TAC`

`BARTIO_RPC_URL` (Berachain testnet) has no secret configured and is left unwired — the one test using it stays failing for now.

## Result (PR CI vs prior run)

| Metric | Before (#698) | After (this PR) | Δ |
|---|---|---|---|
| Suites passing | 5 | **14** | **+9** |
| Suites failing | 150 | 141 | -9 |
| `env var not found` errors | 148 | 12 | -136 |
| Infura 401 errors | 434 | 434 | unchanged |

The 12 remaining `env var not found` errors are all the deliberately-skipped `BARTIO_RPC_URL`. No regressions on chains that were already configured.

## What this does NOT fix

This is one of two CI blockers. The other — the **Infura key 401 errors** (434 failures, every fork that uses `INFURA_API_KEY` hits HTTP 401 \"invalid project id\") — needs IT to rotate the key. That's tracked separately.

After both land, the **150 failing test suites** in the latest CI run should drop sharply.

## Test plan

- [x] PR CI completes and the count of `environment variable not found` errors drops dramatically (148 → 12, only BARTIO left)
- [x] Suites previously failing on missing-env-var (Sonic / Bera / Hyper EVM / Scroll / Sepolia / etc.) now reach real fork calls — 9 of them now pass outright
- [x] No regressions in the chains already configured (mainnet / base / etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)