### PR TITLE
vmUSD deployment

### DIFF
--- a/deployments/skeletons/addresses/Mainnet/vmUSD.json
+++ b/deployments/skeletons/addresses/Mainnet/vmUSD.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "AccountantWithYieldStreaming": "0x98A45D90E81849a5743241d3ff765F9Fd788206a",
+    "BoringOnChainQueue": "0xAd6b8d86bd66fF82a4663b9F9c7dBf0fc8C5f3ca",
+    "BoringVault": "0x1C8a336051D2024E318A229d01F9F6CF96efD316",
+    "Lens": "0xa3b5f71AB29BA99B9750327575Dcc456CadC550b",
+    "ManagerWithMerkleVerification": "0xf05bFFA1c0aeF77473B5D8A15502d52f0F41dF2B",
+    "Pauser": "0x425b512cC784d0C1A1a2A72156811852A3599feB",
+    "QueueSolver": "0xC1C95a8547e47E01Db5336db4CCa69703f0c63aE",
+    "RolesAuthority": "0xA1299741024a9213E555D6C3D12335D96F9F1770",
+    "TellerWithYieldStreaming": "0xB30755C750E0A7E5BeD3dDAf0D9948Cf2b1CDc87",
+    "Timelock": "0x0000000000000000000000000000000000000000"
+  }
+}

--- a/deployments/skeletons/addresses/Monad/vmUSD.json
+++ b/deployments/skeletons/addresses/Monad/vmUSD.json
@@ -1,0 +1,16 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "AccountantWithYieldStreaming": "0x98A45D90E81849a5743241d3ff765F9Fd788206a",
+    "BoringOnChainQueue": "0xAd6b8d86bd66fF82a4663b9F9c7dBf0fc8C5f3ca",
+    "BoringVault": "0x1C8a336051D2024E318A229d01F9F6CF96efD316",
+    "ERC4626BufferHelper": "0x11C2782c1e1a6eDf18bEe5360035b97E48b88A72",
+    "Lens": "0xa3b5f71AB29BA99B9750327575Dcc456CadC550b",
+    "ManagerWithMerkleVerification": "0xf05bFFA1c0aeF77473B5D8A15502d52f0F41dF2B",
+    "Pauser": "0x425b512cC784d0C1A1a2A72156811852A3599feB",
+    "QueueSolver": "0xC1C95a8547e47E01Db5336db4CCa69703f0c63aE",
+    "RolesAuthority": "0xA1299741024a9213E555D6C3D12335D96F9F1770",
+    "TellerWithYieldStreaming": "0xB30755C750E0A7E5BeD3dDAf0D9948Cf2b1CDc87",
+    "Timelock": "0x0000000000000000000000000000000000000000"
+  }
+}

