### PR TITLE
certora: fix teller deposit rule + make nightly-certora fail on real violations

### DIFF
--- a/.github/workflows/nightly-certora.yml
+++ b/.github/workflows/nightly-certora.yml
@@ -9,15 +9,18 @@ on:
 env:
   FOUNDRY_PROFILE: ci
 
+# We invoke certoraRun directly (not the certora-run-action) so the job's
+# exit status reflects the actual verification verdict: the action submits with
+# `--wait_for_results none` (async) and always exits 0 on successful submission,
+# so a violated rule left the job green. `--wait_for_results all` blocks and
+# returns non-zero on a real property violation, which fails the job and fires
+# the Slack alert below. Only needs CERTORAKEY (no GitHub App / PR scopes).
 jobs:
   fv:
     name: Verified Rules (${{ matrix.scenario }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      statuses: write
-      pull-requests: write
-      id-token: write
     strategy:
       # Run every scenario even if one fails (these were 5 separate workflows).
       fail-fast: false
@@ -74,19 +77,46 @@ jobs:
           corepack enable
           yarn install
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Certora CLI + solc 0.8.21
+        run: |
+          uv tool install --python 3.12 "certora-cli==8.16.1"
+          uv tool install solc-select
+          solc-select install 0.8.21
+          # The confs pin `solc8.21`; expose the 0.8.21 binary under that name.
+          ln -sf "$(find "$HOME/.solc-select/artifacts" -name 'solc-0.8.21' -type f | head -1)" "$HOME/.local/bin/solc8.21"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Certora munge
         run: certora/scripts/setup.sh ${{ matrix.scenario }}
 
-      - name: run configs
-        uses: Certora/certora-run-action@1b56663420688a98038ba93168f67c43210f99c5 # pinned to commit (post-v2.9.0) per security review: PR#95 safe arg parsing (no eval), PR#91 solc SHA-256
-        with:
-          configurations: ${{ matrix.configs }}
-          solc-versions: 0.8.21
-          solc-remove-version-prefix: "0."
-          job-name: "Verified Rules"
-          certora-key: ${{ secrets.CERTORAKEY }}
+      - name: Run Certora verification
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CERTORAKEY: ${{ secrets.CERTORAKEY }}
+        run: |
+          set -uo pipefail
+          fail=0
+          while IFS= read -r line; do
+            # skip blank lines
+            [ -z "${line//[[:space:]]/}" ] && continue
+            # Parse the config line into args honoring quotes (no eval).
+            mapfile -t -d '' parts < <(printf '%s' "$line" | xargs printf '%s\0')
+            echo "::group::certoraRun ${parts[*]}"
+            if ! certoraRun "${parts[@]}" --wait_for_results all; then
+              echo "::error::Certora verification failed for: $line"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done <<< '${{ matrix.configs }}'
+          exit "$fail"
 
       # Scheduled runs notify no one by default, so ping Slack on failure.
       # Requires the SLACK_WEBHOOK_URL repo secret (a Slack incoming webhook).

--- a/.github/workflows/nightly-certora.yml
+++ b/.github/workflows/nightly-certora.yml
@@ -78,13 +78,13 @@ jobs:
           yarn install
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Install Certora CLI + solc 0.8.21
         run: |
@@ -101,6 +101,9 @@ jobs:
       - name: Run Certora verification
         env:
           CERTORAKEY: ${{ secrets.CERTORAKEY }}
+          # Pass the config block through the environment (not inline ${{ }}
+          # interpolation) so config contents can't break shell quoting or inject.
+          CONFIGS: ${{ matrix.configs }}
         run: |
           set -uo pipefail
           fail=0
@@ -115,7 +118,7 @@ jobs:
               fail=1
             fi
             echo "::endgroup::"
-          done <<< '${{ matrix.configs }}'
+          done <<< "$CONFIGS"
           exit "$fail"
 
       # Scheduled runs notify no one by default, so ping Slack on failure.

--- a/certora/specs/teller_accounting_easyRules.spec
+++ b/certora/specs/teller_accounting_easyRules.spec
@@ -129,7 +129,8 @@ rule onlyContributionMethodsReduceAssets(env e, method f)
     uint256 userAssetsAfter = userAssets(e, asset, user);
 
     assert userAssetsBefore > userAssetsAfter =>
-        (f.selector == sig:deposit(address, uint256, uint256,address).selector 
+        (f.selector == sig:deposit(address, uint256, uint256,address).selector
+        || f.selector == sig:deposit(address,uint256,uint256,address,address).selector
         || f.selector == sig:depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
         || f.selector == sig:bulkDeposit(address,uint256,uint256,address).selector
         || f.selector == 4172789357 // sig:depositAndBridge(..).selector


### PR DESCRIPTION
## Summary

Two changes toward accurate Certora formal-verification in CI.

### 1. Spec fix — `onlyContributionMethodsReduceAssets`
The rule (in `teller_accounting_easyRules.spec`) asserts a user's assets may only
decrease via a contribution method, and allowlists deposit selectors. It listed
the 4-arg `deposit(address,uint256,uint256,address)` but **not** the 5-arg
`deposit(address,uint256,uint256,address,address)` (`to` + `referralAddress`,
calls `_publicDeposit`) that `TellerWithMultiAssetSupport` also exposes — so that
overload was flagged as an illegitimate asset reduction. Added the 5-arg selector.

Verified on the prover: the rule (and its `rule_sanity` vacuity checks) now pass
on **B (TellerWithBuffer), D (LayerZeroTeller), E (LayerZeroTellerWithRateLimiting)** —
all three shared this exact violation. `certoraRun` exits 0 for each.

### 2. `nightly-certora` now fails on real violations (option D)
The `certora-run-action` submits with `--wait_for_results none`, so the job
always exited 0 on successful submission — a violated rule left the nightly
**green**, and the Slack step (gated on `if: failure()`) never fired. That's why
the last nightly reported "success" despite violations.

This replaces the action with a direct `certoraRun --wait_for_results all` per
config, so the job's exit status reflects the actual verdict and the Slack alert
fires correctly. Details:
- Config lines parsed with `xargs` (quote-honoring, **no `eval`**).
- Toolchain (Temurin 21, `certora-cli==8.16.1` via `uv`, solc 0.8.21 as
  `solc8.21`) mirrors the validated local setup.
- Only `CERTORAKEY` is needed — no GitHub App / PR scopes, so permissions are
  reduced to `contents: read`.

## ⚠️ Intentionally left red for validation
Scenarios **A** and **C** still have real violations (accountant rules) plus
some timeouts/errors, so after merge the nightly will **fail** and Slack will
post a genuine failure alert — which is the point (validates the corrected
signal). Follow-up PRs will fix A and C to reach fully green.

Notes:
- A run can take up to ~2h wall-clock on the slowest scenario (rules that hit
  `smt_timeout` block until then); within the 6h job cap.
- `--rule_sanity` vacuity/triviality noise does not flip the exit code (B/D/E
  exit 0), so no sanity tuning is needed here.

## To see the alert immediately after merge
`workflow_dispatch` the `nightly-certora` workflow (Actions tab) rather than
waiting for 23:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
