### PR TITLE
ci: pin Certora action to security-reviewed commit (eval removal + solc checksums)

### DIFF
--- a/.github/workflows/certoraA.yml
+++ b/.github/workflows/certoraA.yml
@@ -35,7 +35,7 @@ jobs:
         run: certora/scripts/setup.sh A
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@1b56663420688a98038ba93168f67c43210f99c5 # pinned to commit (post-v2.9.0) per security review: PR#95 safe arg parsing (no eval), PR#91 solc SHA-256
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraB.yml
+++ b/.github/workflows/certoraB.yml
@@ -34,7 +34,7 @@ jobs:
         run: certora/scripts/setup.sh B
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@1b56663420688a98038ba93168f67c43210f99c5 # pinned to commit (post-v2.9.0) per security review: PR#95 safe arg parsing (no eval), PR#91 solc SHA-256
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraC.yml
+++ b/.github/workflows/certoraC.yml
@@ -43,7 +43,7 @@ jobs:
         run: certora/scripts/setup.sh C
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@1b56663420688a98038ba93168f67c43210f99c5 # pinned to commit (post-v2.9.0) per security review: PR#95 safe arg parsing (no eval), PR#91 solc SHA-256
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraD.yml
+++ b/.github/workflows/certoraD.yml
@@ -34,7 +34,7 @@ jobs:
         run: certora/scripts/setup.sh D
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@1b56663420688a98038ba93168f67c43210f99c5 # pinned to commit (post-v2.9.0) per security review: PR#95 safe arg parsing (no eval), PR#91 solc SHA-256
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraE.yml
+++ b/.github/workflows/certoraE.yml
@@ -34,7 +34,7 @@ jobs:
         run: certora/scripts/setup.sh E
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@1b56663420688a98038ba93168f67c43210f99c5 # pinned to commit (post-v2.9.0) per security review: PR#95 safe arg parsing (no eval), PR#91 solc SHA-256
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21


### PR DESCRIPTION
## Summary

Pins `Certora/certora-run-action` in all five `Certora_FV_*` workflows from the
mutable `@v2` tag to a specific, security-reviewed commit
(`1b56663420688a98038ba93168f67c43210f99c5`). This satisfies the security
requests Matt raised in the FV-CI thread before installing the Certora GitHub App.

| Request | Status |
|---|---|
| **#1** Replace unsafe `eval "conf_parts=($conf_line)"` in `run-certora.sh` with safe argument parsing | ✅ This commit ("Replace eval arg parsing", PR #95) removes the `eval` and parses with quote-honoring `xargs … printf '%s\0'` + NUL-delimited `mapfile` |
| **#6** Verify integrity of downloaded solc binaries | ✅ Includes "Verify SHA-256 of downloaded solc binaries" (PR #91) — checks each binary against `binaries.soliditylang.org/.../list.json` and aborts on mismatch |
| **#2** Pin third-party Actions to full commit SHAs | ✅ All 5 workflows now pin the full SHA instead of `@v2` |

## Notes
- The `eval` fix is merged to the action's default branch but **not yet in a tagged release** (latest tag is v2.9.0). Pinning to the commit SHA is what #2 asks for and gets the fix now; re-pin to a release tag once Certora cuts one (e.g. v2.10.0).
- This change does **not** by itself turn the Certora jobs green — they currently fail with `403: Failed to get GitHub installation` because the **Certora GitHub App is not installed** on the org. That remains a separate admin step, now unblocked since Matt's requests (#1/#2/#6) are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
