### PR TITLE
ci: skip Berachain, Corn and Scroll integration tests (ETHFI-35)

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -53,6 +53,15 @@ jobs:
         id: build
 
       - name: Run Forge tests
+        # Berachain, Corn and Scroll vaults are being deprecated (ETHFI-35),
+        # so their integration suites are skipped in CI.
         run: |
-          forge test -vv --skip SymbioticVaultIntegration --skip CreateTimelockTx
+          forge test -vv \
+            --skip SymbioticVaultIntegration --skip CreateTimelockTx \
+            --skip GoldiVaultIntegration --skip BGTRewardVaultIntegration \
+            --skip KodiakIslandIntegration --skip KodiakSwappingIntegration \
+            --skip InfraredIntegration --skip HoneyIntegration \
+            --skip DolomiteFinanceIntegration --skip BerachainPOLIntegration \
+            --skip BeraborrowIntegration --skip BeraETHIntegration \
+            --skip ScrollBridgeIntegration
         id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,15 @@ jobs:
         id: build
 
       - name: Run Forge tests
+        # Berachain, Corn and Scroll vaults are being deprecated (ETHFI-35),
+        # so their integration suites are skipped in CI.
         run: |
-          forge test -vv --skip SymbioticVaultIntegration --skip CreateTimelockTx
+          forge test -vv \
+            --skip SymbioticVaultIntegration --skip CreateTimelockTx \
+            --skip GoldiVaultIntegration --skip BGTRewardVaultIntegration \
+            --skip KodiakIslandIntegration --skip KodiakSwappingIntegration \
+            --skip InfraredIntegration --skip HoneyIntegration \
+            --skip DolomiteFinanceIntegration --skip BerachainPOLIntegration \
+            --skip BeraborrowIntegration --skip BeraETHIntegration \
+            --skip ScrollBridgeIntegration
         id: test


### PR DESCRIPTION
Per **[ETHFI-35](https://linear.app/veda-labs/issue/ETHFI-35)** — Veda is deprecating all vaults on **Berachain, Corn and Scroll** (Corn ceasing June 25th, Scroll next). Rather than maintain/repair tests for chains being shut down, skip their integration suites in CI. When ETHFI-35 Phase 1/2 removes the vaults, the suites can be deleted outright and these `--skip`s dropped.

## Skipped
**Berachain / bartio:** `GoldiVault`, `BGTRewardVault`, `KodiakIsland`, `KodiakSwapping`, `Infrared`, `Honey`, `DolomiteFinance` (active path is `_setUpBerachain`; arbitrum scaffolding is commented), `BerachainPOL`, `Beraborrow`, `BeraETH`
**Scroll:** `ScrollBridge`
**Corn:** no active integration suites.

Uses the repo's existing `--skip` convention; applied to both `test.yml` and `nightly-fuzz.yml`. Validated with `forge test --list` that exactly these suites drop out and live suites remain.

## Notes
- Removes a chunk of the current red (bartio Goldi/Infrared/Honey, Beraborrow, FullPOLFlow) plus passing-but-deprecating suites (BeraETH, BGT, Kodiak, Dolomite-berachain, ScrollBridge).
- These are CI skips; if/when ETHFI-35 Phase 1/2 removes the vaults, the suites can be deleted outright and these `--skip`s dropped.
- `DolomiteFinance` has commented-out Arbitrum scaffolding — if Dolomite is re-enabled on a live chain later, drop it from the skip list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)