### PR TITLE
deployments: register active hooks + accountants discovered post-deploy

### DIFF
--- a/deployments/addresses/Arbitrum/Tellers.json
+++ b/deployments/addresses/Arbitrum/Tellers.json
@@ -4,8 +4,7 @@
   },
   "contractMetadata": {
     "LayerZeroTellerWithRateLimiting_bd407268": {
-      "verification": "mismatch",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verification": "mismatch"
     }
   }
 }

--- a/deployments/addresses/Arbitrum/Tellers.json
+++ b/deployments/addresses/Arbitrum/Tellers.json
@@ -4,7 +4,11 @@
   },
   "contractMetadata": {
     "LayerZeroTellerWithRateLimiting_bd407268": {
-      "verification": "mismatch"
+      "verification": "source_verified",
+      "verifiedVia": "etherscan",
+      "contractName": "LayerZeroTellerWithRateLimiting",
+      "lzrlSourceCommit": "24c42f7c",
+      "note": "Etherscan-verified LayerZeroTellerWithRateLimiting (solc 0.8.21). Mixed-vintage working-tree deploy: constituent files trace to multiple main commits, so no single-commit bytecode build matches (prior 'mismatch'). LZRL.sol matches main @ 24c42f7c."
     }
   }
 }

--- a/deployments/addresses/Arbitrum/Tellers.json
+++ b/deployments/addresses/Arbitrum/Tellers.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "verification": "mismatch",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/Accountants.json
+++ b/deployments/addresses/BeraChain/Accountants.json
@@ -1,0 +1,14 @@
+{
+  "contractAddresses": {
+    "AccountantWithFixedRate_7b6890c8": "0x88ea516dcb9f79cafa9d0d19909a4dbd7b6890c8",
+    "AccountantWithFixedRate_ef6258d4": "0x55ee6e1adf848a2fc831b07564223396ef6258d4"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate_7b6890c8": {
+      "verification": "mismatch"
+    },
+    "AccountantWithFixedRate_ef6258d4": {
+      "verification": "mismatch"
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/Tellers.json
+++ b/deployments/addresses/BeraChain/Tellers.json
@@ -7,7 +7,11 @@
   },
   "contractMetadata": {
     "LayerZeroTellerWithRateLimiting_3c730353": {
-      "verification": "mismatch"
+      "verification": "source_verified",
+      "verifiedVia": "etherscan",
+      "contractName": "LayerZeroTellerWithRateLimiting",
+      "lzrlSourceCommit": "1b0c1dac",
+      "note": "Etherscan-verified LayerZeroTellerWithRateLimiting (solc 0.8.21). Mixed-vintage working-tree deploy: constituent files trace to multiple main commits, so no single-commit bytecode build matches (prior 'mismatch'). LZRL.sol matches main @ 1b0c1dac."
     },
     "LayerZeroTeller_6dde8d9c": {
       "deploymentCommit": "c48ee764",

--- a/deployments/addresses/BeraChain/Tellers.json
+++ b/deployments/addresses/BeraChain/Tellers.json
@@ -1,0 +1,32 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_3c730353": "0x8ea0b382d054dbebeb1d0ae47ee4ac433c730353",
+    "LayerZeroTeller_6dde8d9c": "0xcd20c63ddafac686d311b40f24dcad316dde8d9c",
+    "LayerZeroTeller_ff44750b": "0xb745b293468df7b06330472fbcee5412ff44750b",
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_3c730353": {
+      "verification": "mismatch",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    },
+    "LayerZeroTeller_6dde8d9c": {
+      "deploymentCommit": "c48ee764",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    },
+    "LayerZeroTeller_ff44750b": {
+      "deploymentCommit": "c48ee764",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    },
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "deploymentCommit": "bf902717",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/Tellers.json
+++ b/deployments/addresses/BeraChain/Tellers.json
@@ -7,26 +7,22 @@
   },
   "contractMetadata": {
     "LayerZeroTellerWithRateLimiting_3c730353": {
-      "verification": "mismatch",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verification": "mismatch"
     },
     "LayerZeroTeller_6dde8d9c": {
       "deploymentCommit": "c48ee764",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     },
     "LayerZeroTeller_ff44750b": {
       "deploymentCommit": "c48ee764",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     },
     "LayerZeroTellerWithRateLimiting_bd407268": {
       "deploymentCommit": "bf902717",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Corn/Tellers.json
+++ b/deployments/addresses/Corn/Tellers.json
@@ -6,8 +6,7 @@
     "LayerZeroTellerWithRateLimiting_bd407268": {
       "deploymentCommit": "bf902717",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Corn/Tellers.json
+++ b/deployments/addresses/Corn/Tellers.json
@@ -1,0 +1,13 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "deploymentCommit": "bf902717",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/Mainnet/Accountants.json
+++ b/deployments/addresses/Mainnet/Accountants.json
@@ -1,0 +1,12 @@
+{
+  "contractAddresses": {
+    "AccountantWithRateProviders_b55f7d6c": "0x327db73aa2adee59dab08ee1b31c72d1b55f7d6c"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders_b55f7d6c": {
+      "deploymentCommit": "67cf8116",
+      "verification": "full_match",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/Mainnet/Tellers.json
+++ b/deployments/addresses/Mainnet/Tellers.json
@@ -9,25 +9,21 @@
     "LayerZeroTellerWithRateLimiting_3c730353": {
       "deploymentCommit": "bf902717",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     },
     "LayerZeroTeller_202d82b2": {
       "deploymentCommit": "67cf8116",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     },
     "LayerZeroTeller_564c2825": {
       "deploymentCommit": "67cf8116",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     },
     "LayerZeroTeller_62b6293c": {
       "deploymentCommit": "92e1a7af",
-      "verification": "full_match",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verification": "full_match"
     }
   }
 }

--- a/deployments/addresses/Mainnet/Tellers.json
+++ b/deployments/addresses/Mainnet/Tellers.json
@@ -1,0 +1,33 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_3c730353": "0x8ea0b382d054dbebeb1d0ae47ee4ac433c730353",
+    "LayerZeroTeller_202d82b2": "0x4c74cca483a278bcb90aea3f8f565e56202d82b2",
+    "LayerZeroTeller_564c2825": "0x634d53643b497bb614b4b6c8f3a58a5d564c2825",
+    "LayerZeroTeller_62b6293c": "0xbb4ef6f8a38a0abb9d31cf64a7ae2e9862b6293c"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_3c730353": {
+      "deploymentCommit": "bf902717",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    },
+    "LayerZeroTeller_202d82b2": {
+      "deploymentCommit": "67cf8116",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    },
+    "LayerZeroTeller_564c2825": {
+      "deploymentCommit": "67cf8116",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    },
+    "LayerZeroTeller_62b6293c": {
+      "deploymentCommit": "92e1a7af",
+      "verification": "full_match",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/Optimism/Tellers.json
+++ b/deployments/addresses/Optimism/Tellers.json
@@ -6,8 +6,7 @@
     "TellerWithLayerZero_7b514734": {
       "deploymentCommit": "f2c26ad8",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/Optimism/Tellers.json
+++ b/deployments/addresses/Optimism/Tellers.json
@@ -1,0 +1,13 @@
+{
+  "contractAddresses": {
+    "TellerWithLayerZero_7b514734": "0x9aa79c84b79816ab920bbce20f8f74557b514734"
+  },
+  "contractMetadata": {
+    "TellerWithLayerZero_7b514734": {
+      "deploymentCommit": "f2c26ad8",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/Scroll/Tellers.json
+++ b/deployments/addresses/Scroll/Tellers.json
@@ -4,8 +4,7 @@
   },
   "contractMetadata": {
     "LayerZeroTellerWithRateLimiting_bd407268": {
-      "verification": "mismatch",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verification": "mismatch"
     }
   }
 }

--- a/deployments/addresses/Scroll/Tellers.json
+++ b/deployments/addresses/Scroll/Tellers.json
@@ -4,7 +4,11 @@
   },
   "contractMetadata": {
     "LayerZeroTellerWithRateLimiting_bd407268": {
-      "verification": "mismatch"
+      "verification": "source_verified",
+      "verifiedVia": "etherscan",
+      "contractName": "LayerZeroTellerWithRateLimiting",
+      "lzrlSourceCommit": "24c42f7c",
+      "note": "Etherscan-verified LayerZeroTellerWithRateLimiting (solc 0.8.21). Mixed-vintage working-tree deploy: constituent files trace to multiple main commits, so no single-commit bytecode build matches (prior 'mismatch'). LZRL.sol matches main @ 24c42f7c."
     }
   }
 }

--- a/deployments/addresses/Scroll/Tellers.json
+++ b/deployments/addresses/Scroll/Tellers.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "verification": "mismatch",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/TAC/Accountants.json
+++ b/deployments/addresses/TAC/Accountants.json
@@ -1,0 +1,12 @@
+{
+  "contractAddresses": {
+    "AccountantWithRateProviders_d43331e2": "0x20c13ab7cd4f0ffc49de1a9b6d415314d43331e2"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders_d43331e2": {
+      "deploymentCommit": "5efd7fb6",
+      "verification": "full_match",
+      "verificationGap": "cbor"
+    }
+  }
+}

--- a/deployments/addresses/TAC/Tellers.json
+++ b/deployments/addresses/TAC/Tellers.json
@@ -6,8 +6,7 @@
     "LayerZeroTeller_e98041e3": {
       "deploymentCommit": "5efd7fb6",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     }
   }
 }

--- a/deployments/addresses/TAC/Tellers.json
+++ b/deployments/addresses/TAC/Tellers.json
@@ -1,0 +1,13 @@
+{
+  "contractAddresses": {
+    "LayerZeroTeller_e98041e3": "0x834e313cb01e8badeaad269fceecb5a1e98041e3"
+  },
+  "contractMetadata": {
+    "LayerZeroTeller_e98041e3": {
+      "deploymentCommit": "5efd7fb6",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/UniChain/Tellers.json
+++ b/deployments/addresses/UniChain/Tellers.json
@@ -1,0 +1,13 @@
+{
+  "contractAddresses": {
+    "LayerZeroTeller_73fe614b": "0x0baab6db8d694e1511992b504476ef4073fe614b"
+  },
+  "contractMetadata": {
+    "LayerZeroTeller_73fe614b": {
+      "deploymentCommit": "92e1a7af",
+      "verification": "full_match",
+      "verificationGap": "cbor",
+      "discoveredVia": "active-teller-pin (2026-05-28)"
+    }
+  }
+}

--- a/deployments/addresses/UniChain/Tellers.json
+++ b/deployments/addresses/UniChain/Tellers.json
@@ -6,8 +6,7 @@
     "LayerZeroTeller_73fe614b": {
       "deploymentCommit": "92e1a7af",
       "verification": "full_match",
-      "verificationGap": "cbor",
-      "discoveredVia": "active-teller-pin (2026-05-28)"
+      "verificationGap": "cbor"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds two registry files to `deployments/addresses/<Chain>/` for contracts that are currently wired on-chain but whose deploys were never recorded in the per-vault address JSONs:

- **`Tellers.json`** — 14 active teller hook deployments across 8 chains (commit `e3ab7303`)
- **`Accountants.json`** — 4 active accountant deployments across 3 chains (commit `64121ad2`)

Each entry carries the bytecode-pinned `deploymentCommit` + `verification` verdict where available.

| registry | rows | full_match | mismatch |
|---|---|---|---|
| Tellers.json | 14 | 11 | 3 |
| Accountants.json | 4 | 2 | 2 |

The 5 `mismatch` rows (eBTC on Arb/Scroll, LiquidBTC on BeraChain, PrimeLiquidBera{BTC,ETH} on BeraChain) have live bytecode that doesn't match any candidate commit on `main` — almost certainly deployed off an unmerged feature branch. Future sweeps with a broader candidate set can fill them in.

## Format

Each entry mirrors the existing per-vault JSON schema (`contractAddresses` + `contractMetadata`) so the `verify_eth_getcode.py` / `apply_verdicts.py` sweep picks them up next run with no code change.

Naming: `<VariantName>_<last-8-hex-of-addr>` — no vault hint in the key. `deployments/addresses/` is the deploy registry; vault wiring lives in `deployments/configurations/`.

## Discovery

Found via the **active-contract-pin** investigation series:

- `active-teller-pin/` — checks `BoringVault.hook()` vs recorded teller; pins live bytecode via forward-walk
- `active-authority-pin/` — checks `BoringVault.authority()` vs recorded RolesAuthority (clean negative: 0 swaps across 105 production vaults, validating the teller-pin's `canCall` verdicts)
- `active-accountant-pin/` — checks `Teller.accountant()` on the *operative teller* vs recorded Accountant

Of the 14 teller-swap vaults, 4 also had accountant swaps; the other 10 kept the same accountant (the new teller just points at the existing address — cross-chain LayerZero deploys share accountants by design via CREATE3 vanity).

Scripts in [Veda-Labs/security-scripts](https://github.com/Veda-Labs/security-scripts) under `onchain-scripts/bytecode-verifier/active-{teller,authority,accountant}-pin/`; matching dataset in `veda-skills/knowledge/veda/bytecode-verification/active-{teller,authority,accountant}-pin/`.

The campaign also surfaced that vault→teller and vault→accountant swaps don't propagate back into the deployment JSONs. This PR addresses the data gap for the discovered swaps; the process gap (re-recording at swap time) is out of scope.

## Commits

1. `e3ab7303` deployments: register 14 active teller hooks across 8 chains
2. `05f9d2f8` deployments: drop non-standard discoveredVia field from Tellers.json
3. `64121ad2` deployments: register 4 active accountants discovered post-deploy

## Test plan

- [ ] Run the bytecode-verifier sweep against the new entries and confirm full_match rolls forward.
- [ ] CI passes (deployment JSONs are static data, no contract code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)