### PR TITLE
deployments: metadata/verification backfill + deploy-time metadata tooling (dev)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test/limitOrders/*
 .properties-*/
 emv-*-certora-*/
 
+test/fixtures/

--- a/deployments/addresses/Arbitrum/Deployers.json
+++ b/deployments/addresses/Arbitrum/Deployers.json
@@ -1,0 +1,31 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-arbitrum": "0x87D51666Da1b56332b216D456D1C2ba3Aed6089c",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-arbitrum": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Arbitrum/GoldenGoose.json
+++ b/deployments/addresses/Arbitrum/GoldenGoose.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2c017870dea4ba9f33d377ab431b506969e35f76",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2c017870dea4ba9f33d377ab431b506969e35f76",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "e13b98a3f19a6d0cf7614235b5b50f72b83778bd",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2c017870dea4ba9f33d377ab431b506969e35f76",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2c017870dea4ba9f33d377ab431b506969e35f76",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2c017870dea4ba9f33d377ab431b506969e35f76",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2c017870dea4ba9f33d377ab431b506969e35f76",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Arbitrum/Tellers.json
+++ b/deployments/addresses/Arbitrum/Tellers.json
@@ -1,0 +1,10 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "verificationGap": ["etherscan; working-tree multi-commit"]
+    }
+  }
+}

--- a/deployments/addresses/Arbitrum/eBTC.json
+++ b/deployments/addresses/Arbitrum/eBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x6889E57BcA038C28520C0B047a75e567502ea5F6",
     "TellerWithMultiAssetSupport": "0xe19a43B1b8af6CeE71749Af2332627338B3242D1",
     "Timelock": "0x5BECC07fc7Eab131DD7683047EB37c257AA7482f"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Base/Deployers.json
+++ b/deployments/addresses/Base/Deployers.json
@@ -1,0 +1,39 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706",
+    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-base-bsc": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-base-optimism": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Base/GoldenGoose.json
+++ b/deployments/addresses/Base/GoldenGoose.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Base/LBTCvBaseAddresses.json
+++ b/deployments/addresses/Base/LBTCvBaseAddresses.json
@@ -38,5 +38,63 @@
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
     "ShareLockPeriod": 86400
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "bcac7f408b96a0054e3edf82155f78d76ad652ec",
+      "auditGap": ["state", "selectors"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "bcac7f408b96a0054e3edf82155f78d76ad652ec",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "69fa3837f651ed236b35400b69498b50e48e99e9",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/Accountants.json
+++ b/deployments/addresses/BeraChain/Accountants.json
@@ -1,0 +1,14 @@
+{
+  "contractAddresses": {
+    "AccountantWithFixedRate_7b6890c8": "0x88ea516dcb9f79cafa9d0d19909a4dbd7b6890c8",
+    "AccountantWithFixedRate_ef6258d4": "0x55ee6e1adf848a2fc831b07564223396ef6258d4"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate_7b6890c8": {
+      "verificationGap": ["source:no-match"]
+    },
+    "AccountantWithFixedRate_ef6258d4": {
+      "verificationGap": ["source:no-match"]
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/Deployers.json
+++ b/deployments/addresses/BeraChain/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/LiquidBTC.json
+++ b/deployments/addresses/BeraChain/LiquidBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x49F954c67ff235034b69b8a59fbe309A40256c8d",
     "TellerWithLayerZero": "0x9E88C603307fdC33aA5F26E38b6f6aeF3eE92d48",
     "Timelock": "0xD6C60dC4d9Ac983cC1B82F5FA86AE30ABDf35524"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:paris"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "729346a6efed5b70fe1ea2b05e7534e5e9024d12",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/LiquidBeraBTC.json
+++ b/deployments/addresses/BeraChain/LiquidBeraBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x829675330fdcEE01022983493e71F73fb53eaB45",
     "LayerZeroTellerWithRateLimiting": "0xe238e253b67f42ee3aF194BaF7Aba5E2eaddA1B8",
     "Timelock": "0x0F2c66475EC9cef9C6B369CD8ecb04aAf4Db3329"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "LayerZeroTellerWithRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "auditGap": ["unaudited"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/LiquidBeraETH.json
+++ b/deployments/addresses/BeraChain/LiquidBeraETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x5979F753b417c17FCd8f8c87b86154A0EB0E2c17",
     "LayerZeroTellerWithRateLimiting": "0xd445C65e4821dbD4ed0114eCDF6325c69faD7653",
     "Timelock": "0x946F01f13eCafdbbd4CC2BDEd41703b3365b9D17"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "LayerZeroTellerWithRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "auditGap": ["unaudited"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/LiquidETH.json
+++ b/deployments/addresses/BeraChain/LiquidETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x485Bde66Bb668a51f2372E34e45B1c6226798122",
     "TellerWithLayerZero": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x8ffaf6aF36d3A58Fc0E19dD96f592fC1d22310Be"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/LiquidUSD.json
+++ b/deployments/addresses/BeraChain/LiquidUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xaBA6bA1E95E0926a6A6b917FE4E2f19ceaE4FF2e",
     "TellerWithLayerZero": "0x4DE413a26fC24c3FC27Cc983be70aA9c5C299387",
     "Timelock": "0x48b4158b0100B4e69D4a448db6BBe74DE94ee177"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:paris"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/PrimeLiquidBeraBTC.json
+++ b/deployments/addresses/BeraChain/PrimeLiquidBeraBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x1C54f57Fc3879C558915BCEa996DB1dA422fC8BE",
     "TellerWithMultiAssetSupport": "0xf16Cd75E975163f3A0A1af42E5609aB67A6553D7",
     "Timelock": "0xC5Fb304613904dD62621C4c1A59E74406513da56"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/PrimeLiquidBeraETH.json
+++ b/deployments/addresses/BeraChain/PrimeLiquidBeraETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x0eDEBE41b1Ca274DDC4b353363E07FdC8DAc4A05",
     "TellerWithMultiAssetSupport": "0xa6976B2211411461aB6DF4B3AAE896531Eb527df",
     "Timelock": "0x9CDd57C8278C98903f89509FD5280e7bb7D69f8f"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/Tellers.json
+++ b/deployments/addresses/BeraChain/Tellers.json
@@ -1,0 +1,25 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_3c730353": "0x8ea0b382d054dbebeb1d0ae47ee4ac433c730353",
+    "LayerZeroTeller_6dde8d9c": "0xcd20c63ddafac686d311b40f24dcad316dde8d9c",
+    "LayerZeroTeller_ff44750b": "0xb745b293468df7b06330472fbcee5412ff44750b",
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_3c730353": {
+      "verificationGap": ["etherscan; working-tree multi-commit"]
+    },
+    "LayerZeroTeller_6dde8d9c": {
+      "deploymentCommit": "c48ee764",
+      "verificationGap": ["cbor"]
+    },
+    "LayerZeroTeller_ff44750b": {
+      "deploymentCommit": "c48ee764",
+      "verificationGap": ["cbor"]
+    },
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "deploymentCommit": "bf902717",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/BeraChain/eBTC.json
+++ b/deployments/addresses/BeraChain/eBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x6889E57BcA038C28520C0B047a75e567502ea5F6",
     "TellerWithMultiAssetSupport": "0xe19a43B1b8af6CeE71749Af2332627338B3242D1",
     "Timelock": "0x5BECC07fc7Eab131DD7683047EB37c257AA7482f"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BeraChain/weETHRateProvider.json
+++ b/deployments/addresses/BeraChain/weETHRateProvider.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xa2273625b50ca1D77FA6A6A74CDA2611b7b8b0b0",
     "TellerWithMultiAssetSupport": "0x471019775855e7e19C129D599eB7D15eedEB330B",
     "Timelock": "0x5d4Fb3AC69E3e6773556A839d947BB1d0a70EeC5"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/BinanceSmartChain/Deployers.json
+++ b/deployments/addresses/BinanceSmartChain/Deployers.json
@@ -1,0 +1,31 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-base-bsc": "0x633ccAFEF3F42F87a457c44ffF826a5b6fc99706",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-base-bsc": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/BinanceSmartChain/LombardBtcDeployment.json
+++ b/deployments/addresses/BinanceSmartChain/LombardBtcDeployment.json
@@ -34,6 +34,16 @@
     "PlatformFee": 150,
     "StartingExchangeRate": 100377152
   },
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0x28634D0c5edC67CF2450E74deA49B90a4FF93dCE",
+    "BoringVault": "0x5401b8620E5FB570064CA9114fd1e135fd77D57c",
+    "DecoderAndSanitizer": "0x402d89D6c763E8e79b77Ac1424f28cbA80ac9caa",
+    "DelayedWithdraw": "0xDa75512350c03d0F914eF040237E9ABF45913E5a",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0xcf38e37872748E3b66741A42560672A6cef75e9B",
+    "RolesAuthority": "0xF3E03eF7df97511a52f31ea7a22329619db2bdF4",
+    "TellerWithMultiAssetSupport": "0x2eA43384F1A98765257bc6Cb26c7131dEbdEB9B3"
+  },
   "core": {
     "AccountantWithRateProviders": "0x28634D0c5edC67CF2450E74deA49B90a4FF93dCE",
     "BoringVault": "0x5401b8620E5FB570064CA9114fd1e135fd77D57c",
@@ -48,5 +58,63 @@
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
     "ShareLockPeriod": 86400
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "cb1f8d1af77eed14b148a55a4f5b6fc476bfaf8b",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "cb1f8d1af77eed14b148a55a4f5b6fc476bfaf8b",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Bob/Deployers.json
+++ b/deployments/addresses/Bob/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-bob-mainnet": "0xF3d0672a91Fd56C9ef04C79ec67d60c34c6148a0"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-bob-mainnet": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    }
+  }
+}

--- a/deployments/addresses/Bob/HybridBTC.json
+++ b/deployments/addresses/Bob/HybridBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xE62e424DbAf17D702cceba939C9427018DBC19C1",
     "TellerWithLayerZero": "0x19ab8c9896728d3A2AE8677711bc852C706616d3",
     "Timelock": "0xDbE09a066f6D42935f702F700b7E0E5F56028Df2"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "cc839daffc0ec970796b8b024333bd7233eafda3",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "cc839daffc0ec970796b8b024333bd7233eafda3",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Bob/HybridBTC2.json