--- a/deployments/skeletons/configurations/Mainnet/vmUSD.json
+++ b/deployments/skeletons/configurations/Mainnet/vmUSD.json
@@ -1,0 +1,133 @@
+{
+  "deploymentParameters": {
+    "logLevel": 4,
+    "privateKeyEnvName": "BORING_DEVELOPER",
+    "chainName": "mainnet",
+    "evmVersion": "cancun",
+    "deployerContractAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "newDeployer"
+    },
+    "txBundlerAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "newDeployer"
+    },
+    "nativeWrapperAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "WETH"
+    },
+    "deploymentOwnerAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "newDeployer"
+    },
+    "deploymentFileName": "skeletons/addresses/Mainnet/vmUSD.json"
+  },
+  "rolesAuthorityConfiguration": {
+    "rolesAuthorityDeploymentName": "vmUSD RolesAuthority Version 0.0"
+  },
+  "lensConfiguration": {
+    "lensDeploymentName": "Arctic Architecture Lens V0.0"
+  },
+  "boringVaultConfiguration": {
+    "boringVaultDeploymentName": "vmUSD Boring Vault V0.0",
+    "boringVaultName": "mUSD Vault",
+    "boringVaultSymbol": "vmUSD",
+    "boringVaultDecimals": 6
+  },
+  "managerConfiguration": {
+    "managerDeploymentName": "vmUSD ManagerWithMerkleVerification V0.0",
+    "balancerVaultAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000001",
+      "name": "balancerV2Vault"
+    }
+  },
+  "accountantConfiguration": {
+    "accountantDeploymentName": "vmUSD Accountant With Yield Streaming V0.0",
+    "accountantParameters": {
+      "kind": {
+        "variableRate": false,
+        "fixedRate": false,
+        "yieldStreaming": true
+      },
+      "payoutConfiguration": {
+        "payoutTo": "0x4647E6DD7e8E440A8aeFd78860C6A0e56EcA2521",
+        "optionalPaymentSplitterName": "vmUSD Payment Splitter V0.0",
+        "splits": []
+      },
+      "accountantDeploymentParameters": {
+        "allowedExchangeRateChangeLower": 9980,
+        "allowedExchangeRateChangeUpper": 10020,
+        "base": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "mUSD"
+        },
+        "minimumUpateDelayInSeconds": 21600,
+        "performanceFee": 0,
+        "platformFee": 0,
+        "startingExchangeRate": 1000000
+      }
+    }
+  },
+  "tellerConfiguration": {
+    "tellerDeploymentName": "vmUSD Teller With Yield Streaming V0.0",
+    "tellerParameters": {
+      "kind": {
+        "teller": false,
+        "tellerWithRemediation": false,
+        "tellerWithCcip": false,
+        "tellerWithLayerZero": false,
+        "tellerWithLayerZeroRateLimiting": false,
+        "tellerWithYieldStreaming": true
+      }
+    }
+  },
+  "boringQueueConfiguration": {
+    "boringQueueDeploymentName": "vmUSD Queue V0.0",
+    "boringQueueSolverName": "vmUSD Queue Solver V0.0",
+    "excessToSolverNonSelfSolve": true,
+    "queueParameters": {
+      "kind": {
+        "boringQueue": true,
+        "boringQueueWithTracking": false
+      }
+    }
+  },
+  "droneConfiguration": {
+    "droneDeploymentBaseName": "vmUSD Drone V0.0",
+    "droneCount": 0,
+    "safeGasToForwardNative": 21000
+  },
+  "pauserConfiguration": {
+    "shouldDeploy": true,
+    "pauserDeploymentName": "vmUSD Pauser V0.0"
+  },
+  "timelockConfiguration": {
+    "shouldDeploy": false,
+    "timelockDeploymentName": "vmUSD Timelock V0.0",
+    "timelockParameters": {
+      "executors": ["0x68eC1FdD4Bb202B2e07aE751CB5553644aA48cFA"],
+      "minDelay": 43200,
+      "proposers": ["0x68eC1FdD4Bb202B2e07aE751CB5553644aA48cFA"]
+    }
+  },
+  "erc4626BufferHelperConfiguration": {
+    "shouldDeploy": false,
+    "erc4626BufferHelperDeploymentName": "vmUSD ERC4626 Buffer Helper V0.0",
+    "erc4626VaultAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "steakhouseMUSDVault"
+    }
+  },
+  "aaveV3BufferHelperConfiguration": {
+      "shouldDeploy": false,
+      "aaveV3BufferHelperDeploymentName": "vmUSD AaveV3 Buffer Helper V0.0",
+      "aaveV3PoolAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "v3Pool"
+      }
+    },
+    "aaveV3BufferLensConfiguration": {
+      "shouldDeploy": false,
+      "aaveV3BufferLensDeploymentName": "AaveV3 Buffer Lens V0.0"
+    }
+}

