### PR TITLE
deployments: register veda-bundle-create3-v2 across 19 chains

### DIFF
--- a/deployments/addresses/Arbitrum/Deployers.json
+++ b/deployments/addresses/Arbitrum/Deployers.json
@@ -2,7 +2,8 @@
   "Drones": "",
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
-    "veda-bundle-create3-arbitrum": "0x87D51666Da1b56332b216D456D1C2ba3Aed6089c"
+    "veda-bundle-create3-arbitrum": "0x87D51666Da1b56332b216D456D1C2ba3Aed6089c",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -18,6 +19,16 @@
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Arbitrum/Deployers.json
+++ b/deployments/addresses/Arbitrum/Deployers.json
@@ -24,11 +24,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Base/Deployers.json
+++ b/deployments/addresses/Base/Deployers.json
@@ -3,7 +3,8 @@
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
     "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706",
-    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59"
+    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -25,6 +26,16 @@
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Base/Deployers.json
+++ b/deployments/addresses/Base/Deployers.json
@@ -31,11 +31,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/BeraChain/Deployers.json
+++ b/deployments/addresses/BeraChain/Deployers.json
@@ -16,11 +16,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/BinanceSmartChain/Deployers.json
+++ b/deployments/addresses/BinanceSmartChain/Deployers.json
@@ -24,11 +24,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/BinanceSmartChain/Deployers.json
+++ b/deployments/addresses/BinanceSmartChain/Deployers.json
@@ -2,7 +2,8 @@
   "Drones": "",
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
-    "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706"
+    "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -18,6 +19,16 @@
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Flare/Deployers.json
+++ b/deployments/addresses/Flare/Deployers.json
@@ -1,17 +1,9 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
     "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
-    "veda-canonical-create3": {
-      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
-      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "full_match",
-      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
-      "verificationGap": "cbor"
-    },
     "veda-bundle-create3-v2": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",

--- a/deployments/addresses/Flare/Deployers.json
+++ b/deployments/addresses/Flare/Deployers.json
@@ -8,11 +8,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/HypeEVM/Deployers.json
+++ b/deployments/addresses/HypeEVM/Deployers.json
@@ -16,11 +16,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/HypeEVM/Deployers.json
+++ b/deployments/addresses/HypeEVM/Deployers.json
@@ -1,7 +1,8 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -10,6 +11,16 @@
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Ink/Deployers.json
+++ b/deployments/addresses/Ink/Deployers.json
@@ -16,11 +16,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Ink/Deployers.json
+++ b/deployments/addresses/Ink/Deployers.json
@@ -1,7 +1,8 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -10,6 +11,16 @@
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Katana/Deployers.json
+++ b/deployments/addresses/Katana/Deployers.json
@@ -16,11 +16,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Katana/Deployers.json
+++ b/deployments/addresses/Katana/Deployers.json
@@ -1,7 +1,8 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -10,6 +11,16 @@
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Linea/Deployers.json
+++ b/deployments/addresses/Linea/Deployers.json
@@ -24,11 +24,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Linea/Deployers.json
+++ b/deployments/addresses/Linea/Deployers.json
@@ -2,7 +2,8 @@
   "Drones": "",
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
-    "veda-bundle-create3-linea": "0x04fc9C685961934f552b5e01F15CBBa66B61D92c"
+    "veda-bundle-create3-linea": "0x04fc9C685961934f552b5e01F15CBBa66B61D92c",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -18,6 +19,16 @@
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -6,7 +6,7 @@
     "veda-bundle-create3-mainnet": "0x47Cec90FACc9364D7C21A8ab5e2aD9F1f75D740C",
     "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434",
     "veda-layerzero-create3-mainnet": "0x00bF0B30655a43Af93c1b371Be021Bd4567c51d5",
-    "veda-bundle-create3-mainnet-2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -43,7 +43,7 @@
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b"
     },