+++ b/deployments/addresses/Bob/HybridBTC2.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x30cc8270b8b2F758CAbf2693efFF5f608EFcd12b",
     "TellerWithLayerZero": "0xfB03E171d11A5baea4d7bfd5992262CE28404201",
     "Timelock": "0xF34BBA863021Db59AD7017A767432F9F048775EA"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditUrl": "file:audit/certora-boring-vault-1.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Corn/Tellers.json
+++ b/deployments/addresses/Corn/Tellers.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "deploymentCommit": "bf902717",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/Flare/Deployers.json
+++ b/deployments/addresses/Flare/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Fraxtal/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Fraxtal/BridgingTestVaultDeployment.json
@@ -26,7 +26,7 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1000000000000000000
   },
-  "core": {
+  "contractAddresses": {
     "AccountantWithRateProviders": "0xBA4397B2B1780097eD1B483E3C0717E0Ed4fAAa5",
     "BoringVault": "0xf8203A33027607D2C82dFd67b46986096257dFA5",
     "DecoderAndSanitizer": "0xD9023495256B23D7b4FA32A5Fd724140F179F51b",
@@ -40,5 +40,63 @@
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
     "ShareLockPeriod": 0
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["state", "selectors"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["state"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ae8e0b6573cca14c70e1e8edbef2209d62639eea",
+      "auditGap": ["state"]
+    }
   }
 }

--- a/deployments/addresses/Fraxtal/Deployers.json
+++ b/deployments/addresses/Fraxtal/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    }
+  }
+}

--- a/deployments/addresses/HypeEVM/Deployers.json
+++ b/deployments/addresses/HypeEVM/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/HypeEVM/kHYPE.json
+++ b/deployments/addresses/HypeEVM/kHYPE.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x345BB6a4249419e34a7C750B90178Fc7B2e4c50f",
     "TellerWithMultiAssetSupport": "0x29C0C36eD3788F1549b6a1fd78F40c51F0f73158",
     "Timelock": "0xf86604d4cbc10796522605298C4BD864fCF9d032"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditUrl": "file:audit/certora-boring-vault-1.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "c3dde9653a59ffbb52fd0d3493c5ceaa5850dab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-45",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Ink/Deployers.json
+++ b/deployments/addresses/Ink/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Ink/InkedBTC.json
+++ b/deployments/addresses/Ink/InkedBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xF60c540Bd5aC805F4453C84Ec941b68aC9bD7328",
     "TellerWithLayerZero": "0xa344c435478E7590E82619007Af2240921824Bae",
     "Timelock": "0x7EDE533c0B9257ae93908cdE5F98d1Cc51DD120E"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "deploymentCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "e3c4762ea5594dabbf0b7b506c8129fddf5d7de2",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Ink/InkedETH.json
+++ b/deployments/addresses/Ink/InkedETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x14c55D919a7587B730120528099f3B7464bC6006",
     "TellerWithLayerZero": "0xBC27FAf3F5437a42B19a78d37A7aDBc6FF0ED80c",
     "Timelock": "0x6BA782a457744360C8a74636932e5cfC37ffEDF1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "deploymentCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "e3c4762ea5594dabbf0b7b506c8129fddf5d7de2",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Ink/InkedUSDT.json
+++ b/deployments/addresses/Ink/InkedUSDT.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xecE2222D3ac4b21316b6E5F4208A452BB96A8Cb4",
     "TellerWithLayerZero": "0xeFEE4199F7eE3375c04D8B0851b109ED3Df82F74",
     "Timelock": "0x12DeD18937cecdDDa386532B5aA2d1561617Fa27"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "deploymentCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "e3c4762ea5594dabbf0b7b506c8129fddf5d7de2",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Ink/InkedUSDTHY.json
+++ b/deployments/addresses/Ink/InkedUSDTHY.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xBaDA45B8c83Dd662DBf2BfE6f4a7174734352592",
     "TellerWithLayerZero": "0x8E9F8A7E0643F198f2aCf413721b101Fe2B14f12",
     "Timelock": "0x4dEdfbF50d03586f2D5D1653Ea4a75Fe311592dE"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Ink/LiquidETH.json
+++ b/deployments/addresses/Ink/LiquidETH.json
@@ -13,5 +13,70 @@
     "RolesAuthority": "0x485Bde66Bb668a51f2372E34e45B1c6226798122",
     "TellerWithLayerZeroRateLimiting": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["selectors"]
+    }
   }
 }

--- a/deployments/addresses/Katana/Deployers.json
+++ b/deployments/addresses/Katana/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Katana/GoldenGoose.json
+++ b/deployments/addresses/Katana/GoldenGoose.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "173723dbd84ecd0eb5fe9a2f24c3924fc44f698d",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "173723dbd84ecd0eb5fe9a2f24c3924fc44f698d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "173723dbd84ecd0eb5fe9a2f24c3924fc44f698d",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Katana/LBTCvKatanaDeployment.json
+++ b/deployments/addresses/Katana/LBTCvKatanaDeployment.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x11BF7551eb78786Ca167Db04B12201004a743606",
     "TellerWithLayerZero": "0x38d4066cC4B42E2B6615aE15cAa6e347114779E2",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Katana/LiquidETH.json
+++ b/deployments/addresses/Katana/LiquidETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x485Bde66Bb668a51f2372E34e45B1c6226798122",
     "TellerWithLayerZero": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x8ffaf6aF36d3A58Fc0E19dD96f592fC1d22310Be"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7715fb3b0bc2b8ae922c3f23596e6844971a704a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7715fb3b0bc2b8ae922c3f23596e6844971a704a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7715fb3b0bc2b8ae922c3f23596e6844971a704a",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Katana/LiquidKatana.json
+++ b/deployments/addresses/Katana/LiquidKatana.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x1645E0cc24595faB37916a3d57bC51dFf0315Cf7",
     "TellerWithLayerZeroRateLimiting": "0x739A1efFaDDB0b07ef1284598819232df4FD8d16",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2477eb5707e166c2b8a1aae31c685c2c11dd0ed0",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["unaudited"]
+    }
   }
 }

--- a/deployments/addresses/Katana/VedaTestVault.json
+++ b/deployments/addresses/Katana/VedaTestVault.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x222222bbd7F2E56f1320fa8C9f83992da738b036",
     "TellerWithLayerZero": "0x7777776973bC0869e4d106F1F2Ec8b42228EC8e7",
     "Timelock": "0x333333807Ec1b14A5152c5bB7fC69EC8a817885D"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e145668b95f8bbf44cddc0a39257ef576b4ac7b",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e145668b95f8bbf44cddc0a39257ef576b4ac7b",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e145668b95f8bbf44cddc0a39257ef576b4ac7b",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Linea/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Linea/BridgingTestVaultDeployment.json
@@ -40,5 +40,63 @@
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
     "ShareLockPeriod": 0
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "fbda4aaf442bc0b388d0185d166f48868bcc729b",
+      "auditGap": ["state", "selectors"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "fbda4aaf442bc0b388d0185d166f48868bcc729b",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "fbda4aaf442bc0b388d0185d166f48868bcc729b",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "fbda4aaf442bc0b388d0185d166f48868bcc729b",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "fbda4aaf442bc0b388d0185d166f48868bcc729b",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "fbda4aaf442bc0b388d0185d166f48868bcc729b",
+      "auditGap": ["state"]
+    }
   }
 }

--- a/deployments/addresses/Linea/Deployers.json
+++ b/deployments/addresses/Linea/Deployers.json
@@ -1,0 +1,31 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-linea": "0x04fc9C685961934f552b5e01F15CBBa66B61D92c",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-linea": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Linea/GoldenGoose.json
+++ b/deployments/addresses/Linea/GoldenGoose.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x05C0DC4C46E4d18A97bA0BDA01b38B015fB98fb6"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "69fa3837f651ed236b35400b69498b50e48e99e9",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Linea/GoldenGooseTest.json
+++ b/deployments/addresses/Linea/GoldenGooseTest.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x05C0DC4C46E4d18A97bA0BDA01b38B015fB98fb6"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "69fa3837f651ed236b35400b69498b50e48e99e9",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/Accountants.json
+++ b/deployments/addresses/Mainnet/Accountants.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "AccountantWithRateProviders_b55f7d6c": "0x327db73aa2adee59dab08ee1b31c72d1b55f7d6c"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders_b55f7d6c": {
+      "deploymentCommit": "67cf8116",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/Mainnet/AlphaSTETH.json
+++ b/deployments/addresses/Mainnet/AlphaSTETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x8C5Ae128EbFBf700F76FFad9b4634abAf8ED6683",
     "TellerWithLayerZero": "0x9c9944473d7DB901fa32dCf29b6434b4e7AD82e9",
     "Timelock": "0x4419326b1F38aac37635be19e377014869CD78fC"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "64cb06785dc639d2c8fe0e061d09ab12ec12ef82",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "ab880f1c46f1031d1c228df2509c13a5fd9dff7a",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/BTCNDeployment.json
+++ b/deployments/addresses/Mainnet/BTCNDeployment.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0xAA0E63f512758E29831E7bb1e704FcBb860ab7f5",
     "TellerWithLayerZero": "0xeAd024098eE05e8e975043eCc6189b49CfBe35fd",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Mainnet/BridgingTestVaultDeployment.json
@@ -26,7 +26,70 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1000000000000000000
   },
-  "core": {
+  "depositConfiguration": {
+    "AllowPublicDeposits": true,
+    "AllowPublicWithdraws": true,
+    "ShareLockPeriod": 0
+  },
+  "contractMetadata": {
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "30848dc2638f6776eee66d0d5006600a08b7f677",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
+      "auditGap": ["state", "selectors"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "886c96b00100a777f572b8ea05bf971bcd781738",
+      "auditGap": ["state"]
+    }
+  },
+  "contractAddresses": {
     "AccountantWithRateProviders": "0xBA4397B2B1780097eD1B483E3C0717E0Ed4fAAa5",
     "BoringVault": "0xf8203A33027607D2C82dFd67b46986096257dFA5",
     "DecoderAndSanitizer": "0x16D377CE4c95F7737Ef4B45F81301A988F62b61a",
@@ -35,10 +98,5 @@
     "ManagerWithMerkleVerification": "0x3770E6021d7b2617Ba86E89EF210Cc00A7c9Af95",
     "RolesAuthority": "0x08a879438BBcF000d07000F564a46EdCF8f9127B",
     "TellerWithMultiAssetSupport": "0x821EFF4708Ff840a90F5822197418ebba469B232"
-  },
-  "depositConfiguration": {
-    "AllowPublicDeposits": true,
-    "AllowPublicWithdraws": true,
-    "ShareLockPeriod": 0
   }
 }

