### PR TITLE
ci: pin Foundry to stable instead of nightly

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
Pin both `test.yml` and `nightly-fuzz.yml` from `version: nightly` → `version: stable`.

## Why / wins
`nightly` is re-resolved every run — a moving, untested target. CI builds had been **hanging nondeterministically** (same image, `main` included). On `stable`:

- **Build completes — no hang** (~27 min vs hung >1 h / 6 h timeout).
- **Reproducible** CI (tested releases, not daily nightlies).
- **More coverage**: 876 tests run vs 714 on nightly — same 44 failures, +162 now executing and passing.

One line each, no other changes.

> `stable` = latest stable (v1.7.1). Can hard-pin to `v1.7.1` if you prefer; the 44 remaining failures are the pre-existing tail (identical to `main`), addressed in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)