-    "veda-bundle-create3-mainnet-2": {
+    "veda-bundle-create3-v2": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -47,11 +47,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Mantle/Deployers.json
+++ b/deployments/addresses/Mantle/Deployers.json
@@ -16,11 +16,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Mantle/Deployers.json
+++ b/deployments/addresses/Mantle/Deployers.json
@@ -1,7 +1,8 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -10,6 +11,16 @@
       "verification": "full_match",
       "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Monad/Deployers.json
+++ b/deployments/addresses/Monad/Deployers.json
@@ -9,18 +9,13 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     },
     "veda-bundle-create3-monad": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "note": "Pre-existing monad-specific Deployer; runtime byte-equal to v2's source. Predates v2."
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Monad/Deployers.json
+++ b/deployments/addresses/Monad/Deployers.json
@@ -1,0 +1,26 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05",
+    "veda-bundle-create3-monad": "0x144dc4DF655a57d871be8f18aA565b82D3E980f5"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
+    },
+    "veda-bundle-create3-monad": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "note": "Pre-existing monad-specific Deployer; runtime byte-equal to v2's source. Predates v2."
+    }
+  }
+}

--- a/deployments/addresses/Optimism/Deployers.json
+++ b/deployments/addresses/Optimism/Deployers.json
@@ -2,7 +2,8 @@
   "Drones": "",
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
-    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59"
+    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -17,6 +18,16 @@
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Optimism/Deployers.json
+++ b/deployments/addresses/Optimism/Deployers.json
@@ -23,11 +23,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Scroll/Deployers.json
+++ b/deployments/addresses/Scroll/Deployers.json
@@ -24,11 +24,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/Scroll/Deployers.json
+++ b/deployments/addresses/Scroll/Deployers.json
@@ -2,7 +2,8 @@
   "Drones": "",
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
-    "veda-bundle-create3-scroll": "0x534b64608E601B581AB0cbF0b03ec9f4c65f3360"
+    "veda-bundle-create3-scroll": "0x534b64608E601B581AB0cbF0b03ec9f4c65f3360",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -18,6 +19,16 @@
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/Sepolia/Deployers.json
+++ b/deployments/addresses/Sepolia/Deployers.json
@@ -1,17 +1,9 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
     "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
-    "veda-canonical-create3": {
-      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
-      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "full_match",
-      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
-      "verificationGap": "cbor"
-    },
     "veda-bundle-create3-v2": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",

--- a/deployments/addresses/Sepolia/Deployers.json
+++ b/deployments/addresses/Sepolia/Deployers.json
@@ -8,11 +8,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/SonicMainnet/Deployers.json
+++ b/deployments/addresses/SonicMainnet/Deployers.json
@@ -16,11 +16,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/SonicMainnet/Deployers.json
+++ b/deployments/addresses/SonicMainnet/Deployers.json
@@ -1,7 +1,8 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -10,6 +11,16 @@
       "verification": "full_match",
       "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/SwellChain/Deployers.json
+++ b/deployments/addresses/SwellChain/Deployers.json
@@ -1,17 +1,9 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
     "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
-    "veda-canonical-create3": {
-      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
-      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "full_match",
-      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
-      "verificationGap": "cbor"
-    },
     "veda-bundle-create3-v2": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",

--- a/deployments/addresses/SwellChain/Deployers.json
+++ b/deployments/addresses/SwellChain/Deployers.json
@@ -8,11 +8,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/XLayer/Deployers.json
+++ b/deployments/addresses/XLayer/Deployers.json
@@ -1,17 +1,9 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
     "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
-    "veda-canonical-create3": {
-      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
-      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "full_match",
-      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
-      "verificationGap": "cbor"
-    },
     "veda-bundle-create3-v2": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",

--- a/deployments/addresses/XLayer/Deployers.json
+++ b/deployments/addresses/XLayer/Deployers.json
@@ -8,11 +8,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/plasma/Deployers.json
+++ b/deployments/addresses/plasma/Deployers.json
@@ -24,11 +24,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }

--- a/deployments/addresses/plasma/Deployers.json
+++ b/deployments/addresses/plasma/Deployers.json
@@ -2,7 +2,8 @@
   "Drones": "",
   "contractAddresses": {
     "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
-    "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434"
+    "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
     "veda-canonical-create3": {
@@ -18,6 +19,16 @@
       "verification": "full_match",
       "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
       "verificationGap": "cbor"
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "verification": "full_match",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "constructorArgs": {
+        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
+        "_auth": "0x0000000000000000000000000000000000000000"
+      }
     }
   }
 }

--- a/deployments/addresses/plume/Deployers.json
+++ b/deployments/addresses/plume/Deployers.json
@@ -1,17 +1,9 @@
 {
   "Drones": "",
   "contractAddresses": {
-    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
     "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
   },
   "contractMetadata": {
-    "veda-canonical-create3": {
-      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
-      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
-      "verification": "full_match",
-      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
-      "verificationGap": "cbor"
-    },
     "veda-bundle-create3-v2": {
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",

--- a/deployments/addresses/plume/Deployers.json
+++ b/deployments/addresses/plume/Deployers.json
@@ -8,11 +8,7 @@
       "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
       "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
       "verification": "full_match",
-      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
-      "constructorArgs": {
-        "_owner": "0xbE8aa5dC6d5a7a0822ad530631580a14a768250a",
-        "_auth": "0x0000000000000000000000000000000000000000"
-      }
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3"
     }
   }
 }


### PR DESCRIPTION
## Summary

The Deployer originally registered as `veda-bundle-create3-mainnet-2` in #710 is deployed at the **same address** (`0xe80F045fc6F551229f98FA21E0Db35784A590e05`) on 20 chains, per [Joseph's Slack follow-up](https://veda-tech.slack.com/archives/C09SS2H3QG2/p1779860944142869?thread_ts=1779419917.393179). Renames the mainnet entry to `veda-bundle-create3-v2` (dropping the chain-specific suffix) and adds matching entries on all other chains.

Also registers a **second, pre-existing Deployer on Monad mainnet** (`0x144dc4DF655a57d871be8f18aA565b82D3E980f5`, labeled `veda-bundle-create3-monad`) that was already referenced in `test/resources/ChainValues.sol` but never registered in `Deployers.json` or `KNOWN_DEPLOYERS`.

### Verification

Every entry returned `full_match` — runtime bytecode + CBOR metadata byte-equal to the local build at `boring-vault@7dc398f1`. Verified via Etherscan V2 `eth_getCode` (10 chains) or public RPC (10 chains, including Monad mainnet at chainid 143).

### Per-chain disposition (20 chains × `veda-bundle-create3-v2`)

- **Renamed**: Mainnet (`veda-bundle-create3-mainnet-2` → `veda-bundle-create3-v2`)
- **Updated existing** `Deployers.json`: Arbitrum, Base, BeraChain, BinanceSmartChain, HypeEVM, Ink, Katana, Linea, Mantle, Optimism, Scroll, SonicMainnet, plasma
- **Created** `Deployers.json` (chain dir existed): Sepolia, Flare, SwellChain, plume
- **Created chain dir + `Deployers.json`**: XLayer, Monad

### Monad — bonus deployer

`Monad/Deployers.json` carries two entries:
1. `veda-bundle-create3-v2` → `0xe80f045f…` (full_match)
2. `veda-bundle-create3-monad` → `0x144dc4DF…` (full_match) — pre-existing, ran the same source

### Companion PR

[security-scripts#38](https://github.com/Veda-Labs/security-scripts/pull/38) — renames the v2 label and registers `veda-bundle-create3-monad` in `KNOWN_DEPLOYERS`.

## Test plan

- [x] \`jq . deployments/addresses/*/Deployers.json\` — all 20 touched files parse as valid JSON
- [x] Spot-check three entries — Mainnet, Sepolia (new file), Monad (new dir, 2 entries) — for label/address/audit/deploymentCommit consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)