### PR TITLE
test: fix 4 live-chain integration tests (Derive, FluidDex, AvalancheBridge, EtherFiLiquid1)

### DIFF
--- a/test/EtherFiLiquid1Migration.t.sol
+++ b/test/EtherFiLiquid1Migration.t.sol
@@ -389,7 +389,7 @@ contract EtherFiLiquid1MigrationTest is Test, MerkleTreeHelper {
         teller.removeAsset(ERC20(pendleEethYtDecember));
 
         rolesAuthority.setPublicCapability(
-            address(teller), bytes4(keccak256("deposit(address,uint256,uint256,address)")), true
+            address(teller), bytes4(keccak256("deposit(address,uint256,uint256)")), true
         );
         rolesAuthority.setPublicCapability(
             address(teller), TellerWithMultiAssetSupport.depositWithPermit.selector, true

--- a/test/integrations/AvalancheBridgeIntegration.t.sol
+++ b/test/integrations/AvalancheBridgeIntegration.t.sol
@@ -146,51 +146,18 @@ contract AvalancheBridgeIntegration is BaseTestIntegration {
         deal(getAddress(sourceChain, "USDC"), address(boringVault), 1_000e6); 
        
         ManageLeaf[] memory leafs = new ManageLeaf[](4);
-        ERC20[] memory assets = new ERC20[](1); 
-        assets[0] = getERC20(sourceChain, "WETH"); 
+        ERC20[] memory assets = new ERC20[](1);
+        assets[0] = getERC20(sourceChain, "WETH");
 
-        vm.expectRevert(); 
-        _addAvalancheBridgeLeafs(leafs, assets);  
+        // Bridging non-USDC assets from Avalanche is unsupported, so the leaf
+        // builder reverts. Route it through an external call so vm.expectRevert
+        // observes the revert at a lower call depth (a bare internal revert at
+        // the cheatcode's own depth is rejected by newer Foundry).
+        vm.expectRevert();
+        this.addAvalancheBridgeLeafsExternal(leafs, assets);
+    }
 
-        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
-
-        _generateTestLeafs(leafs, manageTree);
-
-        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
-
-        Tx memory tx_ = _getTxArrays(3); 
-
-        tx_.manageLeafs[0] = leafs[0]; //approve USDC
-        tx_.manageLeafs[1] = leafs[1]; //call transferTokens
-        tx_.manageLeafs[2] = leafs[2]; //transfer WETH
-        
-        bytes32[][] memory manageProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);
-
-        //targets
-        tx_.targets[0] = getAddress(sourceChain, "USDC"); //approve 
-        tx_.targets[1] = getAddress(sourceChain, "usdcTokenRouter"); //transferTokens
-        tx_.targets[2] = getAddress(sourceChain, "WETH"); //transfer
-
-        tx_.targetData[0] = abi.encodeWithSignature(
-            "approve(address,uint256)", getAddress(sourceChain, "usdcTokenRouter"), type(uint256).max
-        ); 
-        tx_.targetData[1] = abi.encodeWithSignature(
-            "transferTokens(uint256,uint32,address,address)", 
-            100e6,
-            0, //0 to send to ethereum
-            address(boringVault),
-            getAddress(sourceChain, "USDC")
-        );
-        tx_.targetData[2] = abi.encodeWithSignature(
-            "unwrap(uint256,uint256)", 
-            1e18,
-            0
-        );
-
-        tx_.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
-        tx_.decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
-        tx_.decodersAndSanitizers[2] = rawDataDecoderAndSanitizer;
-        
-        _submitManagerCall(manageProofs, tx_); 
+    function addAvalancheBridgeLeafsExternal(ManageLeaf[] memory leafs, ERC20[] memory assets) external {
+        _addAvalancheBridgeLeafs(leafs, assets);
     }
 }

--- a/test/integrations/DeriveIntegration.t.sol
+++ b/test/integrations/DeriveIntegration.t.sol
@@ -249,7 +249,7 @@ contract DeriveIntegrationTest is BaseTestIntegration {
         tx_ = _getTxArrays(1); 
         
         //manage leafs
-        tx_.manageLeafs[0] = leafs[2]; //redeem stDRV
+        tx_.manageLeafs[0] = leafs[3]; //redeem stDRV
 
         //generate proofs
         manageProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);

--- a/test/integrations/FluidDexIntegration.t.sol
+++ b/test/integrations/FluidDexIntegration.t.sol
@@ -278,8 +278,8 @@ contract FluidDexIntegrationTest is Test, MerkleTreeHelper {
         //setup boring vault tx data
 
         //this is what will be minted after we deposit
-        uint256 nftId = 2795;
-        uint256 nftPerfectId = 2796;
+        uint256 nftId = 8574;
+        uint256 nftPerfectId = 8575;
 
         //deal some dust to payback borrow
         //deal(getAddress(sourceChain, "USDC"), address(boringVault), 10e18); //I know USDC and USDT don't have 18decimals
@@ -442,8 +442,8 @@ contract FluidDexIntegrationTest is Test, MerkleTreeHelper {
         //setup boring vault tx data
 
         //this is what will be minted after we deposit
-        //uint256 nftId = 2795;
-        //uint256 nftPerfectId = 2796;
+        //uint256 nftId = 8574;
+        //uint256 nftPerfectId = 8575;
 
         //deal some dust to payback borrow
         //deal(getAddress(sourceChain, "USDC"), address(boringVault), 10e18); //I know USDC and USDT don't have 18decimals


### PR DESCRIPTION
Four fork integration fixes, one commit each — validated locally and green in CI:

| Test | Root cause | Fix |
|---|---|---|
| `DeriveIntegration::testDeriveClaim` | `finalizeRedeem` used `leafs[2]` (the `cancelRedeem` leaf); a leaf was inserted, shifting the index | → `leafs[3]` |
| `FluidDexIntegration::testFluidDexIntegration` | hard-coded position `nftId` 2795/2796 went stale (now owned by another account) | → 8574/8575 (ids minted at the pinned block) |
| `AvalancheBridgeIntegration::…WETH__Fails` | `vm.expectRevert()` on an **internal** call — rejected by newer Foundry | route through an external wrapper |
| `EtherFiLiquid1Migration::testMigration` | granted public capability for the 4-arg `deposit` selector but calls the 3-arg `deposit` | grant the 3-arg selector (`0x0efe6a8b`) |

Test-only; no `src/` changes. Stacked on #734 (Foundry build caching); rebased onto current `main`, so CI reflects only the genuinely-remaining tail.

## Remaining after this (separate work)
- **Silo** (sonic) — leaf-index/proof drift + a second missing address
- **Odos** (sonic/base) — real swap reverts (likely stale quote calldata)
- **LayerZero referral** — the deployed teller has no cross-chain destinations configured; needs in-test bridge setup or a skip
- **HyperEVM**, **plume** — RPC/infra (non-archive endpoint / dead host), not code

🤖 Generated with [Claude Code](https://claude.com/claude-code)