### PR TITLE
test: fix remaining fork-integration tests (live-chain + LayerZero referral)

### DIFF
--- a/test/EtherFiLiquid1Migration.t.sol
+++ b/test/EtherFiLiquid1Migration.t.sol
@@ -389,7 +389,7 @@ contract EtherFiLiquid1MigrationTest is Test, MerkleTreeHelper {
         teller.removeAsset(ERC20(pendleEethYtDecember));
 
         rolesAuthority.setPublicCapability(
-            address(teller), bytes4(keccak256("deposit(address,uint256,uint256,address)")), true
+            address(teller), bytes4(keccak256("deposit(address,uint256,uint256)")), true
         );
         rolesAuthority.setPublicCapability(
             address(teller), TellerWithMultiAssetSupport.depositWithPermit.selector, true

--- a/test/integrations/AvalancheBridgeIntegration.t.sol
+++ b/test/integrations/AvalancheBridgeIntegration.t.sol
@@ -146,51 +146,18 @@ contract AvalancheBridgeIntegration is BaseTestIntegration {
         deal(getAddress(sourceChain, "USDC"), address(boringVault), 1_000e6); 
        
         ManageLeaf[] memory leafs = new ManageLeaf[](4);
-        ERC20[] memory assets = new ERC20[](1); 
-        assets[0] = getERC20(sourceChain, "WETH"); 
+        ERC20[] memory assets = new ERC20[](1);
+        assets[0] = getERC20(sourceChain, "WETH");
 
-        vm.expectRevert(); 
-        _addAvalancheBridgeLeafs(leafs, assets);  
+        // Bridging non-USDC assets from Avalanche is unsupported, so the leaf
+        // builder reverts. Route it through an external call so vm.expectRevert
+        // observes the revert at a lower call depth (a bare internal revert at
+        // the cheatcode's own depth is rejected by newer Foundry).
+        vm.expectRevert();
+        this.addAvalancheBridgeLeafsExternal(leafs, assets);
+    }
 
-        bytes32[][] memory manageTree = _generateMerkleTree(leafs);
-
-        _generateTestLeafs(leafs, manageTree);
-
-        manager.setManageRoot(address(this), manageTree[manageTree.length - 1][0]);
-
-        Tx memory tx_ = _getTxArrays(3); 
-
-        tx_.manageLeafs[0] = leafs[0]; //approve USDC
-        tx_.manageLeafs[1] = leafs[1]; //call transferTokens
-        tx_.manageLeafs[2] = leafs[2]; //transfer WETH
-        
-        bytes32[][] memory manageProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);
-
-        //targets
-        tx_.targets[0] = getAddress(sourceChain, "USDC"); //approve 
-        tx_.targets[1] = getAddress(sourceChain, "usdcTokenRouter"); //transferTokens
-        tx_.targets[2] = getAddress(sourceChain, "WETH"); //transfer
-
-        tx_.targetData[0] = abi.encodeWithSignature(
-            "approve(address,uint256)", getAddress(sourceChain, "usdcTokenRouter"), type(uint256).max
-        ); 
-        tx_.targetData[1] = abi.encodeWithSignature(
-            "transferTokens(uint256,uint32,address,address)", 
-            100e6,
-            0, //0 to send to ethereum
-            address(boringVault),
-            getAddress(sourceChain, "USDC")
-        );
-        tx_.targetData[2] = abi.encodeWithSignature(
-            "unwrap(uint256,uint256)", 
-            1e18,
-            0
-        );
-
-        tx_.decodersAndSanitizers[0] = rawDataDecoderAndSanitizer;
-        tx_.decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
-        tx_.decodersAndSanitizers[2] = rawDataDecoderAndSanitizer;
-        
-        _submitManagerCall(manageProofs, tx_); 
+    function addAvalancheBridgeLeafsExternal(ManageLeaf[] memory leafs, ERC20[] memory assets) external {
+        _addAvalancheBridgeLeafs(leafs, assets);
     }
 }