--- a/deployments/addresses/Mainnet/Deployers.json
+++ b/deployments/addresses/Mainnet/Deployers.json
@@ -1,0 +1,55 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-bob-mainnet": "0xF3d0672a91Fd56C9ef04C79ec67d60c34c6148a0",
+    "veda-bundle-create3-mainnet": "0x47Cec90FACc9364D7C21A8ab5e2aD9F1f75D740C",
+    "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434",
+    "veda-layerzero-create3-mainnet": "0x00bF0B30655a43Af93c1b371Be021Bd4567c51d5",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-bob-mainnet": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-mainnet": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-mainnet-plasma": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-layerzero-create3-mainnet": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Mainnet/EthenaPlasma.json
+++ b/deployments/addresses/Mainnet/EthenaPlasma.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xa0620014B7AFf15999fa299757fCb257b482d513",
     "TellerWithLayerZero": "0x8f64F21c66937CDefA33097BA41681EBc0964a3f",
     "Timelock": "0xECAeF0fd3c5241D4F98D7e797500C9a5B8F9E11e"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/EthenaRWA.json
+++ b/deployments/addresses/Mainnet/EthenaRWA.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0xa77E25096F2F69561A712a0B236689453841684C",
     "TellerWithMultiAssetSupport": "0xDEa662f24389eB7CaFA9b3B10021884FCe7314f0",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "463b7a874c4480c7663473dfdb844aeb7567cb13",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "c3dde9653a59ffbb52fd0d3493c5ceaa5850dab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-45",
+      "verificationGap": ["cbor", "evm:cancun"],
+      "deploymentCommit": "c3dde9653a59ffbb52fd0d3493c5ceaa5850dab2",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
+++ b/deployments/addresses/Mainnet/EtherFiEigenDeployment.json
@@ -24,7 +24,70 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1000000000000000000
   },
-  "core": {
+  "depositConfiguration": {
+    "AllowPublicDeposits": true,
+    "AllowPublicWithdraws": false,
+    "ShareLockPeriod": 86400
+  },
+  "contractMetadata": {
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai", "source:execute_method_not_in_repo"],
+      "deploymentCommit": "353e102866e7f1f014aad691bb63e4f994110429",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
+      "auditGap": ["state", "selectors"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fe0bf0afde965723bb540fdbb616dcc8564a31c7",
+      "auditGap": ["state"]
+    }
+  },
+  "contractAddresses": {
     "AccountantWithRateProviders": "0x075e60550C6f77f430B284E76aF699bC31651f75",
     "BoringVault": "0xE77076518A813616315EaAba6cA8e595E845EeE9",
     "DecoderAndSanitizer": "0xb7Dd199ABE801cC4985B60B8B1365264Eb31ad26",
@@ -33,10 +96,5 @@
     "ManagerWithMerkleVerification": "0x354ade0382EEC1BF0a444339ABc82931457C2c0e",
     "RolesAuthority": "0x1f5D0e8e7eb6390D2eb6024cdC8B38A7faab596E",
     "TellerWithMultiAssetSupport": "0x63b2B0528376d1B34Ed8c9FF61Bd67ab2C8c2Bb0"
-  },
-  "depositConfiguration": {
-    "AllowPublicDeposits": true,
-    "AllowPublicWithdraws": false,
-    "ShareLockPeriod": 86400
   }
 }

--- a/deployments/addresses/Mainnet/EtherFiLiquidBTC.json
+++ b/deployments/addresses/Mainnet/EtherFiLiquidBTC.json
@@ -9,5 +9,63 @@
     "QueueSolver": "0x7102C6889B0BB93Acf4A895f3EbeB17080D91d29",
     "RolesAuthority": "0x49F954c67ff235034b69b8a59fbe309A40256c8d",
     "TellerWithMultiAssetSupport": "0x9E88C603307fdC33aA5F26E38b6f6aeF3eE92d48"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "QueueSolver": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/GoldenGoose.json
+++ b/deployments/addresses/Mainnet/GoldenGoose.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f1483e8f8f7c698ccf34f9b72ea0ec62874b320d",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "53cee812d378c7c2f2ce8acaa5355cc7a34dfee2",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "92e1a7af2d550c98bb89adfdd3687862abed7545",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f1483e8f8f7c698ccf34f9b72ea0ec62874b320d",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f1483e8f8f7c698ccf34f9b72ea0ec62874b320d",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "92e1a7af2d550c98bb89adfdd3687862abed7545",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/HourglassBTC.json
+++ b/deployments/addresses/Mainnet/HourglassBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xBAFaD8627F577f95A437e26111EbFB682dE036CD",
     "TellerWithMultiAssetSupport": "0xe6a0E8DFe6017bD6161cd98e0AE02A04FDe90de2",
     "Timelock": "0x1F52658486f0c0ff080efc87A2F2eb572276654D"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f6f9d295a21dd35d3fdeb17942df63a02c1bbea1",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/HybridBTC.json
+++ b/deployments/addresses/Mainnet/HybridBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xE62e424DbAf17D702cceba939C9427018DBC19C1",
     "TellerWithLayerZero": "0x19ab8c9896728d3A2AE8677711bc852C706616d3",
     "Timelock": "0xDbE09a066f6D42935f702F700b7E0E5F56028Df2"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b46fed25294170c2f26ba7bf84c68705e3605d2f",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/HyperBTC.json
+++ b/deployments/addresses/Mainnet/HyperBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xD1D2926e025609FB792aFA5673b755BdC22404a5",
     "TellerWithLayerZero": "0xc8e88864800dCa0Ca7e68D0bD313296288c5eafa",
     "Timelock": "0xaE35522cF11Ad7bF245821a56d047210AF0cFF1b"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/HyperETH.json
+++ b/deployments/addresses/Mainnet/HyperETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x0308296E380aB78d920e7d9EE5A2cF8cB38280C0",
     "TellerWithLayerZero": "0x47a871268CdC8846fa36afa5dE09302066349BaE",
     "Timelock": "0x847e33fd0b0e74269d09E1D475156dc123796c4c"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/HyperUSD.json
+++ b/deployments/addresses/Mainnet/HyperUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xED8C9A514eB81124e370015878ea1fB3fEF18158",
     "TellerWithLayerZero": "0xbC08eF3368615Be8495EB394a0b7d8d5FC6d1A55",
     "Timelock": "0x910D4dC298Baa7691EF4FE77E0C6f2c5a77b72F6"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/InkedBTC.json
+++ b/deployments/addresses/Mainnet/InkedBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xF60c540Bd5aC805F4453C84Ec941b68aC9bD7328",
     "TellerWithLayerZero": "0xa344c435478E7590E82619007Af2240921824Bae",
     "Timelock": "0x7EDE533c0B9257ae93908cdE5F98d1Cc51DD120E"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "55cae33d7f553c5b241778750758500434db6303",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "55cae33d7f553c5b241778750758500434db6303",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/InkedETH.json
+++ b/deployments/addresses/Mainnet/InkedETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x14c55D919a7587B730120528099f3B7464bC6006",
     "TellerWithLayerZero": "0xBC27FAf3F5437a42B19a78d37A7aDBc6FF0ED80c",
     "Timelock": "0x6BA782a457744360C8a74636932e5cfC37ffEDF1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "55cae33d7f553c5b241778750758500434db6303",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "55cae33d7f553c5b241778750758500434db6303",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/InkedUSDT.json
+++ b/deployments/addresses/Mainnet/InkedUSDT.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xecE2222D3ac4b21316b6E5F4208A452BB96A8Cb4",
     "TellerWithLayerZero": "0xeFEE4199F7eE3375c04D8B0851b109ED3Df82F74",
     "Timelock": "0x12DeD18937cecdDDa386532B5aA2d1561617Fa27"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "55cae33d7f553c5b241778750758500434db6303",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "55cae33d7f553c5b241778750758500434db6303",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2da280b409ff57fdedd7528b70bf0e5edf710501",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/InkedUSDTHY.json
+++ b/deployments/addresses/Mainnet/InkedUSDTHY.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xBaDA45B8c83Dd662DBf2BfE6f4a7174734352592",
     "TellerWithLayerZero": "0x8E9F8A7E0643F198f2aCf413721b101Fe2B14f12",
     "Timelock": "0x4dEdfbF50d03586f2D5D1653Ea4a75Fe311592dE"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "c990c693a85a95f9ae6e2a03c5239dfab95269ba",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LBTCvKatanaDeployment.json
+++ b/deployments/addresses/Mainnet/LBTCvKatanaDeployment.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x11BF7551eb78786Ca167Db04B12201004a743606",
     "TellerWithLayerZero": "0x38d4066cC4B42E2B6615aE15cAa6e347114779E2",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LBTCvSonicDeployment.json
+++ b/deployments/addresses/Mainnet/LBTCvSonicDeployment.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0xdE428aE2fA7C648b21697B6B826787F0b4F80A36",
     "TellerWithLayerZero": "0x258f532CB41393c505554228e66eaf580B0171b2",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c28d595a89295335aa02fc397fd571b43215a89",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c2d11ecb471a0d0a55d1c1a67c90a3fb749c2e42",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LiquidBeraBTC.json
+++ b/deployments/addresses/Mainnet/LiquidBeraBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x829675330fdcEE01022983493e71F73fb53eaB45",
     "LayerZeroTellerWithRateLimiting": "0xe238e253b67f42ee3aF194BaF7Aba5E2eaddA1B8",
     "Timelock": "0x0F2c66475EC9cef9C6B369CD8ecb04aAf4Db3329"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["external"]
+    },
+    "LayerZeroTellerWithRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "auditGap": ["unaudited"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LiquidBeraETH.json
+++ b/deployments/addresses/Mainnet/LiquidBeraETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x5979F753b417c17FCd8f8c87b86154A0EB0E2c17",
     "LayerZeroTellerWithRateLimiting": "0xd445C65e4821dbD4ed0114eCDF6325c69faD7653",
     "Timelock": "0x946F01f13eCafdbbd4CC2BDEd41703b3365b9D17"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["external"]
