### PR TITLE
ci: Certora spec fix + pin per-PR workflows to v2.10.0 (dev)

### DIFF
--- a/.github/workflows/certoraA.yml
+++ b/.github/workflows/certoraA.yml
@@ -35,7 +35,7 @@ jobs:
         run: certora/scripts/setup.sh A
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@b37dc99cef13413f8996b2a137b95e8a25749285 # v2.10.0 (eval fix PR#95 + solc SHA-256 PR#91)
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraB.yml
+++ b/.github/workflows/certoraB.yml
@@ -34,7 +34,7 @@ jobs:
         run: certora/scripts/setup.sh B
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@b37dc99cef13413f8996b2a137b95e8a25749285 # v2.10.0 (eval fix PR#95 + solc SHA-256 PR#91)
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraC.yml
+++ b/.github/workflows/certoraC.yml
@@ -43,7 +43,7 @@ jobs:
         run: certora/scripts/setup.sh C
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@b37dc99cef13413f8996b2a137b95e8a25749285 # v2.10.0 (eval fix PR#95 + solc SHA-256 PR#91)
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraD.yml
+++ b/.github/workflows/certoraD.yml
@@ -34,7 +34,7 @@ jobs:
         run: certora/scripts/setup.sh D
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@b37dc99cef13413f8996b2a137b95e8a25749285 # v2.10.0 (eval fix PR#95 + solc SHA-256 PR#91)
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/.github/workflows/certoraE.yml
+++ b/.github/workflows/certoraE.yml
@@ -34,7 +34,7 @@ jobs:
         run: certora/scripts/setup.sh E
 
       - name: run configs
-        uses: Certora/certora-run-action@v2
+        uses: Certora/certora-run-action@b37dc99cef13413f8996b2a137b95e8a25749285 # v2.10.0 (eval fix PR#95 + solc SHA-256 PR#91)
         with:
           configurations: ${{ env.CONFIGS }}
           solc-versions: 0.8.21

--- a/certora/specs/teller_accounting_easyRules.spec
+++ b/certora/specs/teller_accounting_easyRules.spec
@@ -129,7 +129,8 @@ rule onlyContributionMethodsReduceAssets(env e, method f)
     uint256 userAssetsAfter = userAssets(e, asset, user);
 
     assert userAssetsBefore > userAssetsAfter =>
-        (f.selector == sig:deposit(address, uint256, uint256,address).selector 
+        (f.selector == sig:deposit(address, uint256, uint256,address).selector
+        || f.selector == sig:deposit(address,uint256,uint256,address,address).selector
         || f.selector == sig:depositWithPermit(address,uint256,uint256,uint256,uint8,bytes32,bytes32,address).selector
         || f.selector == sig:bulkDeposit(address,uint256,uint256,address).selector
         || f.selector == 4172789357 // sig:depositAndBridge(..).selector


### PR DESCRIPTION
## Summary

Per-project split of the CI-green work onto `dev/oct-2025` — the **Certora** slice.
Kept intentionally small: the actual green-fix plus a version/security bump to the
existing per-PR workflows.

- **Teller spec fix**: allow the 5-arg `deposit(...,address,address)` in
  `onlyContributionMethodsReduceAssets` — clears that violation across scenarios
  B/D/E and the C variant.
- **Pin the action to v2.10.0**: `certoraA–E` bumped from the mutable `@v2` tag to
  the `certora-run-action` **v2.10.0** release SHA — the first release carrying the
  eval-parsing fix (PR #95) on top of solc SHA-256 verification (PR #91). This
  satisfies Matt's review requests (#1 eval, #2 SHA-pin, #6 solc integrity) while
  keeping the per-PR workflows unchanged in shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
