### PR TITLE
NatSpec: rate-provider return convention (design choice #19)

### DIFF
--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -245,6 +245,15 @@ contract AccountantWithRateProviders is Auth, IRateProvider, IPausable {
      * @dev Rate providers must return rates in terms of `base` or
      * an asset pegged to base and they must use the same decimals
      * as `asset`.
+     * @dev If `asset` has fewer decimals than `base`, the conversion
+     * math in `claimFees`, `claimYield`, and `getRateInQuote`
+     * truncates the base-denominated amount by
+     * `10**(base.decimals - asset.decimals)` before applying the rate.
+     * For an 18-decimal `base` paired with a 6-decimal `asset`, base
+     * amounts smaller than `1e12` round to zero in the conversion and
+     * produce zero output. Realistic fee or yield accruals sit well
+     * above this floor; very small amounts or extremely frequent
+     * claims may not.
      * @dev Callable by OWNER_ROLE.
      */
     function setRateProviderData(ERC20 asset, bool isPeggedToBase, address rateProvider) external requiresAuth {

--- a/src/base/Roles/AccountantWithRateProviders.sol
+++ b/src/base/Roles/AccountantWithRateProviders.sol
@@ -246,8 +246,9 @@ contract AccountantWithRateProviders is Auth, IRateProvider, IPausable {
      * an asset pegged to base and they must use the same decimals
      * as `asset`.
      * @dev If `asset` has fewer decimals than `base`, the conversion
-     * math in `claimFees`, `claimYield`, and `getRateInQuote`
-     * truncates the base-denominated amount by
+     * math in `claimFees`, `claimYield`, `getRateInQuote`, and
+     * `AccountantWithYieldStreaming.getRateInQuote` truncates the
+     * base-denominated amount by
      * `10**(base.decimals - asset.decimals)` before applying the rate.
      * For an 18-decimal `base` paired with a 6-decimal `asset`, base
      * amounts smaller than `1e12` round to zero in the conversion and

--- a/src/interfaces/IRateProvider.sol
+++ b/src/interfaces/IRateProvider.sol
@@ -19,5 +19,12 @@
 pragma solidity ^0.8.0;
 
 interface IRateProvider {
+    /**
+     * @notice Returns the current price of one unit of this provider's asset, expressed in the base asset.
+     * @dev The return value uses this provider's asset decimals, not the base asset's decimals.
+     *      A USDC (6-decimal) rate provider returns `price * 1e6`; a DAI (18-decimal) provider returns
+     *      `price * 1e18`. `AccountantWithRateProviders.claimFees`, `AccountantWithFixedRate.claimYield`,
+     *      and `AccountantWithRateProviders.getRateInQuote` rely on this convention.
+     */
     function getRate() external view returns (uint256);
 }

--- a/src/interfaces/IRateProvider.sol
+++ b/src/interfaces/IRateProvider.sol
@@ -24,7 +24,7 @@ interface IRateProvider {
      * @dev The return value uses this provider's asset decimals, not the base asset's decimals.
      *      A USDC (6-decimal) rate provider returns `price * 1e6`; a DAI (18-decimal) provider returns
      *      `price * 1e18`. `AccountantWithRateProviders.claimFees`, `AccountantWithFixedRate.claimYield`,
-     *      and `AccountantWithRateProviders.getRateInQuote` rely on this convention.
+     *      `AccountantWithRateProviders.getRateInQuote`, and `AccountantWithYieldStreaming.getRateInQuote` rely on this convention.
      */
     function getRate() external view returns (uint256);
 }


### PR DESCRIPTION
## Summary

Documents the convention `IRateProvider.getRate()` implementations are expected to follow: **the return value uses the provider's asset decimals, not the base asset's decimals.** A USDC (6-decimal) rate provider returns `price * 1e6`; a DAI (18-decimal) provider returns `price * 1e18`.

The convention was previously only encoded in two places — the `getRateInQuote` math at `src/base/Roles/AccountantWithRateProviders.sol:369-384` and the test `test/AccountantWithRateProvidersUsingDifferentDecimalAssets.t.sol::testClaimFeesUsingRateProviderAsset` — with no NatSpec at the interface itself. This PR closes that source-of-truth gap so a custom rate provider author sees the requirement at the call site.

No code change. NatSpec only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)