+    },
+    "LayerZeroTellerWithRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c9b8b82b57a0b902182cc79784caab6a6a5fb062",
+      "auditGap": ["unaudited"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LiquidKatana.json
+++ b/deployments/addresses/Mainnet/LiquidKatana.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x1645E0cc24595faB37916a3d57bC51dFf0315Cf7",
     "TellerWithLayerZeroRateLimiting": "0x739A1efFaDDB0b07ef1284598819232df4FD8d16",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["unaudited"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LiquidMoveETH.json
+++ b/deployments/addresses/Mainnet/LiquidMoveETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x7Dcbd5c38C128f83aa8264120bcec8662f35AdAF",
     "TellerWithMultiAssetSupport": "0x63ede83cbB1c8D90bA52E9497e6C1226a673e884",
     "Timelock": "0x0AD030B3ED355Aa1690b0748176129AeFc2C33BD"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2d20d3825c08bf0b09bcc381a145a38a9f65c37e",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LoopBTC.json
+++ b/deployments/addresses/Mainnet/LoopBTC.json
@@ -9,5 +9,63 @@
     "QueueSolver": "0x5d7E40C5A3ff167Ceabfe60DBc570603A6dcD043",
     "RolesAuthority": "0xfcfD55fC8b0a46787f2B5B10faAC1c5db1fe19B5",
     "TellerWithMultiAssetSupport": "0x7C340Cf98B675740caB584B84bF51b564A92DCd1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "QueueSolver": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LtacBTC.json
+++ b/deployments/addresses/Mainnet/LtacBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x8Dc384D9C0a3c28210A019C487bC66fA564F3DC5",
     "TellerWithLayerZero": "0xf494715A67E547162e385f8AAb725376a0083B99",
     "Timelock": "0xff176110B1eBeb813fC02Ab108272d21b4eD8f83"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "e70735426590d83c5673a117e9a8fade09d66d60",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7fb689d55d2a535b4c52388c49736629ff111a82",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "88b61f44f4b65953b976c0e6c98a0806b4dd7c59",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LtacETH.json
+++ b/deployments/addresses/Mainnet/LtacETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x5226fC54fA5eCB2D773dB920cCEDE43376aCb7D2",
     "TellerWithLayerZero": "0xfFb063FbA8d947FFa6aE75d729324383d3B4B393",
     "Timelock": "0x7c5Ff0C46B76B7E7078C6D311b13B4B688bd377c"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/LtacUSD.json
+++ b/deployments/addresses/Mainnet/LtacUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x3558EA6b01C01D3008f6f21201D10Dbc52861f8B",
     "TellerWithLayerZero": "0x7430d98Fd6aA7484754A67210973BC3dB95f1d70",
     "Timelock": "0x89308AC8f0Ab4d3E07607D0Bf9fbAc8d5D87352E"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "d0d2f5c80d16865f6efcda2b9e3b8d0eb842664d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "81c4ef977425572e373133cc7ebfceb7356eb345",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/PlasmaUSD.json
+++ b/deployments/addresses/Mainnet/PlasmaUSD.json
@@ -11,7 +11,77 @@
     "RolesAuthority": "0xb381DE863dadFEA44738E7179f0d1Fc73b59e278",
     "TellerWithLayerZero": "0x4E7d2186eB8B75fBDcA867761636637E05BaeF1E",
     "Timelock": "0xE4438652F747439bF1496C4f9dBeC430B2A691Dd"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "92e1a7af2d550c98bb89adfdd3687862abed7545",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "auditGap": ["external"]
+    }
   }
 }
-
-0x97474f39

--- a/deployments/addresses/Mainnet/PrimeGoldenGoose.json
+++ b/deployments/addresses/Mainnet/PrimeGoldenGoose.json
@@ -11,5 +11,63 @@
     "RolesAuthority": "0x25863400F4541543a47E97c6a7b1FD226B234723",
     "TellerWithLayerZero": "0x4ecC202775678F7bCfF8350894e2F2E3167Cc3Df",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "6b0b1ea7287258d8e77dbcca41ca409c620c50d0",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "4df9f9b4350d7b96d73578c59fdada3cea2a363f",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "7e92682b293c3f83fe1e5527139e958bc1be727e",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/SonicBTC.json
+++ b/deployments/addresses/Mainnet/SonicBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xe2C7E397b35fF40962eBc205217B6795520Fb264",
     "TellerWithLayerZero": "0xAce7DEFe3b94554f0704d8d00F69F273A0cFf079",
     "Timelock": "0x7ec34170b540ca4cf8d2b52dbE41BE6D050Fb1D8"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/SonicETH.json
+++ b/deployments/addresses/Mainnet/SonicETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xA7F4Aec487ca3F3A9b5ADDC058daFD4644725902",
     "TellerWithLayerZero": "0x31A5A9F60Dc3d62fa5168352CaF0Ee05aA18f5B8",
     "Timelock": "0xea5d87D95de328C405E5693A0aD921c1512dd409"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/SonicUSD.json
+++ b/deployments/addresses/Mainnet/SonicUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x7D5f6108e23c0CB2cfD744E5c46f1aAfFc30A348",
     "TellerWithLayerZero": "0x358CFACf00d0B4634849821BB3d1965b472c776a",
     "Timelock": "0x064C10d1A1659Af66A49Afdd4e77e376bFaec6E8"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/SteakhouseUSD.json
+++ b/deployments/addresses/Mainnet/SteakhouseUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xd0E689DAe08A5A1F7F65670a48df05b0D1F3Fe46",
     "TellerWithLayerZero": "0xBB987c1570A3886df740721E773aBe067BBb268D",
     "Timelock": "0x480A5B25a5962623ab349F9545930deaFBB86B5c"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "63b9a02facfdcce70b487fc26afdab56f068e0b2",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c715797a904e37483580b12e59c94e20d8888a7b",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/TacLBTCv.json
+++ b/deployments/addresses/Mainnet/TacLBTCv.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x7d4dB1F1175DD77F9F746bf666F6BfF4a213C1c1",
     "TellerWithLayerZero": "0xAe499dAa7350b78746681931c47394eB7cC4Cf7F",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "da108c32e06dba782679802c4edaed6300460704",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "da108c32e06dba782679802c4edaed6300460704",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "da108c32e06dba782679802c4edaed6300460704",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "da108c32e06dba782679802c4edaed6300460704",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c48ee76499340cb1cab9e4e5493e441d1088e7d1",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/Tellers.json
+++ b/deployments/addresses/Mainnet/Tellers.json
@@ -1,0 +1,26 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_3c730353": "0x8ea0b382d054dbebeb1d0ae47ee4ac433c730353",
+    "LayerZeroTeller_202d82b2": "0x4c74cca483a278bcb90aea3f8f565e56202d82b2",
+    "LayerZeroTeller_564c2825": "0x634d53643b497bb614b4b6c8f3a58a5d564c2825",
+    "LayerZeroTeller_62b6293c": "0xbb4ef6f8a38a0abb9d31cf64a7ae2e9862b6293c"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_3c730353": {
+      "deploymentCommit": "bf902717",
+      "verificationGap": ["cbor"]
+    },
+    "LayerZeroTeller_202d82b2": {
+      "deploymentCommit": "67cf8116",
+      "verificationGap": ["cbor"]
+    },
+    "LayerZeroTeller_564c2825": {
+      "deploymentCommit": "67cf8116",
+      "verificationGap": ["cbor"]
+    },
+    "LayerZeroTeller_62b6293c": {
+      "deploymentCommit": "92e1a7af",
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Mainnet/TestPlasmaUSD.json
+++ b/deployments/addresses/Mainnet/TestPlasmaUSD.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x2B9A752B7407D37A16A089c2A28d39d08EdB108D",
     "TellerWithLayerZero": "0x187c8aA8ec6a57731406824ee247377296Ed362D",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "d13c47c3ded2bcfe651471cf3e4b8021bf4b481a",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/TurleTACETH.json
+++ b/deployments/addresses/Mainnet/TurleTACETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xc48478d53B5aB32f57223D77b035405555d75Bd4",
     "TellerWithLayerZero": "0xe97365b41B340352d3d32CA2C7230330F19A1e73",
     "Timelock": "0xCE8DdA3c60E7D59d74Df844428e43018394Aa5Fc"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/TurtleTACBTC.json
+++ b/deployments/addresses/Mainnet/TurtleTACBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xB849b2D2794C1f8b6A45E3Ed68A962043Cd4b544",
     "TellerWithLayerZero": "0x7C75cbb851D321B2Ec8034D58A9B5075e991E584",
     "Timelock": "0x96b5CE041311F82E8CdE62295266A74E53d219b6"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/TurtleTACUSD.json
+++ b/deployments/addresses/Mainnet/TurtleTACUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xCaa41d658e161255eF0dCa7c0eE8d8d5B12d426b",
     "TellerWithLayerZero": "0xBbf9E8718D83CF67b568bfFd9d3034BfF02A0103",
     "Timelock": "0x8B1f87950204462d0F7580628b52E459711243AD"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "bf90271750b6b8d46326808e7af03f554fb53356",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7500c2f21134ef0178ce9c707a59ef829b5af18",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/UltraUSD.json
+++ b/deployments/addresses/Mainnet/UltraUSD.json
@@ -13,5 +13,77 @@
     "RolesAuthority": "0x3E6D22a67b9728A0866D69EFa16c2e20E60A8451",
     "TellerWithMultiAssetSupport": "0xc8c58d1567e1db8c02542e6df5241A0d71f91Fe2",
     "Timelock": "0x68E0a14EAD593E757EE04d520E71F8263fb34c40"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "42d79a49696f85358255813d69ab28e8a78f8441",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/UsualBera.json
+++ b/deployments/addresses/Mainnet/UsualBera.json
@@ -11,5 +11,63 @@
     "RolesAuthority": "0x646256aFb3Af90f5527Fc46fA3484CA4145C3a9b",
     "TellerWithMultiAssetSupport": "0x16454063CA71085e0EF2622CA30d7c371441d1C8",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "474893ded885115e19cbea264377ca9e4d76ff1c",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/VedaTestVault.json
+++ b/deployments/addresses/Mainnet/VedaTestVault.json
@@ -1,16 +1,87 @@
 {
-    "Drones": "",
-    "contractAddresses": {
-      "AccountantWithRateProviders": "0x5555559e499d2107aBb035a5feA1235b7f942E6D",
-      "BoringOnChainQueue": "0x1111115849b462ac0781e10638FEb02947928397",
-      "BoringVault": "0x00007EDa736C6CdF973BDefF2191bbCfE6175db7",
-      "Lens": "0x4444448f6eA5Ac40a9c547f119152EE189579CeD",
-      "ManagerWithMerkleVerification": "0x999999e868Fb298c6EDbf0060f7cE077f01ad782",
-      "Pauser": "0x888888AF9791197133aE7AE487704E2c6164FF23",
-      "QueueSolver": "0x6666669a5FDf3b83CB30b88A5A332fAC9e90C1d8",
-      "RolesAuthority": "0x222222bbd7F2E56f1320fa8C9f83992da738b036",
-      "TellerWithLayerZero": "0x7777776973bC0869e4d106F1F2Ec8b42228EC8e7",
-      "Timelock": "0x333333807Ec1b14A5152c5bB7fC69EC8a817885D"
+  "Drones": "",
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0x5555559e499d2107aBb035a5feA1235b7f942E6D",
+    "BoringOnChainQueue": "0x1111115849b462ac0781e10638FEb02947928397",
+    "BoringVault": "0x00007EDa736C6CdF973BDefF2191bbCfE6175db7",
+    "Lens": "0x4444448f6eA5Ac40a9c547f119152EE189579CeD",
+    "ManagerWithMerkleVerification": "0x999999e868Fb298c6EDbf0060f7cE077f01ad782",
+    "Pauser": "0x888888AF9791197133aE7AE487704E2c6164FF23",
+    "QueueSolver": "0x6666669a5FDf3b83CB30b88A5A332fAC9e90C1d8",
+    "RolesAuthority": "0x222222bbd7F2E56f1320fa8C9f83992da738b036",
+    "TellerWithLayerZero": "0x7777776973bC0869e4d106F1F2Ec8b42228EC8e7",
+    "Timelock": "0x333333807Ec1b14A5152c5bB7fC69EC8a817885D"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "9373ec027dd9ce1214199ce2f25e349de91b8866",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
     }
   }
-  
+}

