### PR TITLE
test: re-add BaseDecoderAndSanitizer to Full decoder test helpers

### DIFF
--- a/test/integrations/AgglayerIntegration.t.sol
+++ b/test/integrations/AgglayerIntegration.t.sol
@@ -5,11 +5,12 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {AgglayerDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/AgglayerDecoderAndSanitizer.sol"; 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
-contract FullAgglayerDecoderAndSanitizer is AgglayerDecoderAndSanitizer{}
+contract FullAgglayerDecoderAndSanitizer is AgglayerDecoderAndSanitizer, BaseDecoderAndSanitizer{}
 
 
 contract AgglayerIntegrationTest is BaseTestIntegration {

--- a/test/integrations/AmbientIntegration.t.sol
+++ b/test/integrations/AmbientIntegration.t.sol
@@ -4,6 +4,7 @@
 // Licensed under Software Evaluation License, Version 1.0
 pragma solidity 0.8.21;
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -822,4 +823,4 @@ contract AmbientIntegrationTest is Test, MerkleTreeHelper {
 }
 
 
-contract FullAmbientDecoderAndSanitizer is AmbientDecoderAndSanitizer{}
+contract FullAmbientDecoderAndSanitizer is AmbientDecoderAndSanitizer, BaseDecoderAndSanitizer{}

--- a/test/integrations/BGTRewardVaultIntegration.t.sol
+++ b/test/integrations/BGTRewardVaultIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {BGTRewardVaultDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/BGTRewardVaultDecoderAndSanitizer.sol"; 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
@@ -12,7 +13,7 @@ import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protoco
 import {CurveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol"; 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
-contract FullBGTRewardVaultDecoderAndSanitizer is BGTRewardVaultDecoderAndSanitizer {
+contract FullBGTRewardVaultDecoderAndSanitizer is BGTRewardVaultDecoderAndSanitizer, BaseDecoderAndSanitizer {
 
     //function deposit(uint256, address receiver) external pure override(ERC4626DecoderAndSanitizer, CurveDecoderAndSanitizer) returns (bytes memory addressesFound) {
     //    addressesFound = abi.encodePacked(receiver);

--- a/test/integrations/BalancerSwapsIntegration.t.sol
+++ b/test/integrations/BalancerSwapsIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -219,4 +220,4 @@ contract RingsVoterIntegration is Test, MerkleTreeHelper {
 }
 
 
-contract FullRingsDecoderAndSanitizer is BalancerV2DecoderAndSanitizer {}
+contract FullRingsDecoderAndSanitizer is BalancerV2DecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/BeraETHIntegration.t.sol
+++ b/test/integrations/BeraETHIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -158,4 +159,4 @@ contract BeraETHIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullBeraETHDecoderAndSanitizer is BeraETHDecoderAndSanitizer {}
+contract FullBeraETHDecoderAndSanitizer is BeraETHDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/BeraborrowIntegration.t.sol
+++ b/test/integrations/BeraborrowIntegration.t.sol
@@ -5,12 +5,13 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {BeraborrowDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/BeraborrowDecoderAndSanitizer.sol"; 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
 import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
 
-contract FullBeraborrowDecoderAndSanitizer is BeraborrowDecoderAndSanitizer {}
+contract FullBeraborrowDecoderAndSanitizer is BeraborrowDecoderAndSanitizer, BaseDecoderAndSanitizer {}
         
 
 contract BeraborrowIntegrationTest is BaseTestIntegration {

--- a/test/integrations/BerachainPOLIntegration.t.sol
+++ b/test/integrations/BerachainPOLIntegration.t.sol
@@ -11,13 +11,15 @@ import {InfraredDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protoc
 import {OogaBoogaDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/OogaBoogaDecoderAndSanitizer.sol";
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
 import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/ERC4626DecoderAndSanitizer.sol";
-import {CurveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol"; 
+import {CurveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
-contract FullBerachainDecoder is 
+contract FullBerachainDecoder is
     KodiakIslandDecoderAndSanitizer,
     InfraredDecoderAndSanitizer,
-    OogaBoogaDecoderAndSanitizer
+    OogaBoogaDecoderAndSanitizer,
+    BaseDecoderAndSanitizer
 {
 
 }

--- a/test/integrations/BoringChefIntegration.t.sol
+++ b/test/integrations/BoringChefIntegration.t.sol
@@ -245,7 +245,7 @@ contract BoringChefIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullBoringChefDecoderAndSanitizer is BoringChefDecoderAndSanitizer {
+contract FullBoringChefDecoderAndSanitizer is BoringChefDecoderAndSanitizer, BaseDecoderAndSanitizer {
 }
 
 // Temporary Mock Contract for test until real BoringChef is deployed

--- a/test/integrations/CompoundV2Integration.t.sol
+++ b/test/integrations/CompoundV2Integration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -244,7 +245,7 @@ contract CompoundV2IntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullCompoundV2DecoderAndSanitizer is CompoundV2DecoderAndSanitizer {}
+contract FullCompoundV2DecoderAndSanitizer is CompoundV2DecoderAndSanitizer, BaseDecoderAndSanitizer {}
 
 interface IUnitroller {
     function _setMarketBorrowCaps(address[] memory cTokens, uint256[] memory newBorrowCaps) external;

--- a/test/integrations/ConvexFXIntegration.t.sol
+++ b/test/integrations/ConvexFXIntegration.t.sol
@@ -213,6 +213,6 @@ contract ConvexFXIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullConvexDecoderAndSanitizer is ConvexFXDecoderAndSanitizer {
+contract FullConvexDecoderAndSanitizer is ConvexFXDecoderAndSanitizer, BaseDecoderAndSanitizer {
     constructor(address _poolRegistry) ConvexFXDecoderAndSanitizer(_poolRegistry){}
 }

--- a/test/integrations/DeriveIntegration.t.sol
+++ b/test/integrations/DeriveIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {DeriveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/DeriveDecoderAndSanitizer.sol"; 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
@@ -12,7 +13,7 @@ import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protoco
 import {CurveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol"; 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
-contract FullDeriveDecoderAndSanitizer is DeriveDecoderAndSanitizer {}
+contract FullDeriveDecoderAndSanitizer is DeriveDecoderAndSanitizer, BaseDecoderAndSanitizer {}
 
 contract DeriveIntegrationTest is BaseTestIntegration {
 

--- a/test/integrations/DolomiteFinanceIntegration.t.sol
+++ b/test/integrations/DolomiteFinanceIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -653,7 +654,7 @@ contract DolomiteFinanceIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullDolomiteDecoderAndSanitizer is DolomiteDecoderAndSanitizer, ERC4626DecoderAndSanitizer {
+contract FullDolomiteDecoderAndSanitizer is DolomiteDecoderAndSanitizer, ERC4626DecoderAndSanitizer, BaseDecoderAndSanitizer {
     constructor(address _dolomiteMargin) DolomiteDecoderAndSanitizer(_dolomiteMargin){}
 }
 

--- a/test/integrations/GoldiVaultIntegration.t.sol
+++ b/test/integrations/GoldiVaultIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -594,7 +595,7 @@ contract GoldiVaultIntegration is Test, MerkleTreeHelper {
     }
 }
 
-contract FullGoldiVaultDecoderAndSanitizer is GoldiVaultDecoderAndSanitizer {}
+contract FullGoldiVaultDecoderAndSanitizer is GoldiVaultDecoderAndSanitizer, BaseDecoderAndSanitizer {}
 
 interface IGoldiVault {
     function concludeTime() external view returns (uint256);

--- a/test/integrations/KodiakIslandIntegration.t.sol
+++ b/test/integrations/KodiakIslandIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -419,4 +420,4 @@ contract KodiakIslandIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract KodiakDecoderAndSanitizer is KodiakIslandDecoderAndSanitizer {}
+contract KodiakDecoderAndSanitizer is KodiakIslandDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/LBTCBridgeIntegration.t.sol
+++ b/test/integrations/LBTCBridgeIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -159,4 +160,4 @@ contract LBTCBridgeIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullLBTCBridgeDecoderAndSanitizer is LBTCBridgeDecoderAndSanitizer {}
+contract FullLBTCBridgeDecoderAndSanitizer is LBTCBridgeDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/OdosIntegration.t.sol
+++ b/test/integrations/OdosIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -843,6 +844,6 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullOdosDecoderAndSanitizer is OdosDecoderAndSanitizer {
+contract FullOdosDecoderAndSanitizer is OdosDecoderAndSanitizer, BaseDecoderAndSanitizer {
     constructor(address _odosRouter) OdosDecoderAndSanitizer(_odosRouter){}
 }

--- a/test/integrations/RingsVoterIntegration.t.sol
+++ b/test/integrations/RingsVoterIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -184,4 +185,4 @@ contract RingsVoterIntegration is Test, MerkleTreeHelper {
     }
 }
 
-contract FullRingsDecoderAndSanitizer is SonicDepositDecoderAndSanitizer {}
+contract FullRingsDecoderAndSanitizer is SonicDepositDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/RoycoIntegration.t.sol
+++ b/test/integrations/RoycoIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {ERC4626} from "@solmate/tokens/ERC4626.sol";
 import {RoycoWeirollDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/RoycoDecoderAndSanitizer.sol";
@@ -628,6 +629,6 @@ contract RoycoIntegrationTest is BaseTestIntegration {
     }
 }
 
-contract FullRoycoDecoderAndSanitizer is RoycoWeirollDecoderAndSanitizer {
+contract FullRoycoDecoderAndSanitizer is RoycoWeirollDecoderAndSanitizer, BaseDecoderAndSanitizer {
     constructor(address _recipeMarketHub) RoycoWeirollDecoderAndSanitizer(_recipeMarketHub) {}
 }

--- a/test/integrations/RsWETHUnstakingIntegration.t.sol
+++ b/test/integrations/RsWETHUnstakingIntegration.t.sol
@@ -5,12 +5,13 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {SwellDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/SwellDecoderAndSanitizer.sol"; 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
-contract FullSwellDecoderAndSanitizer is SwellDecoderAndSanitizer {}
+contract FullSwellDecoderAndSanitizer is SwellDecoderAndSanitizer, BaseDecoderAndSanitizer {}
 
 
 

--- a/test/integrations/SiloVaultIntegration.t.sol
+++ b/test/integrations/SiloVaultIntegration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {BaseTestIntegration} from "test/integrations/BaseTestIntegration.t.sol"; 
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {SiloDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/SiloDecoderAndSanitizer.sol"; 
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol"; 
@@ -12,7 +13,7 @@ import {ERC4626DecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protoco
 import {CurveDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/Protocols/CurveDecoderAndSanitizer.sol"; 
 import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
 
-contract FullSiloDecoderAndSanitizer is SiloDecoderAndSanitizer {
+contract FullSiloDecoderAndSanitizer is SiloDecoderAndSanitizer, BaseDecoderAndSanitizer {
 
 }
 

--- a/test/integrations/SkyMoneyIntegration.t.sol
+++ b/test/integrations/SkyMoneyIntegration.t.sol
@@ -203,4 +203,4 @@ contract SkyMoneyIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullSkyMoneyDecoderAndSanitizer is SkyMoneyDecoderAndSanitizer {}
+contract FullSkyMoneyDecoderAndSanitizer is SkyMoneyDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/SonicGatewayIntegration.t.sol
+++ b/test/integrations/SonicGatewayIntegration.t.sol
@@ -497,7 +497,7 @@ contract SonicGatewayIntegration is Test, MerkleTreeHelper {
     }
 }
 
-contract FullSonicGatewayDecoderAndSanitizer is SonicGatewayDecoderAndSanitizer {}
+contract FullSonicGatewayDecoderAndSanitizer is SonicGatewayDecoderAndSanitizer, BaseDecoderAndSanitizer {}
 
 contract MockProofVerifier {
     function verifyProof(address target, bytes32 slot, bytes32 value, bytes32 stateRoot, bytes calldata proof)

--- a/test/integrations/StakeStoneIntegration.t.sol
+++ b/test/integrations/StakeStoneIntegration.t.sol
@@ -167,4 +167,4 @@ contract StakeStoneIntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullStakeStoneDecoderAndSanitizer is StakeStoneDecoderAndSanitizer {}
+contract FullStakeStoneDecoderAndSanitizer is StakeStoneDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/TermFinanceIntegration.t.sol
+++ b/test/integrations/TermFinanceIntegration.t.sol
@@ -13,6 +13,7 @@ import {ERC20} from "@solmate/tokens/ERC20.sol";
 import {ERC4626} from "@solmate/tokens/ERC4626.sol";
 import {TermFinanceDecoderAndSanitizer} from
     "src/base/DecodersAndSanitizers/Protocols/TermFinanceDecoderAndSanitizer.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {DecoderCustomTypes} from "src/interfaces/DecoderCustomTypes.sol";
 import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
 import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
@@ -214,7 +215,7 @@ contract TermFinanceIntegrationTest is Test, MerkleTreeHelper {
         manager =
             new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
 
-        rawDataDecoderAndSanitizer = address(new TermFinanceDecoderAndSanitizer());
+        rawDataDecoderAndSanitizer = address(new FullTermFinanceDecoderAndSanitizer());
 
         setAddress(false, sourceChain, "boringVault", address(boringVault));
         setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
@@ -276,3 +277,5 @@ contract TermFinanceIntegrationTest is Test, MerkleTreeHelper {
         vm.selectFork(forkId);
     }
 }
+
+contract FullTermFinanceDecoderAndSanitizer is TermFinanceDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/UltraYieldIntegration.t.sol
+++ b/test/integrations/UltraYieldIntegration.t.sol
@@ -222,4 +222,4 @@ interface IUltraYield {
     function fulfillRedeem(uint256 shares, address controller) external;
 }
 
-contract FullUltraYieldDecoderAndSanitizer is UltraYieldDecoderAndSanitizer {}
+contract FullUltraYieldDecoderAndSanitizer is UltraYieldDecoderAndSanitizer, BaseDecoderAndSanitizer {}

--- a/test/integrations/UniswapV2Integration.t.sol
+++ b/test/integrations/UniswapV2Integration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -491,7 +492,7 @@ contract UniswapV2IntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullUniswapV2DecoderAndSanitizer is UniswapV2DecoderAndSanitizer {}
+contract FullUniswapV2DecoderAndSanitizer is UniswapV2DecoderAndSanitizer, BaseDecoderAndSanitizer {}
 
 interface IUniswapV2Factory {
     function getPair(address token0, address token1) external view returns (address);

--- a/test/integrations/UniswapV3SwapRouter02Integration.t.sol
+++ b/test/integrations/UniswapV3SwapRouter02Integration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -172,6 +173,6 @@ contract UniswapV3SwapRouter02IntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullUniswapV3DecoderAndSanitizer is UniswapV3SwapRouter02DecoderAndSanitizer {
+contract FullUniswapV3DecoderAndSanitizer is UniswapV3SwapRouter02DecoderAndSanitizer, BaseDecoderAndSanitizer {
     constructor(address _nfpm) UniswapV3SwapRouter02DecoderAndSanitizer(_nfpm) {}
 }

--- a/test/integrations/UniswapV4Integration.t.sol
+++ b/test/integrations/UniswapV4Integration.t.sol
@@ -5,6 +5,7 @@
 pragma solidity 0.8.21;
 
 import {MainnetAddresses} from "test/resources/MainnetAddresses.sol";
+import {BaseDecoderAndSanitizer} from "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 import {BoringVault} from "src/base/BoringVault.sol";
 import {ManagerWithMerkleVerification} from "src/base/Roles/ManagerWithMerkleVerification.sol";
 import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
@@ -1708,7 +1709,7 @@ contract UniswapV4IntegrationTest is Test, MerkleTreeHelper {
     }
 }
 
-contract FullUniswapV4DecoderAndSanitizer is UniswapV4DecoderAndSanitizer {
+contract FullUniswapV4DecoderAndSanitizer is UniswapV4DecoderAndSanitizer, BaseDecoderAndSanitizer {
     constructor(address _posm) UniswapV4DecoderAndSanitizer(_posm){} 
 }
 


### PR DESCRIPTION
## What this fixes

Recovers **~70 fork integration tests** that were reverting `FailedInnerCall()`.
CI `Foundry project` job: **670 passing / 44 failing** (was 600 / 114).

## Why

The *"Refactor decoders and sanitizers"* change dropped `is BaseDecoderAndSanitizer`
from the protocol decoders, moving the shared functions (`approve`, `transfer`, …)
up into the composed **Full** decoders. Production Full decoders inherit Base
directly, but the test-only `Full<X>DecoderAndSanitizer` helpers inherit only their
single protocol decoder — so every sanitized `approve`/`transfer` leaf reverted:

```
FailedInnerCall() — unrecognized function selector 0x095ea7b3, no fallback
```

This stayed hidden because these tests `401`'d at fork creation until the
Infura→Alchemy switch (#725) and hadn't run in CI for ~a year.

## Change

Re-add `BaseDecoderAndSanitizer` to the test `Full*` decoder helpers (28 files).
Test-only — no `src/` changes.

The 44 still-failing tests are pre-existing issues out of scope here (EigenLayer
leaf indices, Silo address, missing CI secrets, etc.) — none are regressions from
this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)