### PR TITLE
test: fix Odos integration suite (executor rotation + block drift)

### DIFF
--- a/test/integrations/OdosIntegration.t.sol
+++ b/test/integrations/OdosIntegration.t.sol
@@ -51,6 +51,11 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
 
         rawDataDecoderAndSanitizer = address(new FullOdosDecoderAndSanitizer(getAddress(sourceChain, "odosRouterV2")));
 
+        // The hardcoded swap calldata below was generated against the Odos executor that was live at this
+        // block (0xd768d1...). The registry "odosExecutor" has since been rotated to a newer executor that
+        // has no code at this pinned block, so override it back to the historical one for this fork.
+        setAddress(true, sourceChain, "odosExecutor", 0xd768d1Fe6Ef1449A54F9409400fe9d0E4954ea3F);
+
         setAddress(false, sourceChain, "boringVault", address(boringVault));
         setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
         setAddress(false, sourceChain, "manager", address(manager));
@@ -180,7 +185,9 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
         setSourceChainName("sonicMainnet");
         // Setup forked environment.
         string memory rpcKey = "SONIC_MAINNET_RPC_URL";
-        uint256 blockNumber = 16413113; 
+        // Block must match the block the hardcoded Odos calldata below was generated for; otherwise the
+        // swap routes through stale pool state and reverts (e.g. GYR#357 in a Gyroscope pool).
+        uint256 blockNumber = 11169032;
 
         _startFork(rpcKey, blockNumber);
 
@@ -190,6 +197,10 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
             new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
 
         rawDataDecoderAndSanitizer = address(new FullOdosDecoderAndSanitizer(getAddress(sourceChain, "odosRouterV2")));
+
+        // Pin "odosExecutor" to the executor that was live at this block (the registry has since rotated it
+        // to a newer executor that has no code here). Matches the executor embedded in the calldata below.
+        setAddress(true, sourceChain, "odosExecutor", 0xB28Ca7e465C452cE4252598e0Bc96Aeba553CF82);
 
         setAddress(false, sourceChain, "boringVault", address(boringVault));
         setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
@@ -250,7 +261,7 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
         setSourceChainName("sonicMainnet");
         // Setup forked environment.
         string memory rpcKey = "SONIC_MAINNET_RPC_URL";
-        uint256 blockNumber = 16175047; 
+        uint256 blockNumber = 16175047;
 
         _startFork(rpcKey, blockNumber);
 
@@ -260,6 +271,10 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
             new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
 
         rawDataDecoderAndSanitizer = address(new FullOdosDecoderAndSanitizer(getAddress(sourceChain, "odosRouterV2")));
+
+        // Pin "odosExecutor" to the executor that was live at this block (the registry has since rotated it
+        // to a newer executor that has no code here). Matches the executor embedded in the calldata below.
+        setAddress(true, sourceChain, "odosExecutor", 0xECDfcB1dD81d07c3551CbA94023EE443450353E1);
 
         setAddress(false, sourceChain, "boringVault", address(boringVault));
         setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);
@@ -320,7 +335,9 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
         setSourceChainName("base");
         // Setup forked environment.
         string memory rpcKey = "BASE_RPC_URL";
-        uint256 blockNumber = 28158816; 
+        // Block must match the block the hardcoded Odos calldata below was generated for; otherwise the
+        // swap routes through stale pool state and reverts (e.g. Uniswap V4 CurrencyNotSettled()).
+        uint256 blockNumber = 27469585;
 
         _startFork(rpcKey, blockNumber);
 
@@ -330,6 +347,10 @@ contract OdosIntegrationTest is Test, MerkleTreeHelper {
             new ManagerWithMerkleVerification(address(this), address(boringVault), getAddress(sourceChain, "vault"));
 
         rawDataDecoderAndSanitizer = address(new FullOdosDecoderAndSanitizer(getAddress(sourceChain, "odosRouterV2")));
+
+        // Pin "odosExecutor" to the executor that was live at this block (the registry has since rotated it
+        // to a newer executor that has no code here). Matches the executor embedded in the calldata below.
+        setAddress(true, sourceChain, "odosExecutor", 0x52bB904473E0aDC699c7B103962D35a0F53D9E1e);
 
         setAddress(false, sourceChain, "boringVault", address(boringVault));
         setAddress(false, sourceChain, "rawDataDecoderAndSanitizer", rawDataDecoderAndSanitizer);


### PR DESCRIPTION
## Summary

Fixes the 5 `OdosIntegrationTest` fork-integration tests, which had been failing
since the fork suite started running in CI again. The root cause was **not** stale
swap quotes — the tests had drifted out of sync with their block-pinned, hardcoded
Odos API calldata in two ways:

### 1. Executor rotation (all 5 tests)
The Odos router calls into the Odos *executor* to perform the swap, and the leaf
builder reads that executor address from the `odosExecutor` registry entry. That
entry has since been rotated to a newer executor that has **no code at the pinned
blocks**, so every swap reverted with `call to non-contract address`.

Fix: per-fork override `odosExecutor` back to the executor that was live at each
block — the same address that is already embedded in that test's hardcoded swap
calldata:

| Fork | Executor |
|------|----------|
| mainnet | `0xd768d1Fe6Ef1449A54F9409400fe9d0E4954ea3F` |
| sonic | `0xB28Ca7e465C452cE4252598e0Bc96Aeba553CF82` |
| sonic2 | `0xECDfcB1dD81d07c3551CbA94023EE443450353E1` |
| base | `0x52bB904473E0aDC699c7B103962D35a0F53D9E1e` |

### 2. Block drift (Sonic + Base)
Those two forks were additionally pinned to blocks *later* than the ones their
calldata was generated for, so the same path routed through stale pool state and
reverted inside third-party pools (`GYR#357` in a Gyroscope pool / Uniswap V4
`CurrencyNotSettled()`). Re-pinned to the calldata's blocks, matching the
already-passing `OdosOwnedIntegration` equivalents:

- sonic: `16413113` → `11169032`
- base: `28158816` → `27469585`

## Testing
All changes are test-only.

- `OdosIntegrationTest`: **5/5 pass**
- `OdosOwnedIntegration`: untouched, still **6/6 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