--- a/test/integrations/DeriveIntegration.t.sol
+++ b/test/integrations/DeriveIntegration.t.sol
@@ -249,7 +249,7 @@ contract DeriveIntegrationTest is BaseTestIntegration {
         tx_ = _getTxArrays(1); 
         
         //manage leafs
-        tx_.manageLeafs[0] = leafs[2]; //redeem stDRV
+        tx_.manageLeafs[0] = leafs[3]; //redeem stDRV
 
         //generate proofs
         manageProofs = _getProofsUsingTree(tx_.manageLeafs, manageTree);

--- a/test/integrations/FluidDexIntegration.t.sol
+++ b/test/integrations/FluidDexIntegration.t.sol
@@ -278,8 +278,8 @@ contract FluidDexIntegrationTest is Test, MerkleTreeHelper {
         //setup boring vault tx data
 
         //this is what will be minted after we deposit
-        uint256 nftId = 2795;
-        uint256 nftPerfectId = 2796;
+        uint256 nftId = 8574;
+        uint256 nftPerfectId = 8575;
 
         //deal some dust to payback borrow
         //deal(getAddress(sourceChain, "USDC"), address(boringVault), 10e18); //I know USDC and USDT don't have 18decimals
@@ -442,8 +442,8 @@ contract FluidDexIntegrationTest is Test, MerkleTreeHelper {
         //setup boring vault tx data
 
         //this is what will be minted after we deposit
-        //uint256 nftId = 2795;
-        //uint256 nftPerfectId = 2796;
+        //uint256 nftId = 8574;
+        //uint256 nftPerfectId = 8575;
 
         //deal some dust to payback borrow
         //deal(getAddress(sourceChain, "USDC"), address(boringVault), 10e18); //I know USDC and USDT don't have 18decimals

--- a/test/integrations/TellerWithReferral.t.sol
+++ b/test/integrations/TellerWithReferral.t.sol
@@ -138,7 +138,14 @@ contract BoringVaultIntegrationTest is Test, MerkleTreeHelper {
         RolesAuthority(address(0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF)).setPublicCapability(address(GoldenGooseTeller), bytes4(keccak256(abi.encodePacked("withdraw(address,uint256,uint256,address)"))), true);
         GoldenGooseTeller.setShareLockPeriod(0);
         RolesAuthority(address(0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF)).setPublicCapability(address(GoldenGooseTeller), bytes4(keccak256(abi.encodePacked("depositAndBridge(address,uint256,uint256,address,bytes,address,uint256,address)"))), true);
+        // The deployed GoldenGoose teller has no bridge destinations configured at this block, so any
+        // depositAndBridge reverts with LayerZeroTeller__MessagesNotAllowedTo. Configure Linea in-test
+        // (sets idToChains + the LayerZero peer) so the deposit-and-bridge-with-referral path can run.
+        // Mirrors the setup in test/LayerZeroTellerNoMock.t.sol.
+        RolesAuthority(address(0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF)).setPublicCapability(address(GoldenGooseTeller), GoldenGooseTeller.addChain.selector, true);
         vm.stopPrank();
+
+        GoldenGooseTeller.addChain(layerZeroLineaEndpointId, true, true, address(GoldenGooseTeller), 200_000);
     }
 
     function testBoringVaultDepositAndWithdraw() external {
@@ -218,6 +225,13 @@ contract BoringVaultIntegrationTest is Test, MerkleTreeHelper {
         targets[0] = getAddress(sourceChain, "WETH"); //approve WETH to be spent by GoldenGooseTeller
         targets[1] = address(GoldenGooseTeller);
 
+        // Quote the LayerZero fee for this destination and fund the vault with the native ETH it needs to
+        // pay it (forwarded as msg.value on the depositAndBridge manage call below).
+        uint256 fee = GoldenGooseTeller.previewFee(
+            uint96(assets), getAddress(sourceChain, "boringVault"), abi.encode(layerZeroLineaEndpointId), ERC20(getAddress(sourceChain, "ETH"))
+        );
+        deal(getAddress(sourceChain, "boringVault"), fee);
+
         DepositAndBridgeParams memory params = DepositAndBridgeParams({
             depositAsset: getAddress(sourceChain, "WETH"),
             depositAmount: assets,
@@ -225,7 +239,7 @@ contract BoringVaultIntegrationTest is Test, MerkleTreeHelper {
             to: getAddress(sourceChain, "boringVault"),
             bridgeWildCard: abi.encode(layerZeroLineaEndpointId),
             feeToken: getAddress(sourceChain, "ETH"),
-            maxFee: 1e18,
+            maxFee: fee,
             referrer: referrer
         });
 
@@ -248,7 +262,7 @@ contract BoringVaultIntegrationTest is Test, MerkleTreeHelper {
         decodersAndSanitizers[1] = rawDataDecoderAndSanitizer;
 
         uint256[] memory values = new uint256[](2);
-        values[1] = 30819757242215;
+        values[1] = fee;
 
         manager.manageVaultWithMerkleVerification(manageProofs, decodersAndSanitizers, targets, targetData, values);
 


### PR DESCRIPTION
## Summary

Final batch of fixes to get the `test.yml` fork-integration suite green. This PR
is stacked on `test/live-chain-fixes` (#735) so it carries **both** sets of fixes;
merging it lands everything and turns `main` fully green. #735 then becomes
redundant and can be closed.

### LayerZero referral (this PR's own fix)
`testBoringVaultDepositAndBridgeWithReferral` bridged to Linea via the live
GoldenGoose `LayerZeroTeller`, which has **no bridge destinations configured** at
the pinned block, so `depositAndBridge` reverted with
`LayerZeroTeller__MessagesNotAllowedTo(30183)` before LayerZero was touched.
Fixed by configuring Linea in-test (mirrors `test/LayerZeroTellerNoMock.t.sol`):
`addChain(...)` via the teller's `RolesAuthority` (sets `idToChains` + the LZ
peer), and deriving the fee from `previewFee(...)` + dealing the vault the native
ETH it forwards, instead of a stale hardcoded value.

### Live-chain fixes (from #735)
- **Derive**: corrected `finalizeRedeem` leaf index in the claim proof.
- **FluidDex**: updated hardcoded position `nftId`s for the pinned block.
- **AvalancheBridge**: fixed the WETH negative test for newer Foundry revert semantics.
- **EtherFiLiquid1Migration**: granted the deposit selector the migration test actually calls.

## Testing
All test-only. Verified in CI on the rebased branches that the full suite runs
end to end (848 tests / 144 suites); with both batches present the only
remaining non-pass is the one intentional `testSiloRewardsClaiming` skip.
HyperEVM (Kinetiq/Valantis) and plume (NestBasis) pass — confirming the
`HYPER_EVM_RPC_URL` / `PLUME_RPC_URL` secret repoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