--- a/deployments/skeletons/configurations/Monad/vmUSD.json
+++ b/deployments/skeletons/configurations/Monad/vmUSD.json
@@ -1,0 +1,133 @@
+{
+  "deploymentParameters": {
+    "logLevel": 4,
+    "privateKeyEnvName": "BORING_DEVELOPER",
+    "chainName": "monad",
+    "evmVersion": "cancun",
+    "deployerContractAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "newDeployer"
+    },
+    "txBundlerAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "txBundlerAddress"
+    },
+    "nativeWrapperAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "WMON"
+    },
+    "deploymentOwnerAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "txBundlerAddress"
+    },
+    "deploymentFileName": "skeletons/addresses/Monad/vmUSD.json"
+  },
+  "rolesAuthorityConfiguration": {
+    "rolesAuthorityDeploymentName": "vmUSD RolesAuthority Version 0.0"
+  },
+  "lensConfiguration": {
+    "lensDeploymentName": "Arctic Architecture Lens V0.0"
+  },
+  "boringVaultConfiguration": {
+    "boringVaultDeploymentName": "vmUSD Boring Vault V0.0",
+    "boringVaultName": "mUSD Vault",
+    "boringVaultSymbol": "vmUSD",
+    "boringVaultDecimals": 6
+  },
+  "managerConfiguration": {
+    "managerDeploymentName": "vmUSD ManagerWithMerkleVerification V0.0",
+    "balancerVaultAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000001",
+      "name": "balancerV2Vault"
+    }
+  },
+  "accountantConfiguration": {
+    "accountantDeploymentName": "vmUSD Accountant With Yield Streaming V0.0",
+    "accountantParameters": {
+      "kind": {
+        "variableRate": false,
+        "fixedRate": false,
+        "yieldStreaming": true
+      },
+      "payoutConfiguration": {
+        "payoutTo": "0x4647E6DD7e8E440A8aeFd78860C6A0e56EcA2521",
+        "optionalPaymentSplitterName": "vmUSD Payment Splitter V0.0",
+        "splits": []
+      },
+      "accountantDeploymentParameters": {
+        "allowedExchangeRateChangeLower": 9980,
+        "allowedExchangeRateChangeUpper": 10020,
+        "base": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "name": "mUSD"
+        },
+        "minimumUpateDelayInSeconds": 21600,
+        "performanceFee": 0,
+        "platformFee": 50,
+        "startingExchangeRate": 1000000
+      }
+    }
+  },
+  "tellerConfiguration": {
+    "tellerDeploymentName": "vmUSD Teller With Yield Streaming V0.0",
+    "tellerParameters": {
+      "kind": {
+        "teller": false,
+        "tellerWithRemediation": false,
+        "tellerWithCcip": false,
+        "tellerWithLayerZero": false,
+        "tellerWithLayerZeroRateLimiting": false,
+        "tellerWithYieldStreaming": true
+      }
+    }
+  },
+  "boringQueueConfiguration": {
+    "boringQueueDeploymentName": "vmUSD Queue V0.0",
+    "boringQueueSolverName": "vmUSD Queue Solver V0.0",
+    "excessToSolverNonSelfSolve": true,
+    "queueParameters": {
+      "kind": {
+        "boringQueue": true,
+        "boringQueueWithTracking": false
+      }
+    }
+  },
+  "droneConfiguration": {
+    "droneDeploymentBaseName": "vmUSD Drone V0.0",
+    "droneCount": 0,
+    "safeGasToForwardNative": 21000
+  },
+  "pauserConfiguration": {
+    "shouldDeploy": true,
+    "pauserDeploymentName": "vmUSD Pauser V0.0"
+  },
+  "timelockConfiguration": {
+    "shouldDeploy": false,
+    "timelockDeploymentName": "vmUSD Timelock V0.0",
+    "timelockParameters": {
+      "executors": ["0x68eC1FdD4Bb202B2e07aE751CB5553644aA48cFA"],
+      "minDelay": 43200,
+      "proposers": ["0x68eC1FdD4Bb202B2e07aE751CB5553644aA48cFA"]
+    }
+  },
+  "erc4626BufferHelperConfiguration": {
+    "shouldDeploy": true,
+    "erc4626BufferHelperDeploymentName": "vmUSD ERC4626 Buffer Helper V0.0",
+    "erc4626VaultAddressOrName": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "steakhouseMUSDVault"
+    }
+  },
+  "aaveV3BufferHelperConfiguration": {
+      "shouldDeploy": false,
+      "aaveV3BufferHelperDeploymentName": "vmUSD AaveV3 Buffer Helper V0.0",
+      "aaveV3PoolAddressOrName": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "name": "v3Pool"
+      }
+    },
+    "aaveV3BufferLensConfiguration": {
+      "shouldDeploy": false,
+      "aaveV3BufferLensDeploymentName": "AaveV3 Buffer Lens V0.0"
+    }
+}

--- a/script/ArchitectureDeployments/DeploySkeleton.s.sol
+++ b/script/ArchitectureDeployments/DeploySkeleton.s.sol
@@ -983,7 +983,6 @@ contract DeploySkeletonScript is Script, ChainValues {
                 }
                 (string memory name, bytes memory creationCode, bytes memory constructorArgs, uint256 deployValue) =
                     abi.decode(encodedArgs, (string, bytes, bytes, uint256));
