### PR TITLE
docs: sync IRateProvider NatSpec convention note from main

### DIFF
--- a/src/interfaces/IRateProvider.sol
+++ b/src/interfaces/IRateProvider.sol
@@ -24,7 +24,7 @@ interface IRateProvider {
      * @dev The return value uses this provider's asset decimals, not the base asset's decimals.
      *      A USDC (6-decimal) rate provider returns `price * 1e6`; a DAI (18-decimal) provider returns
      *      `price * 1e18`. `AccountantWithRateProviders.claimFees`, `AccountantWithFixedRate.claimYield`,
-     *      and `AccountantWithRateProviders.getRateInQuote` rely on this convention.
+     *      `AccountantWithRateProviders.getRateInQuote`, and `AccountantWithYieldStreaming.getRateInQuote` rely on this convention.
      */
     function getRate() external view returns (uint256);
 }


### PR DESCRIPTION
Ports the one remaining main-only NatSpec residual on `IRateProvider.getRate()` (cherry-picked from main `4c3d3dd6` with `-x`).

Adds `AccountantWithYieldStreaming.getRateInQuote` to the list of consumers that rely on the rate-provider decimals convention — the YS override exercises the same `_changeDecimals` path as the other listed consumers, so it belongs in the note. Originally a Greptile suggestion on main's design-choice #19 PR; #753 cherry-picked the earlier version of this NatSpec into dev but not this follow-up line.

**Comment-only, 1 line changed, no behavior change.** `IRateProvider.sol` is now byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)