--- a/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
+++ b/deployments/addresses/Mainnet/cbBtcDefiVaultDeployment.json
@@ -44,7 +44,70 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 100000000
   },
-  "core": {
+  "depositConfiguration": {
+    "AllowPublicDeposits": true,
+    "AllowPublicWithdraws": false,
+    "ShareLockPeriod": 86400
+  },
+  "contractMetadata": {
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ba47235b12273d1a4c8554f6d84744a0d1ab1631",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
+      "auditGap": ["state", "selectors"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "228b4b66174f66385646e90ca30c1f354423bdf3",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "037e1cb12189d26a5c375df94383f2b13e550927",
+      "auditGap": ["state"]
+    }
+  },
+  "contractAddresses": {
     "AccountantWithRateProviders": "0x1c217f17d57d3CCD1CB3d8CB16B21e8f0b544156",
     "BoringVault": "0x42A03534DBe07077d705311854E3B6933dD6Af85",
     "DecoderAndSanitizer": "0xA6b52921652A828Da445b457442F8cA10638a4Bb",
@@ -53,10 +116,5 @@
     "ManagerWithMerkleVerification": "0xcb4647c77688489655F45bB5bac42E14a0b05F85",
     "RolesAuthority": "0x01D68fBb5518Ea87895c5B1aA05d8A86EB9d04D8",
     "TellerWithMultiAssetSupport": "0x66B912f197D9810d7b74E43d55bBbFC60034E98a"
-  },
-  "depositConfiguration": {
-    "AllowPublicDeposits": true,
-    "AllowPublicWithdraws": false,
-    "ShareLockPeriod": 86400
   }
 }

--- a/deployments/addresses/Mainnet/sLBTCDeployment.json
+++ b/deployments/addresses/Mainnet/sLBTCDeployment.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0xDD9214A2EB4E1501001715891618253669B5c8ee",
     "TellerWithMultiAssetSupport": "0x97Deb8Fb02A2553976DCD3d25FaA1501Eef4585b",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "deploymentCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "deploymentCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3",
+      "verificationGap": ["none"],
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "3144c8391cd1f7cc1311713b814ed66f085947b3",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "c3dde9653a59ffbb52fd0d3493c5ceaa5850dab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-45",
+      "verificationGap": ["cbor", "evm:cancun"],
+      "deploymentCommit": "c3dde9653a59ffbb52fd0d3493c5ceaa5850dab2",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mainnet/uniBTCv.json
+++ b/deployments/addresses/Mainnet/uniBTCv.json
@@ -9,5 +9,63 @@
     "QueueSolver": "0x959F23c38938a9FDe0529E238eBE5f0555ed0cfd",
     "RolesAuthority": "0x6992eD92EB9510A6efAa4b9e103466c141f8dB1B",
     "TellerWithMultiAssetSupport": "0xb02D0996039C1D98eA4716D7781347f7CCFD328e"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "QueueSolver": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "847d0cba0b778bd54f94754e93fa3224fac989ee",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Mantle/Deployers.json
+++ b/deployments/addresses/Mantle/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Monad/Deployers.json
+++ b/deployments/addresses/Monad/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05",
+    "veda-bundle-create3-monad": "0x144dc4DF655a57d871be8f18aA565b82D3E980f5"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    },
+    "veda-bundle-create3-monad": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Optimism/Deployers.json
+++ b/deployments/addresses/Optimism/Deployers.json
@@ -1,0 +1,31 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-base-optimism": "0xd249755C0E79dF8F3A05C2398A73333eFDb6EB59",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "d68f47b5c3310f841f9a619a2f64e3e4bd19d42f",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-base-optimism": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Optimism/GoldenGoose.json
+++ b/deployments/addresses/Optimism/GoldenGoose.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/Optimism/LiquidEthDeployment.json
+++ b/deployments/addresses/Optimism/LiquidEthDeployment.json
@@ -33,6 +33,16 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1028735518391250446
   },
+  "contractAddresses": {
+    "AccountantWithRateProviders": "0x0d05D94a5F1E76C18fbeB7A13d17C8a314088198",
+    "BoringVault": "0xf0bb20865277aBd641a307eCe5Ee04E79073416C",
+    "DecoderAndSanitizer": "0x568a4E08909aab6995979dB24B3cdaE00244CeB4",
+    "DelayedWithdraw": "0xA1177Bc62E42eF2f9225a6cBF1CfE5CbC360C33A",
+    "Lens": "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    "ManagerWithMerkleVerification": "0x227975088C28DBBb4b421c6d96781a53578f19a8",
+    "RolesAuthority": "0x485Bde66Bb668a51f2372E34e45B1c6226798122",
+    "TellerWithMultiAssetSupport": "0x5c135e8eC99557b412b9B4492510dCfBD36066F5"
+  },
   "core": {
     "AccountantWithRateProviders": "0x0d05D94a5F1E76C18fbeB7A13d17C8a314088198",
     "BoringVault": "0xf0bb20865277aBd641a307eCe5Ee04E79073416C",
@@ -47,5 +57,63 @@
     "AllowPublicDeposits": false,
     "AllowPublicWithdraws": false,
     "ShareLockPeriod": 86400
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "529104270f693af771b1469e6f830c0010e34107",
+      "auditGap": ["state", "selectors"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:paris"],
+      "deploymentCommit": "529104270f693af771b1469e6f830c0010e34107",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:paris"],
+      "deploymentCommit": "529104270f693af771b1469e6f830c0010e34107",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "6064f06f72d8f972876009071b986f7d2e09feb1",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "529104270f693af771b1469e6f830c0010e34107",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "529104270f693af771b1469e6f830c0010e34107",
+      "auditGap": ["state"]
+    }
   }
 }

--- a/deployments/addresses/Optimism/Tellers.json
+++ b/deployments/addresses/Optimism/Tellers.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "TellerWithLayerZero_7b514734": "0x9aa79c84b79816ab920bbce20f8f74557b514734"
+  },
+  "contractMetadata": {
+    "TellerWithLayerZero_7b514734": {
+      "deploymentCommit": "f2c26ad8",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/Scroll/BridgingTestVaultDeployment.json
+++ b/deployments/addresses/Scroll/BridgingTestVaultDeployment.json
@@ -26,7 +26,7 @@
     "PayoutAddress": "0xA9962a5BfBea6918E958DeE0647E99fD7863b95A",
     "StartingExchangeRate": 1000000000000000000
   },
-  "core": {
+  "contractAddresses": {
     "AccountantWithRateProviders": "0xBA4397B2B1780097eD1B483E3C0717E0Ed4fAAa5",
     "BoringVault": "0xf8203A33027607D2C82dFd67b46986096257dFA5",
     "DecoderAndSanitizer": "0x16D377CE4c95F7737Ef4B45F81301A988F62b61a",
@@ -40,5 +40,63 @@
     "AllowPublicDeposits": true,
     "AllowPublicWithdraws": true,
     "ShareLockPeriod": 0
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["state", "selectors"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["state"]
+    },
+    "DecoderAndSanitizer": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["unaudited"]
+    },
+    "DelayedWithdraw": {
+      "auditCommit": "938478e59619c693150a2290ff677191b19a0948",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-8",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "35433417a394c49538260f30b5d37ab3e8de99d1",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-10",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["state"]
+    }
   }
 }

