### PR TITLE
Fix 18 fork integration tests over 5 suites

### DIFF
--- a/test/DeployMetadataHelpers.t.sol
+++ b/test/DeployMetadataHelpers.t.sol
@@ -27,6 +27,8 @@ contract DeployMetadataHelpersTest is Test {
 
     function setUp() public {
         harness = new MetadataHarness();
+        // Tests write temporary fixtures here; ensure the directory exists in CI.
+        vm.createDir("./test/fixtures", true);
     }
 
     // -------------------------------------------------------------------------

--- a/test/MerkleTreeChecker.t.sol
+++ b/test/MerkleTreeChecker.t.sol
@@ -108,88 +108,32 @@ contract MerkleTreeCheckerTest is Test, MerkleTreeHelper {
         _verifyDecoderImplementsLeafsFunctionSelectors(leafs);
     }
 
-    function testFailCheckingBadTree() external {
+    /// @dev External wrapper so `vm.expectRevert` can catch the revert thrown
+    ///      inside the (internal) verification helper.
+    function verifyLeafsExternal(ManageLeaf[] calldata leafs) external view {
+        _verifyDecoderImplementsLeafsFunctionSelectors(leafs);
+    }
+
+    function test_RevertWhen_CheckingBadTree() external {
         setSourceChainName(mainnet);
-        setAddress(false, mainnet, "boringVault", boringVault);
-        setAddress(false, mainnet, "managerAddress", managerAddress);
-        setAddress(false, mainnet, "accountantAddress", accountantAddress);
         setAddress(false, mainnet, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](128);
+        // A "bad" tree contains a leaf whose function selector the decoder does not
+        // implement. The decoder's fallback reverts with
+        // BaseDecoderAndSanitizer__FunctionSelectorNotSupported(), which the checker
+        // surfaces as MerkleTreeHelper__DecoderAndSanitizerMissingFunction.
+        ManageLeaf[] memory leafs = new ManageLeaf[](1);
+        leafs[0] = ManageLeaf(
+            address(this),
+            false,
+            "thisFunctionIsNotSupportedByTheDecoder()",
+            new address[](0),
+            "Unsupported function leaf",
+            rawDataDecoderAndSanitizer
+        );
 
-        // ========================== Aave V3 ==========================
-        ERC20[] memory supplyAssets = new ERC20[](1);
-        supplyAssets[0] = getERC20(sourceChain, "WBTC");
-        ERC20[] memory borrowAssets = new ERC20[](1);
-        borrowAssets[0] = getERC20(sourceChain, "WBTC");
-        _addAaveV3Leafs(leafs, supplyAssets, borrowAssets);
-
-        // ========================== SparkLend ==========================
-        /**
-         * lend USDC, USDT, DAI, sDAI
-         * borrow wETH, wstETH
-         */
-        borrowAssets = new ERC20[](1);
-        borrowAssets[0] = getERC20(sourceChain, "WBTC");
-        _addSparkLendLeafs(leafs, supplyAssets, borrowAssets);
-
-        // ========================== Gearbox ==========================
-        _addGearboxLeafs(leafs, ERC4626(getAddress(sourceChain, "dWBTCV3")), getAddress(sourceChain, "sdWBTCV3"));
-
-        // ========================== UniswapV3 ==========================
-        address[] memory token0 = new address[](1);
-        token0[0] = getAddress(sourceChain, "WBTC");
-
-        address[] memory token1 = new address[](1);
-        token1[0] = getAddress(sourceChain, "LBTC");
-
-        _addUniswapV3Leafs(leafs, token0, token1, false, false);
-
-        // ========================== Fee Claiming ==========================
-        /**
-         * Claim fees in USDC, DAI, USDT and USDE
-         */
-        ERC20[] memory feeAssets = new ERC20[](2);
-        feeAssets[0] = getERC20(sourceChain, "WBTC");
-        feeAssets[1] = getERC20(sourceChain, "LBTC");
-        _addLeafsForFeeClaiming(leafs, getAddress(sourceChain, "accountantAddress"), feeAssets, false);
-
-        // ========================== 1inch ==========================
-        address[] memory assets = new address[](10);
-        SwapKind[] memory kind = new SwapKind[](10);
-        assets[0] = getAddress(sourceChain, "WBTC");
-        kind[0] = SwapKind.BuyAndSell;
-        assets[1] = getAddress(sourceChain, "LBTC");
-        kind[1] = SwapKind.BuyAndSell;
-        assets[2] = getAddress(sourceChain, "GEAR");
-        kind[2] = SwapKind.Sell;
-        assets[3] = getAddress(sourceChain, "CRV");
-        kind[3] = SwapKind.Sell;
-        assets[4] = getAddress(sourceChain, "CVX");
-        kind[4] = SwapKind.Sell;
-        assets[5] = getAddress(sourceChain, "AURA");
-        kind[5] = SwapKind.Sell;
-        assets[6] = getAddress(sourceChain, "BAL");
-        kind[6] = SwapKind.Sell;
-        assets[7] = getAddress(sourceChain, "PENDLE");
-        kind[7] = SwapKind.Sell;
-        assets[8] = getAddress(sourceChain, "INST");
-        kind[8] = SwapKind.Sell;
-        assets[9] = getAddress(sourceChain, "RSR");
-        kind[9] = SwapKind.Sell;
-        _addLeafsFor1InchGeneralSwapping(leafs, assets, kind);
-
-        // ========================== Flashloans ==========================
-        _addBalancerFlashloanLeafs(leafs, getAddress(sourceChain, "WBTC"));
-
-        // ========================== Curve ==========================
-        _addCurveLeafs(leafs, getAddress(sourceChain, "lBTC_wBTC_Curve_Pool"), 2, address(0));
-
-        ERC20[] memory tellerAssets = new ERC20[](1);
-        tellerAssets[0] = getERC20(sourceChain, "WBTC");
-        _addTellerLeafs(leafs, 0xe19a43B1b8af6CeE71749Af2332627338B3242D1, tellerAssets, false, true);
-
-        _verifyDecoderImplementsLeafsFunctionSelectors(leafs);
+        vm.expectRevert();
+        this.verifyLeafsExternal(leafs);
     }
 
     // ========================================= HELPER FUNCTIONS =========================================

--- a/test/integrations/BeraborrowIntegration.t.sol
+++ b/test/integrations/BeraborrowIntegration.t.sol
@@ -183,7 +183,7 @@ contract BeraborrowIntegrationTest is BaseTestIntegration {
         
         deal(getAddress(sourceChain, "WBTC"), address(boringVault), 10e8);
         
-        ManageLeaf[] memory leafs = new ManageLeaf[](4);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
 
         address[] memory managedVaults = new address[](1);
         managedVaults[0] = getAddress(sourceChain, "bbWBTCManagedVault");
@@ -247,7 +247,7 @@ contract BeraborrowIntegrationTest is BaseTestIntegration {
         
         deal(getAddress(sourceChain, "WBTC"), address(boringVault), 10e8);
         
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
 
         address[] memory managedVaults = new address[](1);
         managedVaults[0] = getAddress(sourceChain, "bbWBTCManagedVault");

--- a/test/integrations/EigenLayerLSTSTakingIntegration.t.sol
+++ b/test/integrations/EigenLayerLSTSTakingIntegration.t.sol
@@ -190,7 +190,7 @@ contract EigenLayerLSTStakingIntegrationTest is Test, MerkleTreeHelper {
         // Call deposit
         // withdraw
         // complete withdraw
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "METH"),
@@ -308,7 +308,7 @@ contract EigenLayerLSTStakingIntegrationTest is Test, MerkleTreeHelper {
         // Call deposit
         // withdraw
         // complete withdraw
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "METH"),
@@ -425,7 +425,7 @@ contract EigenLayerLSTStakingIntegrationTest is Test, MerkleTreeHelper {
         _setUpOld(); 
         deal(getAddress(sourceChain, "METH"), address(boringVault), 1_000e18);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "METH"),
@@ -442,8 +442,8 @@ contract EigenLayerLSTStakingIntegrationTest is Test, MerkleTreeHelper {
         manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
 
         ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
-        manageLeafs[0] = leafs[5];
-        manageLeafs[1] = leafs[6];
+        manageLeafs[0] = leafs[6];
+        manageLeafs[1] = leafs[7];
 
         bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
 
@@ -477,7 +477,7 @@ contract EigenLayerLSTStakingIntegrationTest is Test, MerkleTreeHelper {
         // Call deposit
         // withdraw
         // complete withdraw
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "METH"),

--- a/test/integrations/EigenRewardsIntegration.t.sol
+++ b/test/integrations/EigenRewardsIntegration.t.sol
@@ -65,7 +65,7 @@ contract EigenRewardsIntegrationTest is Test, MerkleTreeHelper {
     function testProcessClaim() external {
         deal(getAddress(sourceChain, "EIGEN"), address(boringVault), 0);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "EIGEN"),
@@ -83,7 +83,7 @@ contract EigenRewardsIntegrationTest is Test, MerkleTreeHelper {
         manager.setManageRoot(strategist, manageTree[manageTree.length - 1][0]);
 
         ManageLeaf[] memory manageLeafs = new ManageLeaf[](1);
-        manageLeafs[0] = leafs[6];
+        manageLeafs[0] = leafs[8];
 
         bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
 
@@ -119,7 +119,7 @@ contract EigenRewardsIntegrationTest is Test, MerkleTreeHelper {
         deal(getAddress(sourceChain, "EIGEN"), address(boringVault), 1_000e18);
 
         address claimer = getAddress(sourceChain, "dev0Address");
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "EIGEN"),
@@ -137,7 +137,7 @@ contract EigenRewardsIntegrationTest is Test, MerkleTreeHelper {
         manager.setManageRoot(strategist, manageTree[manageTree.length - 1][0]);
 
         ManageLeaf[] memory manageLeafs = new ManageLeaf[](1);
-        manageLeafs[0] = leafs[6];
+        manageLeafs[0] = leafs[8];
 
         bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
 

--- a/test/integrations/EigenStakingIntegration.t.sol
+++ b/test/integrations/EigenStakingIntegration.t.sol
@@ -68,7 +68,7 @@ contract EigenStakingIntegrationTest is Test, MerkleTreeHelper {
         // Call deposit
         // withdraw
         // complete withdraw
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "EIGEN"),
@@ -190,7 +190,7 @@ contract EigenStakingIntegrationTest is Test, MerkleTreeHelper {
     function testDelegation() external {
         deal(getAddress(sourceChain, "EIGEN"), address(boringVault), 1_000e18);
 
-        ManageLeaf[] memory leafs = new ManageLeaf[](8);
+        ManageLeaf[] memory leafs = new ManageLeaf[](16);
         _addLeafsForEigenLayerLST(
             leafs,
             getAddress(sourceChain, "EIGEN"),
@@ -208,8 +208,8 @@ contract EigenStakingIntegrationTest is Test, MerkleTreeHelper {
         manager.setManageRoot(strategist, manageTree[manageTree.length - 1][0]);
 
         ManageLeaf[] memory manageLeafs = new ManageLeaf[](2);
-        manageLeafs[0] = leafs[4];
-        manageLeafs[1] = leafs[5];
+        manageLeafs[0] = leafs[6];
+        manageLeafs[1] = leafs[7];
 
         bytes32[][] memory manageProofs = _getProofsUsingTree(manageLeafs, manageTree);
 

--- a/test/integrations/EthenaMintingIntegration.t.sol
+++ b/test/integrations/EthenaMintingIntegration.t.sol
@@ -29,7 +29,7 @@ contract EthenaMintingIntegrationTest is BaseTestIntegration {
         _setUpMainnet(); 
 
         //get env var
-        uint256 privateKey = vm.envUint("PRIVATE_KEY"); 
+        uint256 privateKey = vm.envOr("PRIVATE_KEY", uint256(0xA11CE)); 
         address signer = vm.addr(privateKey); 
 
         vm.startPrank(0x3B0AAf6e6fCd4a7cEEf8c92C32DFeA9E64dC1862); 
@@ -136,7 +136,7 @@ contract EthenaMintingIntegrationTest is BaseTestIntegration {
         _setUpMainnet(); 
 
         //get env var
-        uint256 privateKey = vm.envUint("PRIVATE_KEY"); 
+        uint256 privateKey = vm.envOr("PRIVATE_KEY", uint256(0xA11CE)); 
         address signer = vm.addr(privateKey); 
 
         vm.startPrank(0x3B0AAf6e6fCd4a7cEEf8c92C32DFeA9E64dC1862); 
@@ -232,7 +232,7 @@ contract EthenaMintingIntegrationTest is BaseTestIntegration {
         _setUpMainnet(); 
 
         //get env var
-        uint256 privateKey = vm.envUint("PRIVATE_KEY"); 
+        uint256 privateKey = vm.envOr("PRIVATE_KEY", uint256(0xA11CE)); 
         address signer = vm.addr(privateKey); 
 
         vm.startPrank(0x3B0AAf6e6fCd4a7cEEf8c92C32DFeA9E64dC1862); 

--- a/test/integrations/TreehouseIntegration.t.sol
+++ b/test/integrations/TreehouseIntegration.t.sol
@@ -43,7 +43,9 @@ contract SwellSimpleStakingIntegrationTest is Test, MerkleTreeHelper {
         setSourceChainName("mainnet");
         // Setup forked environment.
         string memory rpcKey = "MAINNET_RPC_URL";
-        uint256 blockNumber = 20825215;
+        // TreehouseRedemption was not yet deployed at the original block (20825215),
+        // which caused AddressEmptyCode on the redeem leg.
+        uint256 blockNumber = 21665883;
 
         _startFork(rpcKey, blockNumber);
 
@@ -158,7 +160,7 @@ contract SwellSimpleStakingIntegrationTest is Test, MerkleTreeHelper {
         targetData[2] = abi.encodeWithSignature(
             "approve(address,uint256)", getAddress(sourceChain, "TreehouseRedemption"), type(uint256).max
         );
-        uint96 expectedShareBalance = 999994557806148621988;
+        uint96 expectedShareBalance = 999345523658314748338;
         targetData[3] = abi.encodeWithSignature("redeem(uint96)", expectedShareBalance);
 
         address[] memory decodersAndSanitizers = new address[](4);


### PR DESCRIPTION
Fixes **18** fork integration tests that broke while the fork suite was dark (they 401'd at fork creation for ~a year until the Infura→Alchemy switch). One fix per commit:

| Commit | Tests | Fix |
|---|---|---|
| EigenLayer leaf arrays + indices | 8 | helper grew 2 leafs → array-OOB + shifted hard-coded `manageLeafs` indices |
| DeployMetadataHelpers | 5 | create `./test/fixtures` before the tests write into it |
| Ethena `PRIVATE_KEY` → `vm.envOr` | 3 | deterministic default so it doesn't need a CI secret |
| MerkleTreeChecker | 1 | `testFail*` removed in Foundry → `test_RevertWhen_` + explicit unsupported-fn leaf |
| Treehouse | 1 | fork block predated `TreehouseRedemption` deploy |

Test-only; no `src/` changes. Builds + passes on the stable toolchain (depends on #730, now merged).

### Re: the Ethena change
The 3 Ethena tests **pass** in CI (full job ~36 min, no stall). The toy key isn't relied on being a mainnet-authorised signer — each test *registers* `vm.addr(0xA11CE)` as the vault's delegated signer on the fork (`setDelegatedSigner` + `confirmDelegatedSigner`) before signing. The earlier "CI stall" was the Foundry-`nightly` **build** hang, fixed by pinning to stable in #730 — not these tests. (An earlier revision of this description said Ethena was split out; it was deliberately folded back in.)

### Remaining failures (not this PR)
26 pre-existing failures remain (Silo, Beraborrow managed-vault, bartio/plume/HyperEVM env, FluidDex, AvalancheBridge, EtherFiLiquid1, Odos, Derive, LayerZero referral) — none introduced here; tracked for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)