### PR TITLE
ci(certora): retry transient Certora cloud errors in nightly

### DIFF
--- a/.github/workflows/nightly-certora.yml
+++ b/.github/workflows/nightly-certora.yml
@@ -113,6 +113,35 @@ jobs:
           CONFIGS: ${{ matrix.configs }}
         run: |
           set -uo pipefail
+
+          # Certora's cloud intermittently fails to RETURN results ("request failed" /
+          # "Could not find job results") even when the proof itself passed ("No errors
+          # found by Prover!"). certoraRun then exits non-zero, reddening the nightly and
+          # paging Slack for a Certora-side blip, not a rule violation. Retry only those
+          # transient backend errors; a real violation doesn't match the pattern and fails
+          # fast (no wasted re-proofs).
+          MAX_ATTEMPTS=3
+          RETRY_SLEEP=60
+          TRANSIENT_RE='Could not find job results|request failed|An error occurred'
+
+          # Runs one certoraRun, streaming output live while capturing it to match on.
+          # Returns certoraRun's exit code; retries in place on transient cloud errors.
+          run_certora() {
+            local attempt=1 rc log
+            log="$(mktemp)"
+            while :; do
+              certoraRun "$@" --wait_for_results all 2>&1 | tee "$log"
+              rc=${PIPESTATUS[0]}
+              if [ "$rc" -eq 0 ]; then rm -f "$log"; return 0; fi
+              if [ "$attempt" -ge "$MAX_ATTEMPTS" ] || ! grep -qE "$TRANSIENT_RE" "$log"; then
+                rm -f "$log"; return "$rc"
+              fi
+              echo "::warning::Certora transient cloud error (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${RETRY_SLEEP}s: $*"
+              attempt=$((attempt + 1))
+              sleep "$RETRY_SLEEP"
+            done
+          }
+
           fail=0
           while IFS= read -r line; do
             # skip blank lines
@@ -120,7 +149,7 @@ jobs:
             # Parse the config line into args honoring quotes (no eval).
             mapfile -t -d '' parts < <(printf '%s' "$line" | xargs printf '%s\0')
             echo "::group::certoraRun ${parts[*]}"
-            if ! certoraRun "${parts[@]}" --wait_for_results all; then
+            if ! run_certora "${parts[@]}"; then
               echo "::error::Certora verification failed for: $line"
               fail=1
             fi


### PR DESCRIPTION
## Problem

`nightly-certora` intermittently reddens (and pages Slack) when Certora's cloud fails to **return results** — `certoraRun` prints `ERROR: request failed` / `Could not find job results` and exits non-zero **even though the proof itself passed** (`No errors found by Prover!`). At the run level this is indistinguishable from a real rule violation.

Observed on unchanged commit `39f9d31` (which passed on adjacent nights):
- **2026-08-05** — all 10 jobs hit it
- **2026-08-07** — 1 job (`main / C`), with `No errors found by Prover!` right above the retrieval error

## Fix

Wrap `certoraRun` in a retry that fires **only** on the transient retrieval errors (matched by pattern), up to 3 attempts with 60s backoff:

- **Transient cloud blip** → retry (a single retry has cleared it in every manual re-run).
- **Real rule violation** → doesn't match the pattern, **fails fast** — no wasted re-proofs, no masking.
- **Persistent outage** → still fails after 3 attempts, so genuine problems still page.
- Output streamed live (`tee`) while captured for matching — CI logs unchanged.

Validated: YAML parses, `bash -n` clean, and a behavioral harness confirmed transient→3 attempts/fail, violation→1 attempt/fail-fast, success→1 attempt. `+30/-1`, one call site changed (`run_certora` wraps the direct call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)