--- a/deployments/addresses/Scroll/Deployers.json
+++ b/deployments/addresses/Scroll/Deployers.json
@@ -1,0 +1,31 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-scroll": "0x534b64608E601B581AB0cbF0b03ec9f4c65f3360",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "4538ccf7706290e38b739e939854897c0f81f6de",
+      "verificationGap": ["cbor"],
+      "auditGap": ["selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-scroll": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/Scroll/Tellers.json
+++ b/deployments/addresses/Scroll/Tellers.json
@@ -1,0 +1,10 @@
+{
+  "contractAddresses": {
+    "LayerZeroTellerWithRateLimiting_bd407268": "0x6ee3aaccf9f2321e49063c4f8da775ddbd407268"
+  },
+  "contractMetadata": {
+    "LayerZeroTellerWithRateLimiting_bd407268": {
+      "verificationGap": ["etherscan; working-tree multi-commit"]
+    }
+  }
+}

--- a/deployments/addresses/Scroll/eBTC.json
+++ b/deployments/addresses/Scroll/eBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x6889E57BcA038C28520C0B047a75e567502ea5F6",
     "TellerWithMultiAssetSupport": "0xe19a43B1b8af6CeE71749Af2332627338B3242D1",
     "Timelock": "0x5BECC07fc7Eab131DD7683047EB37c257AA7482f"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["cbor", "evm:london"],
+      "deploymentCommit": "ec3abe3832b3c984201f46df529641ca0d42b3e2",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/Sepolia/Deployers.json
+++ b/deployments/addresses/Sepolia/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/SonicMainnet/Deployers.json
+++ b/deployments/addresses/SonicMainnet/Deployers.json
@@ -1,0 +1,23 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "504437c22c961ce127f1269eac6b879bb56ae10b",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/SonicMainnet/LBTCvSonicDeployment.json
+++ b/deployments/addresses/SonicMainnet/LBTCvSonicDeployment.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0xdE428aE2fA7C648b21697B6B826787F0b4F80A36",
     "TellerWithLayerZero": "0x258f532CB41393c505554228e66eaf580B0171b2",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "50c574751d1c8a5e090aa7ecc1018f93b5b50520",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/SonicMainnet/SonicBTC.json
+++ b/deployments/addresses/SonicMainnet/SonicBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xe2C7E397b35fF40962eBc205217B6795520Fb264",
     "TellerWithLayerZero": "0xAce7DEFe3b94554f0704d8d00F69F273A0cFf079",
     "Timelock": "0x7ec34170b540ca4cf8d2b52dbE41BE6D050Fb1D8"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/SonicMainnet/SonicETH.json
+++ b/deployments/addresses/SonicMainnet/SonicETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xA7F4Aec487ca3F3A9b5ADDC058daFD4644725902",
     "TellerWithMultiAssetSupport": "0x31A5A9F60Dc3d62fa5168352CaF0Ee05aA18f5B8",
     "Timelock": "0xea5d87D95de328C405E5693A0aD921c1512dd409"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b9f0c94b403e7b879898721a3ea7392fc48a9d49",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "10a0dae53f20c85e08b66b2ecb8d2f322010ea5a",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/SonicMainnet/SonicUSD.json
+++ b/deployments/addresses/SonicMainnet/SonicUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x7D5f6108e23c0CB2cfD744E5c46f1aAfFc30A348",
     "TellerWithLayerZero": "0x358CFACf00d0B4634849821BB3d1965b472c776a",
     "Timelock": "0x064C10d1A1659Af66A49Afdd4e77e376bFaec6E8"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b9f0c94b403e7b879898721a3ea7392fc48a9d49",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "50c574751d1c8a5e090aa7ecc1018f93b5b50520",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "fb4d39c628927791cd093c0f5621bb9956c7083b",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/SonicMainnet/StakedSonicBTC.json
+++ b/deployments/addresses/SonicMainnet/StakedSonicBTC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x8255CeE62568566742248B5eCa3f83B6B4780f98",
     "TellerWithMultiAssetSupport": "0x825254012306bB410b550631895fe58DdCE1f4a9",
     "Timelock": "0x5acF0Bd22AEb91F9CFa714FE651916910025F079"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f472abafb22f7a45e81df2814ae4bdf6f56dd74a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/SonicMainnet/StakedSonicETH.json
+++ b/deployments/addresses/SonicMainnet/StakedSonicETH.json
@@ -12,5 +12,84 @@
     "RolesAuthority": "0xc62d74F8F4f7fB799448C763ac3f604d2B888c7a",
     "TellerWithMultiAssetSupport": "0x49AcEbF8f0f79e1Ecb0fd47D684DAdec81cc6562",
     "Timelock": "0xa9f7Dd8E91fF3bD6A2007FFcc974bCD904754843"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "IncentiveDistributor": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "4ef9c70625716d5d204dbf7092e1d216a5754775",
+      "auditGap": ["unaudited"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f472abafb22f7a45e81df2814ae4bdf6f56dd74a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/SonicMainnet/StakedSonicUSD.json
+++ b/deployments/addresses/SonicMainnet/StakedSonicUSD.json
@@ -12,5 +12,84 @@
     "RolesAuthority": "0xFa5b3E35F961229b25Caa108C3D42cEEb20d0122",
     "TellerWithMultiAssetSupport": "0x5e39021Ae7D3f6267dc7995BB5Dd15669060DAe0",
     "Timelock": "0x970c117A3899121A30F906b9AbfE828F8DBAC335"
+  },
+  "contractMetadata": {
+    "AccountantWithFixedRate": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "ec74b24330a1d7b144dc397c1c20c76e3d6fc460",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-18",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditGap": ["none"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditGap": ["state"]
+    },
+    "IncentiveDistributor": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "4ef9c70625716d5d204dbf7092e1d216a5754775",
+      "auditGap": ["unaudited"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "c94d843a6e5d11b91f73f8e27c6b856d52ba8003",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-25",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state", "selectors"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "f472abafb22f7a45e81df2814ae4bdf6f56dd74a",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/SwellChain/Deployers.json
+++ b/deployments/addresses/SwellChain/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/TAC/Accountants.json
+++ b/deployments/addresses/TAC/Accountants.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "AccountantWithRateProviders_d43331e2": "0x20c13ab7cd4f0ffc49de1a9b6d415314d43331e2"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders_d43331e2": {
+      "deploymentCommit": "5efd7fb6",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/TAC/Tellers.json
+++ b/deployments/addresses/TAC/Tellers.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "LayerZeroTeller_e98041e3": "0x834e313cb01e8badeaad269fceecb5a1e98041e3"
+  },
+  "contractMetadata": {
+    "LayerZeroTeller_e98041e3": {
+      "deploymentCommit": "5efd7fb6",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/UniChain/AlphaSTETH.json
+++ b/deployments/addresses/UniChain/AlphaSTETH.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x8C5Ae128EbFBf700F76FFad9b4634abAf8ED6683",
     "TellerWithLayerZero": "0x9c9944473d7DB901fa32dCf29b6434b4e7AD82e9",
     "Timelock": "0x4419326b1F38aac37635be19e377014869CD78fC"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "263cf49f4219f285ccbf9f7fe2a800fea19d4c19",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/UniChain/Deployers.json
+++ b/deployments/addresses/UniChain/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    }
+  }
+}

--- a/deployments/addresses/UniChain/EtherFiLiquidEth.json
+++ b/deployments/addresses/UniChain/EtherFiLiquidEth.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xd83C1C5050f73bbaaa2036F2e0D73163D180C123",
     "TellerWithLayerZeroRateLimiting": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x43119CE1741bb02E3FC191e04775731537E9f5A9"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["unaudited"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/UniChain/EtherFiLiquidUsd.json
+++ b/deployments/addresses/UniChain/EtherFiLiquidUsd.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xaBA6bA1E95E0926a6A6b917FE4E2f19ceaE4FF2e",
     "TellerWithLayerZeroRateLimiting": "0x4DE413a26fC24c3FC27Cc983be70aA9c5C299387",
     "Timelock": "0x48b4158b0100B4e69D4a448db6BBe74DE94ee177"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-38",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "2e1aefc93c797f7b9dcf326e4ecafb089f9b3050",
+      "auditGap": ["none"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "15ea1839120d6da3eeb9a0009d45cd0017a9806d",
+      "auditGap": ["unaudited"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/UniChain/GoldenGoose.json
+++ b/deployments/addresses/UniChain/GoldenGoose.json
@@ -11,5 +11,70 @@
     "RolesAuthority": "0x9778D78495cBbfce0B1F6194526a8c3D4b9C3AAF",
     "TellerWithLayerZero": "0xE89fAaf3968ACa5dCB054D4a9287E54aa84F67e9",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "36c1a1a0a337bcc0063bcf2156cde76bcdab6ac5",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/UniChain/PrimeGoldenGoose.json
+++ b/deployments/addresses/UniChain/PrimeGoldenGoose.json
@@ -11,5 +11,63 @@
     "RolesAuthority": "0x25863400F4541543a47E97c6a7b1FD226B234723",
     "TellerWithLayerZero": "0x4ecC202775678F7bCfF8350894e2F2E3167Cc3Df",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "9c6e1e4458fba53f2ff09efe21195dcf570ffc3e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-7",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["state"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["none"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "dd7b8b54bd9c7ae1fcd4c8b938296db5bb32fb63",
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor", "evm:shanghai"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/UniChain/Tellers.json
+++ b/deployments/addresses/UniChain/Tellers.json
@@ -1,0 +1,11 @@
+{
+  "contractAddresses": {
+    "LayerZeroTeller_73fe614b": "0x0baab6db8d694e1511992b504476ef4073fe614b"
+  },
+  "contractMetadata": {
+    "LayerZeroTeller_73fe614b": {
+      "deploymentCommit": "92e1a7af",
+      "verificationGap": ["cbor"]
+    }
+  }
+}

--- a/deployments/addresses/XLayer/Deployers.json
+++ b/deployments/addresses/XLayer/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/plasma/Deployers.json
+++ b/deployments/addresses/plasma/Deployers.json
@@ -1,0 +1,31 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-canonical-create3": "0x5F2F11ad8656439d5C14d9B351f8b09cDaC2A02d",
+    "veda-bundle-create3-mainnet-plasma": "0xbc90dbeB9e76Ff5577Bc502EBDebd0F6616ec434",
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-canonical-create3": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-mainnet-plasma": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "24c42f7ccb42ad535446605808cfd163d2c94ea2",
+      "verificationGap": ["cbor"],
+      "auditGap": ["state", "selectors", "auth", "constructor"]
+    },
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/plasma/EthenaPlasma.json
+++ b/deployments/addresses/plasma/EthenaPlasma.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xa0620014B7AFf15999fa299757fCb257b482d513",
     "TellerWithLayerZero": "0x8f64F21c66937CDefA33097BA41681EBc0964a3f",
     "Timelock": "0xECAeF0fd3c5241D4F98D7e797500C9a5B8F9E11e"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/plasma/LiquidETH.json
+++ b/deployments/addresses/plasma/LiquidETH.json
@@ -13,5 +13,70 @@
     "RolesAuthority": "0x485Bde66Bb668a51f2372E34e45B1c6226798122",
     "TellerWithLayerZeroRateLimiting": "0x9AA79C84b79816ab920bBcE20f8f74557B514734",
     "Timelock": "0x0000000000000000000000000000000000000000"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZeroRateLimiting": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    }
   }
 }

--- a/deployments/addresses/plasma/PlasmaUSD.json
+++ b/deployments/addresses/plasma/PlasmaUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0xb381DE863dadFEA44738E7179f0d1Fc73b59e278",
     "TellerWithLayerZero": "0x4E7d2186eB8B75fBDcA867761636637E05BaeF1E",
     "Timelock": "0xE4438652F747439bF1496C4f9dBeC430B2A691Dd"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["none"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "selectors", "auth"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "deploymentCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "verificationGap": ["none"],
+      "auditGap": ["none"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-4",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["view", "selectors"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditGap": ["none"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditGap": ["state", "constructor"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/certora-boring-vault-0.pdf",
+      "verificationGap": ["cbor"],
+      "deploymentCommit": "c54949f556cbc9a5e752ef1d6e8c09d64f4975b7",
+      "auditGap": ["none"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "deploymentCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "verificationGap": ["none"],
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/plume/Deployers.json
+++ b/deployments/addresses/plume/Deployers.json
@@ -1,0 +1,15 @@
+{
+  "Drones": "",
+  "contractAddresses": {
+    "veda-bundle-create3-v2": "0xe80F045fc6F551229f98FA21E0Db35784A590e05"
+  },
+  "contractMetadata": {
+    "veda-bundle-create3-v2": {
+      "auditCommit": "0a7d659064c9070bd369d5c511ba94c6b01bbab2",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-1",
+      "deploymentCommit": "7dc398f1cf52acd7e9a7f4f21eb06fe9fbbf6bd3",
+      "auditGap": ["state", "selectors", "auth", "constructor"],
+      "verificationGap": ["none"]
+    }
+  }
+}

--- a/deployments/addresses/plume/royPlumeUSDC.json
+++ b/deployments/addresses/plume/royPlumeUSDC.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x8dA85FC312fD0fa30d4bF0FB53Fd1228dB63a1c0",
     "TellerWithMultiAssetSupport": "0x4Fc294112fD0b7226ecA095FEE9909E30882Cb11",
     "Timelock": "0x438B11b5215F87cb4E45c6b6B4A29c08247397C1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditUrl": "file:audit/certora-boring-vault-1.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["external"]
+    },
+    "TellerWithMultiAssetSupport": {
+      "auditCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditUrl": "file:audit/certora-boring-vault-1.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["external"]
+    }
   }
 }

--- a/deployments/addresses/plume/royUSDCPlumeUSD.json
+++ b/deployments/addresses/plume/royUSDCPlumeUSD.json
@@ -11,5 +11,77 @@
     "RolesAuthority": "0x754213aFB8ecb6D15F169bfD378Fb685f5cB0d4A",
     "TellerWithLayerZero": "0x60EBb5d1454Bb99aa35F63F609E79179b342B0b8",
     "Timelock": "0x6504cdedbB50f3cB848b4A496bA1eDBB116331a1"
+  },
+  "contractMetadata": {
+    "AccountantWithRateProviders": {
+      "auditCommit": "568d9467202a7f6e478cb8967fcee3c2afb38730",
+      "auditUrl": "file:audit/certora-boring-vault-1.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "BoringOnChainQueue": {
+      "auditCommit": "edfcba3f29f691c638b06d04f60af79503632b58",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-27",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "BoringVault": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Lens": {
+      "auditCommit": "939c77e25473dff3ed18fa104f004f7afd13452e",
+      "auditUrl": "file:audit/spearbit-boring-vault-arctic-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "ManagerWithMerkleVerification": {
+      "auditCommit": "b7ad4066a946a5e64285c88617a5de36e5eef436",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-19",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Pauser": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unaudited"]
+    },
+    "QueueSolver": {
+      "auditCommit": "b9eafd46e656c532ea2c28a1bd66ce271ebedbc7",
+      "auditUrl": "https://macroaudits.com/library/audits/sevenSeas-44",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "RolesAuthority": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["external"]
+    },
+    "TellerWithLayerZero": {
+      "auditCommit": "3c768bd068af856b5de3def86b1940676847eb9d",
+      "auditUrl": "file:audit/sigma-prime-boring-vault-0.pdf",
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["unknown"]
+    },
+    "Timelock": {
+      "auditCommit": null,
+      "auditUrl": null,
+      "verificationGap": ["none"],
+      "deploymentCommit": null,
+      "auditGap": ["external"]
+    }
   }
 }

--- a/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
@@ -1531,9 +1531,87 @@ contract DeployArcticArchitectureWithConfigScript is Script, ChainValues {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Deploy-time metadata helpers
+    // -------------------------------------------------------------------------
+
+    function _deploymentCommit() internal view returns (string memory) {
+        bytes memory head = bytes(vm.readFile(".git/HEAD"));
+        uint256 len = head.length;
+        while (len > 0 && (head[len - 1] == 0x0a || head[len - 1] == 0x0d || head[len - 1] == 0x20)) len--;
+        if (len > 5 && head[0] == "r" && head[1] == "e" && head[2] == "f" && head[3] == ":" && head[4] == 0x20) {
+            bytes memory refPath = new bytes(len - 5);
+            for (uint256 i; i < refPath.length; i++) refPath[i] = head[5 + i];
+            bytes memory sha = bytes(vm.readFile(string.concat(".git/", string(refPath))));
+            uint256 shaLen = sha.length;
+            while (shaLen > 0 && (sha[shaLen - 1] == 0x0a || sha[shaLen - 1] == 0x0d || sha[shaLen - 1] == 0x20)) shaLen--;
+            bytes memory shaResult = new bytes(shaLen);
+            for (uint256 i; i < shaLen; i++) shaResult[i] = sha[i];
+            return string(shaResult);
+        }
+        bytes memory result = new bytes(len);
+        for (uint256 i; i < len; i++) result[i] = head[i];
+        return string(result);
+    }
+
+    function _parseAuditLine(string memory sourcePath)
+        internal
+        view
+        returns (string memory auditCommit, string memory auditUrl)
+    {
+        bytes memory b = bytes(vm.readFile(sourcePath));
+        uint256 newlines;
+        uint256 lineStart;
+        for (uint256 i; i < b.length; i++) {
+            if (b[i] == 0x0a) {
+                if (++newlines == 4) { lineStart = i + 1; break; }
+            }
+        }
+        if (newlines < 4) return ("", "");
+
+        uint256 atPos;
+        bool found;
+        for (uint256 i = lineStart; i < b.length && b[i] != 0x0a; i++) {
+            if (b[i] == 0x40) { atPos = i + 1; found = true; break; }
+        }
+        if (!found || atPos + 40 > b.length) return ("", "");
+
+        bytes memory commit = new bytes(40);
+        for (uint256 i; i < 40; i++) commit[i] = b[atPos + i];
+        auditCommit = string(commit);
+
+        uint256 urlStart = atPos + 40 + 5;
+        uint256 urlEnd = urlStart;
+        while (urlEnd < b.length && b[urlEnd] != 0x0a && b[urlEnd] != 0x0d) urlEnd++;
+        bytes memory url = new bytes(urlEnd - urlStart);
+        for (uint256 i; i < url.length; i++) url[i] = b[urlStart + i];
+        auditUrl = string(url);
+    }
+
+    function _addMeta(
+        string memory metaKey,
+        string memory contractName,
+        string memory sourcePath,
+        string memory deployCommit
+    ) internal returns (string memory) {
+        string memory entryKey = string.concat("meta_entry_", contractName);
+        if (bytes(sourcePath).length > 0) {
+            (string memory auditCommit, string memory auditUrl) = _parseAuditLine(sourcePath);
+            if (bytes(auditCommit).length > 0) {
+                vm.serializeString(entryKey, "auditCommit", auditCommit);
+                vm.serializeString(entryKey, "auditUrl", auditUrl);
+            }
+        }
+        string memory entryJson = vm.serializeString(entryKey, "deploymentCommit", deployCommit);
+        return vm.serializeString(metaKey, contractName, entryJson);
+    }
+
+    // -------------------------------------------------------------------------
+
     function _saveContractAddresses() internal {
         // Save deployment details.
         _log("Saving deployment details...", 3);
+        string memory deployCommit = _deploymentCommit();
         // Read deployment file name from configuration file.
         string memory deploymentFileName = vm.parseJsonString(rawJson, ".deploymentParameters.deploymentFileName");
         string memory filePath = string.concat("./deployments/", deploymentFileName);
@@ -1579,8 +1657,38 @@ contract DeployArcticArchitectureWithConfigScript is Script, ChainValues {
                 }
             }
 
+            string memory metadataOutput;
+            {
+                string memory meta = "contract metadata key";
+                _addMeta(meta, "RolesAuthority", "", deployCommit);
+                _addMeta(meta, "Lens", "src/helper/ArcticArchitectureLens.sol", deployCommit);
+                _addMeta(meta, "BoringVault", "src/base/BoringVault.sol", deployCommit);
+                _addMeta(meta, "ManagerWithMerkleVerification", "src/base/Roles/ManagerWithMerkleVerification.sol", deployCommit);
+                _addMeta(meta, "Pauser", "src/base/Roles/Pauser.sol", deployCommit);
+                _addMeta(meta, "Timelock", "", deployCommit);
+                if (accountantKind == AccountantKind.VariableRate) {
+                    _addMeta(meta, "AccountantWithRateProviders", "src/base/Roles/AccountantWithRateProviders.sol", deployCommit);
+                } else if (accountantKind == AccountantKind.FixedRate) {
+                    _addMeta(meta, "AccountantWithFixedRate", "src/base/Roles/AccountantWithFixedRate.sol", deployCommit);
+                }
+                if (tellerKind == TellerKind.Teller) {
+                    _addMeta(meta, "TellerWithMultiAssetSupport", "src/base/Roles/TellerWithMultiAssetSupport.sol", deployCommit);
+                } else if (tellerKind == TellerKind.TellerWithRemediation) {
+                    _addMeta(meta, "TellerWithRemediation", "src/base/Roles/TellerWithRemediation.sol", deployCommit);
+                } else if (tellerKind == TellerKind.TellerWithCcip) {
+                    _addMeta(meta, "TellerWithCcip", "src/base/Roles/CrossChain/Bridges/CCIP/ChainlinkCCIPTeller.sol", deployCommit);
+                } else if (tellerKind == TellerKind.TellerWithLayerZero) {
+                    _addMeta(meta, "TellerWithLayerZero", "src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTeller.sol", deployCommit);
+                } else if (tellerKind == TellerKind.TellerWithLayerZeroRateLimiting) {
+                    _addMeta(meta, "TellerWithLayerZeroRateLimiting", "src/base/Roles/CrossChain/Bridges/LayerZero/LayerZeroTellerWithRateLimiting.sol", deployCommit);
+                }
+                _addMeta(meta, "BoringOnChainQueue", "src/base/Roles/BoringQueue/BoringOnChainQueue.sol", deployCommit);
+                metadataOutput = _addMeta(meta, "QueueSolver", "src/base/Roles/BoringQueue/BoringSolver.sol", deployCommit);
+            }
+
             vm.serializeString(finalJson, "contractAddresses", coreOutput);
-            finalJson = vm.serializeString(finalJson, "Drones", droneOutput);
+            vm.serializeString(finalJson, "Drones", droneOutput);
+            finalJson = vm.serializeString(finalJson, "contractMetadata", metadataOutput);
 
             vm.writeJson(finalJson, filePath);
         }

--- a/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol
@@ -1556,9 +1556,10 @@ contract DeployArcticArchitectureWithConfigScript is Script, ChainValues {
 
     function _parseAuditLine(string memory sourcePath)
         internal
-        view
         returns (string memory auditCommit, string memory auditUrl)
     {
+        // Stale or renamed path: degrade gracefully instead of aborting simulation.
+        if (!vm.exists(sourcePath)) return ("", "");
         bytes memory b = bytes(vm.readFile(sourcePath));
         uint256 newlines;
         uint256 lineStart;
@@ -1576,11 +1577,24 @@ contract DeployArcticArchitectureWithConfigScript is Script, ChainValues {
         }
         if (!found || atPos + 40 > b.length) return ("", "");
 
+        // Validate all 40 chars are hex — guards against an unrelated '@' on the line.
+        for (uint256 i; i < 40; i++) {
+            bytes1 c = b[atPos + i];
+            bool isHex = (c >= "0" && c <= "9") || (c >= "a" && c <= "f") || (c >= "A" && c <= "F");
+            if (!isHex) return ("", "");
+        }
+
+        // Verify separator: space + UTF-8 em-dash (0xe2 0x80 0x94) + space.
+        if (atPos + 45 > b.length) return ("", "");
+        if (b[atPos+40] != 0x20 || b[atPos+41] != 0xe2 || b[atPos+42] != 0x80 || b[atPos+43] != 0x94 || b[atPos+44] != 0x20) {
+            return ("", "");
+        }
+
         bytes memory commit = new bytes(40);
         for (uint256 i; i < 40; i++) commit[i] = b[atPos + i];
         auditCommit = string(commit);
 
-        uint256 urlStart = atPos + 40 + 5;
+        uint256 urlStart = atPos + 45;
         uint256 urlEnd = urlStart;
         while (urlEnd < b.length && b[urlEnd] != 0x0a && b[urlEnd] != 0x0d) urlEnd++;
         bytes memory url = new bytes(urlEnd - urlStart);

--- a/test/DeployMetadataHelpers.t.sol
+++ b/test/DeployMetadataHelpers.t.sol
@@ -16,7 +16,6 @@ contract MetadataHarness is DeployArcticArchitectureWithConfigScript {
 
     function parseAuditLine(string memory sourcePath)
         external
-        view
         returns (string memory auditCommit, string memory auditUrl)
     {
         return _parseAuditLine(sourcePath);
@@ -88,6 +87,48 @@ contract DeployMetadataHelpersTest is Test {
         string memory fixture = "./test/fixtures/short_fixture.sol";
         vm.writeFile(fixture, "// only one line\n");
         (string memory commit, string memory url) = harness.parseAuditLine(fixture);
+        assertEq(commit, "");
+        assertEq(url, "");
+    }
+
+    // Non-hex chars after '@' (e.g. an email address) → ("", "").
+    function test_parseAuditLine_nonHexAfterAt_returnsEmpty() public {
+        string memory fixture = "./test/fixtures/email_fixture.sol";
+        vm.writeFile(
+            fixture,
+            "// SPDX-License-Identifier: MIT\n"
+            "// line 2\n"
+            "// line 3\n"
+            "// line 4\n"
+            "// Contact: name@example.com for audit questions\n"
+            "pragma solidity 0.8.21;\n"
+        );
+        (string memory commit, string memory url) = harness.parseAuditLine(fixture);
+        assertEq(commit, "", "non-hex after @ should return empty");
+        assertEq(url, "");
+    }
+
+    // Wrong separator (hyphen instead of em-dash) → ("", "").
+    function test_parseAuditLine_wrongSeparator_returnsEmpty() public {
+        string memory fixture = "./test/fixtures/wrong_sep_fixture.sol";
+        vm.writeFile(
+            fixture,
+            "// SPDX-License-Identifier: MIT\n"
+            "// line 2\n"
+            "// line 3\n"
+            "// line 4\n"
+            "// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d - https://example.com/audit\n"
+            "pragma solidity 0.8.21;\n"
+        );
+        (string memory commit, string memory url) = harness.parseAuditLine(fixture);
+        assertEq(commit, "", "wrong separator should return empty");
+        assertEq(url, "");
+    }
+
+    // Nonexistent path → ("", "") instead of aborting.
+    function test_parseAuditLine_missingFile_returnsEmpty() public {
+        (string memory commit, string memory url) =
+            harness.parseAuditLine("./test/fixtures/does_not_exist.sol");
         assertEq(commit, "");
         assertEq(url, "");
     }

--- a/test/DeployMetadataHelpers.t.sol
+++ b/test/DeployMetadataHelpers.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: SEL-1.0
+// Copyright © 2025 Veda Tech Labs
+// Derived from Boring Vault Software © 2025 Veda Tech Labs (TEST ONLY – NO COMMERCIAL USE)
+// Licensed under Software Evaluation License, Version 1.0
+pragma solidity 0.8.21;
+
+import {Test} from "@forge-std/Test.sol";
+import {DeployArcticArchitectureWithConfigScript} from
+    "script/ArchitectureDeployments/DeployArcticArchitectureWithConfig.s.sol";
+
+// Thin harness: exposes internal helpers as external so Test can call them.
+contract MetadataHarness is DeployArcticArchitectureWithConfigScript {
+    function deploymentCommit() external view returns (string memory) {
+        return _deploymentCommit();
+    }
+
+    function parseAuditLine(string memory sourcePath)
+        external
+        view
+        returns (string memory auditCommit, string memory auditUrl)
+    {
+        return _parseAuditLine(sourcePath);
+    }
+}
+
+contract DeployMetadataHelpersTest is Test {
+    MetadataHarness harness;
+
+    function setUp() public {
+        harness = new MetadataHarness();
+    }
+
+    // -------------------------------------------------------------------------
+    // _deploymentCommit
+    // -------------------------------------------------------------------------
+
+    function test_deploymentCommit_is40HexChars() public {
+        string memory commit = harness.deploymentCommit();
+        bytes memory b = bytes(commit);
+        assertEq(b.length, 40, "deploymentCommit must be 40 chars");
+        for (uint256 i; i < 40; i++) {
+            bytes1 c = b[i];
+            bool isHex = (c >= "0" && c <= "9") || (c >= "a" && c <= "f") || (c >= "A" && c <= "F");
+            assertTrue(isHex, "deploymentCommit must be hex");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // _parseAuditLine — fixture-based (self-contained, not tied to source files)
+    // -------------------------------------------------------------------------
+
+    // Writes a file whose 5th line is a valid "// Last audited:" comment and
+    // verifies that _parseAuditLine extracts the correct commit + URL.
+    function test_parseAuditLine_parsesValidLine() public {
+        string memory fixture = "./test/fixtures/audit_fixture.sol";
+        vm.writeFile(
+            fixture,
+            "// SPDX-License-Identifier: MIT\n"
+            "// line 2\n"
+            "// line 3\n"
+            "// line 4\n"
+            "// Last audited: boring-vault@3c768bd068af856b5de3def86b1940676847eb9d \xe2\x80\x94 https://example.com/audit\n"
+            "pragma solidity 0.8.21;\n"
+        );
+        (string memory commit, string memory url) = harness.parseAuditLine(fixture);
+        assertEq(commit, "3c768bd068af856b5de3def86b1940676847eb9d", "wrong commit");
+        assertEq(url, "https://example.com/audit", "wrong url");
+    }
+
+    // When line 5 is a normal pragma (no audit annotation), both fields are "".
+    function test_parseAuditLine_noAuditLine_returnsEmpty() public {
+        string memory fixture = "./test/fixtures/no_audit_fixture.sol";
+        vm.writeFile(
+            fixture,
+            "// SPDX-License-Identifier: MIT\n"
+            "// line 2\n"
+            "// line 3\n"
+            "// line 4\n"
+            "pragma solidity 0.8.21;\n"
+        );
+        (string memory commit, string memory url) = harness.parseAuditLine(fixture);
+        assertEq(commit, "", "commit should be empty when no audit line");
+        assertEq(url, "", "url should be empty when no audit line");
+    }
+
+    // File with fewer than 4 newlines → ("", "").
+    function test_parseAuditLine_tooShort_returnsEmpty() public {
+        string memory fixture = "./test/fixtures/short_fixture.sol";
+        vm.writeFile(fixture, "// only one line\n");
+        (string memory commit, string memory url) = harness.parseAuditLine(fixture);
+        assertEq(commit, "");
+        assertEq(url, "");
+    }
+}

--- a/test/DeployMetadataHelpers.t.sol
+++ b/test/DeployMetadataHelpers.t.sol
@@ -27,6 +27,8 @@ contract DeployMetadataHelpersTest is Test {
 
     function setUp() public {
         harness = new MetadataHarness();
+        // Tests write temporary fixtures here; ensure the directory exists in CI.
+        vm.createDir("./test/fixtures", true);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Ports **item 3** (deployment-metadata tooling + registry backfill) from `main` into `dev`. Follows the same curation pattern as #753 (audit anchors + NatSpec).

## What's included

**Deploy-time metadata tooling** (3 commits, cherry-picked from main with `-x` provenance):
- `feat: write contractMetadata at deploy time` — `DeployArcticArchitectureWithConfig.s.sol` now records `contractMetadata` during deployment
- `fix: harden _parseAuditLine against stale paths and malformed lines`
- `test: create ./test/fixtures before DeployMetadataHelpers writes into it`
- Adds new `test/DeployMetadataHelpers.t.sol`

dev had **zero** prior changes to these files, so the cherry-picks applied cleanly.

**Deployments registry backfill** (1 snapshot commit): brings `deployments/` to match main's tip. This squashes 18 deployment-only commits from main (verification/audit-gap metadata, two-axis verification model, and registration of active teller hooks, accountants, and Deployer entries across chains). The full list is enumerated in the commit message.

### Why a snapshot instead of 18 cherry-picks
The metadata evolved on `main` across parallel branches joined by merge commits, so a linear cherry-pick hits an unavoidable add/add conflict on the Teller/Accountant JSON (reshape vs. registration branches). Since `dev` has **no competing changes** to `deployments/`, main's tip is the unambiguous intended state.

## Verification
- Index `deployments/` matches main's `deployments/` exactly, **except** dev's 4 dev-only `vmUSD` skeleton files, which are preserved (main lacks them).
- `forge build` passes (exit 0; only pre-existing lint warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)