-                console.log(msg.sender);
                 deployer.deployContract(name, creationCode, constructorArgs, deployValue);
             }
         } else {

--- a/script/ArchitectureDeployments/DeploySkeleton.s.sol
+++ b/script/ArchitectureDeployments/DeploySkeleton.s.sol
@@ -121,7 +121,7 @@ contract DeploySkeletonScript is Script, ChainValues {
     }
 
     // You might want to adjust this depending on what all you're deploying and on what chain
-    uint256 constant DESIRED_NUMBER_OF_DEPLOYMENT_TXS = 10;
+    uint256 constant DESIRED_NUMBER_OF_DEPLOYMENT_TXS = 3;
 
     // Contracts to deploy
     ArcticArchitectureLens public lens;
@@ -968,12 +968,30 @@ contract DeploySkeletonScript is Script, ChainValues {
             lastIndexDeployed += txsInBundle;
         }
 
-        address txBundler = getAddress(sourceChain, "txBundlerAddress");
-
         vm.startBroadcast();
-        for (uint256 i; i < desiredNumberOfDeploymentTxs; i++) {
-            console.log(string.concat("Sending bundle: ", vm.toString(i)));
-            Deployer(txBundler).bundleTxs(txBundles[i]);
+        if (desiredNumberOfDeploymentTxs == txsLength) {
+            console.log("Desired # of txs >= # of bundles, calling deployer directly rather than using bundler");
+            for (uint256 i; i < txsLength; i++) {
+                console.log(string.concat("Sending tx: ", vm.toString(i)));
+                // Every tx in `txs` is built by _addDeployTx targeting `deployer.deployContract`,
+                // so strip the 4-byte selector and re-issue as a typed call against the deployer.
+                // This lets Foundry's broadcast surface revert reasons instead of swallowing them.
+                bytes memory rawData = txsToSend[i].data;
+                bytes memory encodedArgs = new bytes(rawData.length - 4);
+                for (uint256 j; j < encodedArgs.length; j++) {
+                    encodedArgs[j] = rawData[j + 4];
+                }
+                (string memory name, bytes memory creationCode, bytes memory constructorArgs, uint256 deployValue) =
+                    abi.decode(encodedArgs, (string, bytes, bytes, uint256));
+                console.log(msg.sender);
+                deployer.deployContract(name, creationCode, constructorArgs, deployValue);
+            }
+        } else {
+            address txBundler = _handleAddressOrName(".deploymentParameters.txBundlerAddressOrName");
+            for (uint256 i; i < desiredNumberOfDeploymentTxs; i++) {
+                console.log(string.concat("Sending bundle: ", vm.toString(i)));
+                Deployer(txBundler).bundleTxs(txBundles[i]);
+            }
         }
         vm.stopBroadcast();
     }

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -168,6 +168,7 @@ contract ChainValues {
         // Liquid Ecosystem
         values[mainnet]["deployerAddress"] = 0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d.toBytes32();
         values[mainnet]["deployerAddress2"] = 0xF3d0672a91Fd56C9ef04C79ec67d60c34c6148a0.toBytes32();
+        values[mainnet]["newDeployer"] = 0xe80F045fc6F551229f98FA21E0Db35784A590e05.toBytes32();
         values[mainnet]["dev0Address"] = 0x0463E60C7cE10e57911AB7bD1667eaa21de3e79b.toBytes32();
         values[mainnet]["dev1Address"] = 0xf8553c8552f906C19286F21711721E206EE4909E.toBytes32();
         values[mainnet]["etherfiOpsAddress"] = 0xC8111D00351765c64D301CDFc1848bf5Ff2E23A2.toBytes32();
@@ -3355,13 +3356,13 @@ contract ChainValues {
     }
 
     function _addMonadValues() private {
-        values[monad]["deployerAddress"] = 0x144dc4DF655a57d871be8f18aA565b82D3E980f5.toBytes32();
-        values[monad]["txBundlerAddress"] = 0x144dc4DF655a57d871be8f18aA565b82D3E980f5.toBytes32();
+        values[monad]["newDeployer"] = 0xe80F045fc6F551229f98FA21E0Db35784A590e05.toBytes32();
+        values[monad]["txBundlerAddress"] = 0xe80F045fc6F551229f98FA21E0Db35784A590e05.toBytes32();
         values[monad]["dev1Address"] = 0xf8553c8552f906C19286F21711721E206EE4909E.toBytes32();
         values[monad]["WMON"] = 0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A.toBytes32();
         values[monad]["mUSD"] = 0xacA92E438df0B2401fF60dA7E4337B687a2435DA.toBytes32();
-        values[monad]["steakhouseMUSDVault"] = 0xBEEFF60EC664adb24ff7378A8C69ecD25C3cC867.toBytes32();
-        values[monad]["steakhouseUSDCVault"] = 0xBEEFFf30371ff8EbdEA03d5E2e3C6b7c0bA0303c.toBytes32();
+        values[monad]["steakhouseMUSDVault"] = 0xBEEF067C9D2591aCCAB7d1C336a41ca3bd45b8f5.toBytes32();
+        values[monad]["steakhouseUSDCVault"] = 0xBEEF0C61DA39F7EA2bFa7B0f9d6338A3a2DD2fF0.toBytes32();
 
         // MPortal — same deterministic proxy address as mainnet.
         values[monad]["mportalProxy"] = 0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd.toBytes32();


### PR DESCRIPTION
Includes changes to DeploySkeleton:
- pass in txBundler address
- skip bundling and call deployer directly if bundles won't reduce # of txs

Place newDeployer address and updated steakhouse vaults in ChainValues and remove test deployer/vault addresses from Monad