### PR TITLE
ci: switch Infura RPC endpoints to Alchemy

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 350
     env:
-      MAINNET_RPC_URL: https://mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      ARBITRUM_RPC_URL: https://arbitrum-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      MAINNET_RPC_URL: https://eth-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      ARBITRUM_RPC_URL: https://arb-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
       BASE_RPC_URL: https://base-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      AVALANCHE_RPC_URL: https://avalanche-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      OPTIMISM_RPC_URL: https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      LINEA_RPC_URL: https://linea-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      MANTLE_RPC_URL: https://mantle-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      HOLESKY_RPC_URL: https://holesky.infura.io/v3/${{ secrets.INFURA_API_KEY_0 }}
+      AVALANCHE_RPC_URL: https://avax-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      OPTIMISM_RPC_URL: https://opt-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      LINEA_RPC_URL: https://linea-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      MANTLE_RPC_URL: https://mantle-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      HOLESKY_RPC_URL: https://eth-holesky.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
       BERA_CHAIN_RPC_URL: ${{ secrets.BERA_CHAIN_RPC_URL }}
       BOB_RPC_URL: ${{ secrets.BOB_RPC_URL }}
       DERIVE_RPC_URL: ${{ secrets.DERIVE_RPC_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     env:
-      MAINNET_RPC_URL: https://mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      ARBITRUM_RPC_URL: https://arbitrum-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
+      MAINNET_RPC_URL: https://eth-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      ARBITRUM_RPC_URL: https://arb-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
       BASE_RPC_URL: https://base-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
-      AVALANCHE_RPC_URL: https://avalanche-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      OPTIMISM_RPC_URL: https://optimism-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      LINEA_RPC_URL: https://linea-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      MANTLE_RPC_URL: https://mantle-mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}
-      HOLESKY_RPC_URL: https://holesky.infura.io/v3/${{ secrets.INFURA_API_KEY_0 }}
+      AVALANCHE_RPC_URL: https://avax-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      OPTIMISM_RPC_URL: https://opt-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      LINEA_RPC_URL: https://linea-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      MANTLE_RPC_URL: https://mantle-mainnet.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
+      HOLESKY_RPC_URL: https://eth-holesky.g.alchemy.com/v2/${{ secrets.ALCHEMY_API_KEY }}
       BERA_CHAIN_RPC_URL: ${{ secrets.BERA_CHAIN_RPC_URL }}
       BOB_RPC_URL: ${{ secrets.BOB_RPC_URL }}
       DERIVE_RPC_URL: ${{ secrets.DERIVE_RPC_URL }}


### PR DESCRIPTION
## Summary

Every fork that resolved through Infura failed CI with:

```
vm.createFork: HTTP error 401 with body: invalid project id
```

434 such errors in the latest run — the `INFURA_API_KEY` is broken/invalid. We already use a working `ALCHEMY_API_KEY` for Base, so this PR points the remaining 7 Infura-backed chains at Alchemy as well:

| Chain | Before | After |
|---|---|---|
| mainnet | `mainnet.infura.io/v3/$INFURA_API_KEY` | `eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY` |
| arbitrum | `arbitrum-mainnet.infura.io/...` | `arb-mainnet.g.alchemy.com/...` |
| avalanche | `avalanche-mainnet.infura.io/...` | `avax-mainnet.g.alchemy.com/...` |
| optimism | `optimism-mainnet.infura.io/...` | `opt-mainnet.g.alchemy.com/...` |
| linea | `linea-mainnet.infura.io/...` | `linea-mainnet.g.alchemy.com/...` |
| mantle | `mantle-mainnet.infura.io/...` | `mantle-mainnet.g.alchemy.com/...` |
| holesky | `holesky.infura.io/v3/$INFURA_API_KEY_0` | `eth-holesky.g.alchemy.com/v2/$ALCHEMY_API_KEY` |

This removes the dependency on `INFURA_API_KEY` / `INFURA_API_KEY_0` entirely. Applied to both `test.yml` and `nightly-fuzz.yml`.

## Result (PR CI vs #713 baseline)

| Metric | Before (#713) | After (this PR) | Δ |
|---|---|---|---|
| Suites passing | 14 | **111** | **+97** |
| Suites failing | 141 | 44 | -97 |
| Infura 401 errors | 434 | **0** | gone |

CI goes from almost entirely red to ~72% green. The 44 remaining failures are now mostly *real* test/contract issues (not infra), which is what we wanted to surface — tracked separately:

- 148 `FailedInnerCall()` (likely one broken integration across many cases)
- 16 `array out-of-bounds (0x32)` (fuzz/decoder edge cases)
- 12 `ChainValues__ZeroAddress("sonicMainnet", "silo_wS_USDC…")` (missing address registration)
- 10 `vm.writeFile test/fixtures/…` (missing fixtures dir — pre-existing)
- 12 `BARTIO_RPC_URL not found` (deliberately skipped, no secret)
- 6 `PRIVATE_KEY not found` (script/deploy tests)
- 2 `rpc.plume.finance` DNS failures
- misc: `testFail*` removed (Foundry-nightly breaking change), arithmetic over/underflow, `UNAUTHORIZED`

## Context

Second of the two CI blockers identified earlier (the first — wiring missing chain RPC secrets — landed in #713, +9 passing suites). With Infura's 434 failures resolved, the bulk of the remaining red has cleared.

## Test plan

- [x] PR CI completes with Infura 401 errors at 0
- [x] mainnet / arbitrum / optimism / avalanche / linea / mantle / holesky fork tests execute against real chain state
- [x] Net passing-suite count jumps substantially vs the #713 baseline (14 → 111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)